### PR TITLE
Add "+" to the beginning of jids if not present in the onWhatsApp method

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -168,15 +168,19 @@ export const makeChatsSocket = (config: SocketConfig) => {
 
 	const onWhatsApp = async(...jids: string[]) => {
 		const query = { tag: 'contact', attrs: {} }
-		const list = jids.map((jid) => ({
-			tag: 'user',
-			attrs: {},
-			content: [{
-				tag: 'contact',
+		const list = jids.map((jid) => (
+			const content = (!jid.startsWith('+')) ? `+${jid}` : jid;
+			
+			return {
+				tag: 'user',
 				attrs: {},
-				content: jid,
-			}],
-		}))
+				content: [{
+					tag: 'contact',
+					attrs: {},
+					content,
+				}],
+			}
+		))
 		const results = await interactiveQuery(list, query)
 
 		return results.map(user => {


### PR DESCRIPTION
In Baileys 5.x a "+" was always added at the beginning of the jids provided to the `socket.onWhatsApp` method. This was removed later in the 6.x version and has created a subtle problem.

This is a link of the related pull request: https://github.com/WhiskeySockets/Baileys/pull/85

Many phone numbers where correctly verified but for some reason french mobile number (starting with 336 or 337) always returned an undefined result (maybe there were problems with some other countries too, I couldn't verify).

Adding back the "+" (if missing) should fix the problem.