### PR TITLE
Jid of people who added to the group

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -219,7 +219,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			ev.emit('groups.upsert', [{
 				...metadata,
 				author: participant
-			}]);
+			}])
 			break
 		case 'ephemeral':
 		case 'not_ephemeral':

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -216,7 +216,10 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				name: metadata.subject,
 				conversationTimestamp: metadata.creation,
 			}])
-			ev.emit('groups.upsert', [metadata])
+			ev.emit('groups.upsert', [{
+				...metadata,
+				author: participant
+			}]);
 			break
 		case 'ephemeral':
 		case 'not_ephemeral':

--- a/src/Types/GroupMetadata.ts
+++ b/src/Types/GroupMetadata.ts
@@ -26,6 +26,8 @@ export interface GroupMetadata {
     participants: GroupParticipant[]
     ephemeralDuration?: number
     inviteCode?: string
+    /** the person who added you */
+    author?: string
 }
 
 


### PR DESCRIPTION
With this modification, it is possible to list the person who added you/bot to the group in groups.upsert, with the author tag. Before if someone added, there was no way to know who added it, only the owner of the group and etc.