### PR TITLE
fix: set `moduleResolution` to `node` in `tsconfig.json` to ensure all imports in the emitted code conforms to `require`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2018",
-    "module": "CommonJS",
-    "moduleResolution": "NodeNext",
+    "module": "commonjs",
+    "moduleResolution": "node",
     "experimentalDecorators": true,
     "allowJs": false,
     "checkJs": false,


### PR DESCRIPTION
fix: set `moduleResolution` to `node` (which is the default when `module` is set to `commonjs`) in `tsconfig.json` to ensure all imports (static and dynamic) in the emitted code conforms to `require`