### PR TITLE
Fix yarn installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "test": "jest",
     "prepare": "tsc",
+    "prepack": "tsc",
     "build:all": "tsc && typedoc",
     "build:docs": "typedoc",
     "build:tsc": "tsc",
@@ -68,7 +69,7 @@
     }
   },
   "files": [
-    "lib/*",
+    "lib/**",
     "WAProto/*",
     "WASignalGroup/*.js"
   ],


### PR DESCRIPTION
When trying to install with `yarn` the `lib` folder doesn't appears. That happens because yarn can't run the build script, as you can see [here](https://yarnpkg.com/advanced/lifecycle-scripts) the necessary build script is `prepack`.

The installation before adding `prepack` script:
![2023-05-03_00-30](https://user-images.githubusercontent.com/94945604/235828544-34a313ab-6382-4ee6-beee-e8a3a2094cc6.png)

The installation after adding `prepack` script:
![2023-05-03_00-31](https://user-images.githubusercontent.com/94945604/235828546-69012c5b-f124-43a7-8da7-929d75ebccea.png)