### PR TITLE
Use senderTimestampMs instead of messageTimestamp

### DIFF
--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -362,7 +362,7 @@ const processMessage = async(
 								{
 									pollUpdateMessageKey: message.key,
 									vote: voteMsg,
-									senderTimestampMs: content.pollUpdateMessage.senderTimestampMs.toNumber(),
+									senderTimestampMs: (content.pollUpdateMessage.senderTimestampMs! as Long).toNumber(),
 								}
 							]
 						}


### PR DESCRIPTION
`message.messageTimestamp` contains timestamp in seconds, not in milliseconds as `content.pollUpdateMessage.senderTimestampMs`

It's important to get exact milliseconds for multi options poll, because we can get two `message.update` events with the same `senderTimestampMs` (because it's in seconds, not in milliseconds) so we can understand which vote is the latest one

Here's an event example:
```json
{
    "messages.upsert": {
        "messages": [
            {
                "key": {...},
                "messageTimestamp": 1692774684,
                "message": {
                    "messageContextInfo": {...},
                    },
                    "pollUpdateMessage": {
                        "pollCreationMessageKey": {...},
                        "vote": {...},
                        "senderTimestampMs": "1692774684709"
                    }
                }
            }
        ],
        "type": "notify"
    },
```

There's `.toNumber()` because `senderTimestampMs` has `Long` type
```json
{
  "low": 739148892,
  "high": 394,
  "unsigned": false
}
```

If we want to keep Long - let me know and I'll adjust the changes!