### PR TITLE
Fix pfp change notification

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -357,7 +357,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 
 			ev.emit('contacts.update', [{
 				id: jidNormalizedUser(node?.attrs?.jid) || ((setPicture || delPicture)?.attrs?.hash) || '',
-				imgUrl: setPicture ? 'changed' : "removed"
+				imgUrl: setPicture ? 'changed' : 'removed'
 			}])
 
 			if(isJidGroup(from)) {

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -356,7 +356,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			const delPicture = getBinaryNodeChild(node, 'delete')
 
 			ev.emit('contacts.update', [{
-				id: jidNormalizedUser(node.attrs.jid) || ((setPicture || delPicture).attrs.hash) || "",
+				id: jidNormalizedUser(node?.attrs?.jid) || ((setPicture || delPicture)?.attrs?.hash) || "",
 				imgUrl: setPicture ? 'changed' : "removed"
 			}])
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -356,7 +356,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			const delPicture = getBinaryNodeChild(node, 'delete')
 
 			ev.emit('contacts.update', [{
-				id: jidNormalizedUser(node?.attrs?.jid) || ((setPicture || delPicture)?.attrs?.hash) || "",
+				id: jidNormalizedUser(node?.attrs?.jid) || ((setPicture || delPicture)?.attrs?.hash) || '',
 				imgUrl: setPicture ? 'changed' : "removed"
 			}])
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -356,7 +356,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			const delPicture = getBinaryNodeChild(node, 'delete')
 
 			ev.emit('contacts.update', [{
-				id: from,
+				id: jidNormalizedUser(node.attrs.jid) || getBinaryNodeChild(setPicture || delPicture, 'hash'),
 				imgUrl: setPicture ? 'changed' : null
 			}])
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -356,7 +356,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			const delPicture = getBinaryNodeChild(node, 'delete')
 
 			ev.emit('contacts.update', [{
-				id: jidNormalizedUser(node.attrs.jid) || ((setPicture || delPicture).attrs.hash),
+				id: jidNormalizedUser(node.attrs.jid) || ((setPicture || delPicture).attrs.hash) || "",
 				imgUrl: setPicture ? 'changed' : "removed"
 			}])
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -356,7 +356,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			const delPicture = getBinaryNodeChild(node, 'delete')
 
 			ev.emit('contacts.update', [{
-				id: jidNormalizedUser(node.attrs.jid) || getBinaryNodeChild(setPicture || delPicture, 'hash'),
+				id: jidNormalizedUser(node.attrs.jid) || ((setPicture || delPicture).attrs.hash),
 				imgUrl: setPicture ? 'changed' : "removed"
 			}])
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -357,7 +357,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 
 			ev.emit('contacts.update', [{
 				id: jidNormalizedUser(node.attrs.jid) || getBinaryNodeChild(setPicture || delPicture, 'hash'),
-				imgUrl: setPicture ? 'changed' : null
+				imgUrl: setPicture ? 'changed' : "removed"
 			}])
 
 			if(isJidGroup(from)) {

--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -227,7 +227,9 @@ export default (
 		})
 		ev.on('chats.delete', deletions => {
 			for(const item of deletions) {
-				chats.deleteById(item)
+				if(chats.get(item)) {
+					chats.deleteById(item)
+				}
 			}
 		})
 		ev.on('messages.upsert', ({ messages: newMessages, type }) => {

--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -4,7 +4,7 @@ import type { Logger } from 'pino'
 import { proto } from '../../WAProto'
 import { DEFAULT_CONNECTION_CONFIG } from '../Defaults'
 import type makeMDSocket from '../Socket'
-import type { BaileysEventEmitter, Chat, ConnectionState, Contact, GroupMetadata, PresenceData, WAMessage, WAMessageCursor, WAMessageKey, WASocket } from '../Types'
+import type { BaileysEventEmitter, Chat, ConnectionState, Contact, GroupMetadata, PresenceData, WAMessage, WAMessageCursor, WAMessageKey } from '../Types'
 import { Label } from '../Types/Label'
 import { LabelAssociation, LabelAssociationType, MessageLabelAssociation } from '../Types/LabelAssociation'
 import { toNumber, updateMessageWithReaction, updateMessageWithReceipt, md5 } from '../Utils'
@@ -177,7 +177,7 @@ export default (
 					const contactHashes = await Promise.all(Object.keys(contacts).map(async a => {
 						return (await md5(Buffer.from(a + "WA_ADD_NOTIF", "utf8"))).toString("base64").slice(0,3)
 					}));
-					contact = contactHashes.find(a => a === update.id);				
+					contact = contacts[contactHashes.find(a => a === update.id)];				
 				}
 				if(update.imgUrl === "changed" || update.imgUrl === "removed") {
 					if(contact) {

--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -4,7 +4,7 @@ import type { Logger } from 'pino'
 import { proto } from '../../WAProto'
 import { DEFAULT_CONNECTION_CONFIG } from '../Defaults'
 import type makeMDSocket from '../Socket'
-import type { BaileysEventEmitter, Chat, ConnectionState, Contact, GroupMetadata, PresenceData, WAMessage, WAMessageCursor, WAMessageKey } from '../Types'
+import type { BaileysEventEmitter, Chat, ConnectionState, Contact, GroupMetadata, PresenceData, WAMessage, WAMessageCursor, WAMessageKey, WASocket } from '../Types'
 import { Label } from '../Types/Label'
 import { LabelAssociation, LabelAssociationType, MessageLabelAssociation } from '../Types/LabelAssociation'
 import { toNumber, updateMessageWithReaction, updateMessageWithReceipt, md5 } from '../Utils'
@@ -30,6 +30,7 @@ export type BaileysInMemoryStoreConfig = {
 	chatKey?: Comparable<Chat, string>
 	labelAssociationKey?: Comparable<LabelAssociation, string>
 	logger?: Logger
+	socket?: WASocket
 }
 
 const makeMessagesDictionary = () => makeOrderedDictionary(waMessageID)
@@ -73,7 +74,7 @@ const predefinedLabels = Object.freeze<Record<string, Label>>({
 })
 
 export default (
-	{ logger: _logger, chatKey, labelAssociationKey }: BaileysInMemoryStoreConfig
+	{ logger: _logger, chatKey, labelAssociationKey, socket }: BaileysInMemoryStoreConfig
 ) => {
 	// const logger = _logger || DEFAULT_CONNECTION_CONFIG.logger.child({ stream: 'in-mem-store' })
 	chatKey = chatKey || waChatKey(true)
@@ -181,7 +182,7 @@ export default (
 				if(update.imgUrl === "changed" || update.imgUrl === "removed") {
 					if(contact) {
 						if(update.imgUrl === "changed") {
-							contact.imgUrl = await sock?.profilePictureUrl(contact.id);
+							contact.imgUrl = socket ? await socket?.profilePictureUrl(contact.id) : undefined;
 						} else {
 							delete contact.imgUrl;
 						}

--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -170,13 +170,13 @@ export default (
 
 		ev.on('contacts.update', async updates => {
 			for(const update of updates) {
-				let contact: Contact;
+				let contact: Contact
 				if(contacts[update.id!]) {
 					contact = contacts[update.id!]
 				} else {
 					const contactHashes = await Promise.all(Object.keys(contacts).map(async a => {
-						return (await md5(Buffer.from(a + 'WA_ADD_NOTIF', 'utf8'))).toString('base64').slice(0,3)
-					}));
+						return (await md5(Buffer.from(a + 'WA_ADD_NOTIF', 'utf8'))).toString('base64').slice(0, 3)
+					}))
 					contact = contacts[contactHashes.find(a => a === update.id) || '']
 				}
 

--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -7,7 +7,7 @@ import type makeMDSocket from '../Socket'
 import type { BaileysEventEmitter, Chat, ConnectionState, Contact, GroupMetadata, PresenceData, WAMessage, WAMessageCursor, WAMessageKey } from '../Types'
 import { Label } from '../Types/Label'
 import { LabelAssociation, LabelAssociationType, MessageLabelAssociation } from '../Types/LabelAssociation'
-import { toNumber, updateMessageWithReaction, updateMessageWithReceipt, md5 } from '../Utils'
+import { md5, toNumber, updateMessageWithReaction, updateMessageWithReceipt } from '../Utils'
 import { jidNormalizedUser } from '../WABinary'
 import makeOrderedDictionary from './make-ordered-dictionary'
 import { ObjectRepository } from './object-repository'
@@ -172,24 +172,26 @@ export default (
 			for(const update of updates) {
 				let contact: Contact;
 				if(contacts[update.id!]) {
-					contact = contacts[update.id!];
+					contact = contacts[update.id!]
 				} else {
 					const contactHashes = await Promise.all(Object.keys(contacts).map(async a => {
-						return (await md5(Buffer.from(a + "WA_ADD_NOTIF", "utf8"))).toString("base64").slice(0,3)
+						return (await md5(Buffer.from(a + 'WA_ADD_NOTIF', 'utf8'))).toString('base64').slice(0,3)
 					}));
-					contact = contacts[contactHashes.find(a => a === update.id) || ""];				
+					contact = contacts[contactHashes.find(a => a === update.id) || '']
 				}
-				if(update.imgUrl === "changed" || update.imgUrl === "removed") {
+
+				if(update.imgUrl === 'changed' || update.imgUrl === 'removed') {
 					if(contact) {
-						if(update.imgUrl === "changed") {
-							contact.imgUrl = socket ? await socket?.profilePictureUrl(contact.id) : undefined;
+						if(update.imgUrl === 'changed') {
+							contact.imgUrl = socket ? await socket?.profilePictureUrl(contact.id) : undefined
 						} else {
-							delete contact.imgUrl;
+							delete contact.imgUrl
 						}
 					} else {
 						return logger.debug({ update }, 'got update for non-existant contact')
 					}
 				}
+
 				Object.assign(contacts[update.id!], contact)
 			}
 		})

--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -177,7 +177,7 @@ export default (
 					const contactHashes = await Promise.all(Object.keys(contacts).map(async a => {
 						return (await md5(Buffer.from(a + "WA_ADD_NOTIF", "utf8"))).toString("base64").slice(0,3)
 					}));
-					contact = contacts[contactHashes.find(a => a === update.id)];				
+					contact = contacts[contactHashes.find(a => a === update.id) || ""];				
 				}
 				if(update.imgUrl === "changed" || update.imgUrl === "removed") {
 					if(contact) {


### PR DESCRIPTION
Beforehand, it would try to set the picture as the baileys' user because of the "from" attribute, but this has been corrected to either use the jid attribute or the hash for non-contacts (not saved)

Some md5 hash comparison occurs and we can find the contact to update

also, prior to this update, the field would've just stayed at "changed" and cached that too, which would've caused a bunch of crashes I guess at "store.fetchImageUrl"
Because of this though, a socket is recommended to be passed into the config