### PR TITLE
add isCommunity and communityGroups properties to groupFetchAllParticipating 

### DIFF
--- a/src/Types/GroupMetadata.ts
+++ b/src/Types/GroupMetadata.ts
@@ -16,6 +16,15 @@ export interface GroupMetadata {
     desc?: string
     descOwner?: string
     descId?: string
+    /** whether the group is a community or not */
+    isCommunity?: boolean
+    /** list of community groups */
+    communityGroups?: {
+        name: string
+        jid: string
+        /** is set when the group is the community's default group */
+        isAnnouncement: boolean
+    }[]
     /** is set when the group only allows admins to change group settings */
     restrict?: boolean
     /** is set when the group only allows admins to write messages */


### PR DESCRIPTION
First time contributing to an open-source project.
A few weeks back, I needed to list the communities to do some shenanigans, and I couldn't find anything that helped me. So, I made changes directly to the group.js file right after building my project, and it's been working fine ever since.

I'm not sure if it's the best way to list subgroups within the community, but I haven't had any performance issues so far. If anyone has a better idea, please do share.