### PR TITLE
Fix: TS-Error Property 'default' does not exist on type 'void | { def…

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -41,7 +41,7 @@ const getImageProcessingLibrary = async() => {
 		return { sharp }
 	}
 
-	const jimp = _jimp?.default || _jimp
+	const jimp = (_jimp && _jimp?.default) ? _jimp?.default : _jimp
 	if(jimp) {
 		return { jimp }
 	}


### PR DESCRIPTION
Fix building issues on nest usage:

```
$ nest build
node_modules/@adiwajshing/baileys/src/Utils/messages-media.ts:44:16 - error TS2339: Property 'default' does not exist on type 'void | { default: JimpConstructors & { MIME_JPEG: "image/jpeg"; } & { MIME_PNG: "image/png"; PNG_FILTER_AUTO: -1; PNG_FILTER_NONE: 0; PNG_FILTER_SUB: 1; PNG_FILTER_UP: 2; PNG_FILTER_AVERAGE: 3; PNG_FILTER_PATH: 4; } & ... 5 more ... & { ...; }; ... 67 more ...; decoders: { ...; } & ... 3 more ... & { ...; }; }'.
  Property 'default' does not exist on type 'void'.

44     if (_jimp?.default) return { jimp: _jimp.default }
                  ~~~~~~~

Found 1 error(s).

error Command failed with exit code 1.
```