### PR TITLE
fix downloadMediaMessage crash with ptv messages

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -111,6 +111,7 @@ export const MEDIA_HKDF_KEY_MAPPING = {
 	'md-app-state': 'App State',
 	'product-catalog-image': '',
 	'payment-bg-image': 'Payment Background',
+	'ptv': 'Video'
 }
 
 export const MEDIA_KEYS = Object.keys(MEDIA_PATH_MAP) as MediaType[]


### PR DESCRIPTION
`downloadMediaMessage` crashes when trying to download the media from PTV messages (those video circles).

This fixes it by extending the HKDF map to account for PTV messages