### PR TITLE
fix: do not send message to self if the device is 0 (mobile)

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -420,11 +420,12 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 
 					await authState.keys.set({ 'sender-key-memory': { [jid]: senderKeyMap } })
 				} else {
-					const { user: meUser } = jidDecode(meId)!
+					const { user: meUser, device: meDevice } = jidDecode(meId)!
 
 					if(!participant) {
 						devices.push({ user })
-						devices.push({ user: meUser })
+						// do not send message to self if the device is 0 (mobile)
+						if (meDevice != undefined && meDevice !== 0) devices.push({ user: meUser })
 
 						const additionalDevices = await getUSyncDevices([ meId, jid ], !!useUserDevicesCache, true)
 						devices.push(...additionalDevices)


### PR DESCRIPTION
When baileys sends a direct message to someone, it sends the message to all devices of the recipient and oneself.
This is achieved by querying the recipient and oneselves devices via `getUSyncDevices` and then sending the message to all linked devices.
Additionally, the message is always sent to oneselves primary device with id 0, because the primary device is not included in the list of devices returned by `getUSyncDevices`.
This is correct for the multi device api however, it does not work for the mobile api.
Currently, when sending a direct message to someone from the mobile api, the message is mirrored and sent back to itself, which leads to decryption issues.
Because libsignal tries to getSession() for oneselves message, which results in the error `Tried to lookup a session using our basekey`, because it tries to get the session for oneself.
To fix this issue, baileys should only mirror the message to device 0, if the message is sent from a linked device.
`authState.creds.me.id` (meId) has no device id or device id 0, if the user is logged in as a mobile device, otherwise it is the multi device id.
