### PR TITLE
Fix getaddrinfo error at downloading sticker

### DIFF
--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -863,7 +863,11 @@ export const downloadMediaMessage = async(
 			}
 			mediaType = 'thumbnail-link'
 		} else {
-			download = media
+			download = {
+				mediaKey: media.mediaKey,
+				directPath: media.directPath,
+				url: 'https://mmg.whatsapp.net'+media.directPath
+		    	};
 		}
 
 		const stream = await downloadContentFromMessage(download, mediaType, options)


### PR DESCRIPTION
I noticed that the URL of the sticker type messages were coming with the URL set to "https://web.whatsapp.net'" and this was causing the error to occur.