### PR TITLE
In memory store: normalize user when asserting message list to update messages

### DIFF
--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -170,9 +170,20 @@ export default (
 				const list = assertMessageList( jidNormalizedUser(key.remoteJid!) )
 
 				if(update?.status){
-					
-					logger.debug({ updatestatus: list.get(key.id!)?.status }, ' status from store')
+					const listStatus = list.get(key.id!)?.status;
+
+					if(listStatus && update?.status <= listStatus){
+
+						logger.debug({ update, storedStatus: listStatus }, 'status stored newer then update')
+
+						delete update.status;
+
+						logger.debug({ update }, 'new update object')
+
+					}
+
 				}
+
 				const result = list.updateAssign(key.id!, update)
 				if(!result) {
 					logger.debug({ update }, 'got update for non-existent message')

--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -167,23 +167,15 @@ export default (
 		})
 		ev.on('messages.update', updates => {
 			for(const { update, key } of updates) {
-				const list = assertMessageList( jidNormalizedUser(key.remoteJid!) )
-
+				const list = assertMessageList(jidNormalizedUser(key.remoteJid!))
 				if(update?.status){
 					const listStatus = list.get(key.id!)?.status;
-
 					if(listStatus && update?.status <= listStatus){
-
 						logger.debug({ update, storedStatus: listStatus }, 'status stored newer then update')
-
 						delete update.status;
-
 						logger.debug({ update }, 'new update object')
-
 					}
-
 				}
-
 				const result = list.updateAssign(key.id!, update)
 				if(!result) {
 					logger.debug({ update }, 'got update for non-existent message')

--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -168,14 +168,15 @@ export default (
 		ev.on('messages.update', updates => {
 			for(const { update, key } of updates) {
 				const list = assertMessageList(jidNormalizedUser(key.remoteJid!))
-				if(update?.status){
-					const listStatus = list.get(key.id!)?.status;
-					if(listStatus && update?.status <= listStatus){
+				if(update?.status) {
+					const listStatus = list.get(key.id!)?.status
+					if(listStatus && update?.status <= listStatus) {
 						logger.debug({ update, storedStatus: listStatus }, 'status stored newer then update')
-						delete update.status;
+						delete update.status
 						logger.debug({ update }, 'new update object')
 					}
 				}
+
 				const result = list.updateAssign(key.id!, update)
 				if(!result) {
 					logger.debug({ update }, 'got update for non-existent message')

--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -167,7 +167,7 @@ export default (
 		})
 		ev.on('messages.update', updates => {
 			for(const { update, key } of updates) {
-				const list = assertMessageList(key.remoteJid!)
+				const list = assertMessageList( jidNormalizedUser(key.remoteJid!) )
 				const result = list.updateAssign(key.id!, update)
 				if(!result) {
 					logger.debug({ update }, 'got update for non-existent message')

--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -168,6 +168,11 @@ export default (
 		ev.on('messages.update', updates => {
 			for(const { update, key } of updates) {
 				const list = assertMessageList( jidNormalizedUser(key.remoteJid!) )
+
+				if(update?.status){
+					
+					logger.debug({ updatestatus: list.get(key.id!)?.status }, ' status from store')
+				}
 				const result = list.updateAssign(key.id!, update)
 				if(!result) {
 					logger.debug({ update }, 'got update for non-existent message')


### PR DESCRIPTION
I was having some problem with message status update (4 - read).

The remotejid from update was with "device number" inside, and the stored one was normalized, so it could not be found: "got update for non-existent message".

This solved the problem.

Sorry my poor english ;)