### PR TITLE
Update getDevice

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -432,7 +432,9 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 					if(!participant) {
 						devices.push({ user })
 						// do not send message to self if the device is 0 (mobile)
-						if (meDevice != undefined && meDevice !== 0) devices.push({ user: meUser })
+						if(meDevice !== undefined && meDevice !== 0) {
+							devices.push({ user: meUser })
+						}
 
 						const additionalDevices = await getUSyncDevices([ meId, jid ], !!useUserDevicesCache, true)
 						devices.push(...additionalDevices)

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -733,7 +733,7 @@ export const extractMessageContent = (content: WAMessageContent | undefined | nu
  * Returns the device predicted by message ID
  */
 export const getDevice = (id: string) => {
-	const deviceType = id.length > 21 ? 'android' : id.substring(0, 2) === '3A' ? 'ios' : 'web'
+	const deviceType = id.substring(0, 2) === '3E' ? 'web' : id.substring(0, 2) === '3A' ? 'ios' : 'android'
 	return deviceType
 }
 


### PR DESCRIPTION
Before getDevice returned id that had above 21 characters as 'android', but whatsapp web messages were returned as 'android' too.

An example of a WhatsApp Web message id that returned android: "id": "3EB0F513CA2F3372B995CA", containing 22 characters (above 21 = android)

Now it's fixed