### PR TITLE
fix: added invite property

### DIFF
--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -193,7 +193,7 @@ export const makeGroupsSocket = (config: SocketConfig) => {
 			const node = getBinaryNodeChild(result, action)
 			const participantsAffected = getBinaryNodeChildren(node!, 'participant')
 			return participantsAffected.map(p => {
-				return { status: p.attrs.error || '200', jid: p.attrs.jid }
+				return { status: p.attrs.error || '200', jid: p.attrs.jid, content: p }
 			})
 		},
 		groupUpdateDescription: async(jid: string, description?: string) => {


### PR DESCRIPTION
If the user does not allow to be added directly, it will be possible to get the invite code and create an invitation message for the user to join the group