### PR TITLE
adding @adiwajshing/keyed-db to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@adiwajshing/keyed-db": "^0.2.4",
     "@hapi/boom": "^9.1.3",
     "axios": "^1.3.3",
     "cache-manager": "^5.2.2",
@@ -57,7 +58,6 @@
   },
   "devDependencies": {
     "@adiwajshing/eslint-config": "https://github.com/adiwajshing/eslint-config.git",
-    "@adiwajshing/keyed-db": "^0.2.4",
     "@types/got": "^9.6.11",
     "@types/jest": "^27.5.1",
     "@types/node": "^16.0.0",
@@ -77,16 +77,12 @@
     "typescript": "^4.0.0"
   },
   "peerDependencies": {
-    "@adiwajshing/keyed-db": "^0.2.4",
     "jimp": "^0.16.1",
     "link-preview-js": "^3.0.0",
     "qrcode-terminal": "^0.12.0",
     "sharp": "^0.30.5"
   },
   "peerDependenciesMeta": {
-    "@adiwajshing/keyed-db": {
-      "optional": true
-    },
     "jimp": {
       "optional": true
     },


### PR DESCRIPTION
throws error 

node_modules/.pnpm/@whiskeysockets+baileys@6.2.1_a9c255cd4f7c72f8caee0a723a9801d6/node_modules/@whiskeysockets/baileys/lib/Store/make-in-memory-store.d.ts:1:21 - error TS2307: Cannot find module '@adiwajshing/keyed-db' or its corresponding type declarations.

1 import KeyedDB from '@adiwajshing/keyed-db';

if it's not installed