### PR TITLE
In Memory Store: contacts.upsert handle

### DIFF
--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -146,7 +146,7 @@ export default (
 			logger.debug({ chatsAdded }, 'synced chats')
 
 			const oldContacts = contactsUpsert(newContacts)
-			if(isLatest){
+			if(isLatest) {
 				for(const jid of oldContacts) {
 					delete contacts[jid]
 				}
@@ -166,7 +166,7 @@ export default (
 		ev.on('contacts.upsert', contacts => {
 			contactsUpsert(contacts)
 		})
-		
+
 		ev.on('contacts.update', updates => {
 			for(const update of updates) {
 				if(contacts[update.id!]) {

--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -146,11 +146,13 @@ export default (
 			logger.debug({ chatsAdded }, 'synced chats')
 
 			const oldContacts = contactsUpsert(newContacts)
-			for(const jid of oldContacts) {
-				delete contacts[jid]
+			if(isLatest){
+				for(const jid of oldContacts) {
+					delete contacts[jid]
+				}
 			}
 
-			logger.debug({ deletedContacts: oldContacts.size, newContacts }, 'synced contacts')
+			logger.debug({ deletedContacts: isLatest ? oldContacts.size : 0, newContacts }, 'synced contacts')
 
 			for(const msg of newMessages) {
 				const jid = msg.key.remoteJid!

--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -161,6 +161,10 @@ export default (
 			logger.debug({ messages: newMessages.length }, 'synced messages')
 		})
 
+		ev.on('contacts.upsert', contacts => {
+			contactsUpsert(contacts)
+		})
+		
 		ev.on('contacts.update', updates => {
 			for(const update of updates) {
 				if(contacts[update.id!]) {


### PR DESCRIPTION
The event "contacts.upsert" was not handled!

Properties "name" and "notify" is not being sended in "messaging-history.set" anymore (as i have noticed sometimes).

So, we need to handle "contacts.upsert" that is sent togheter or just before or in the future, to keep the store updated!

And in "messaging-history.set" check if isLatest to handle the deletition.