### PR TITLE
fix: find platform type based on browser second argument

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -525,7 +525,7 @@ export const makeSocket = (config: SocketConfig) => {
 						{
 							tag: 'companion_platform_display',
 							attrs: {},
-							content: `${config.browser[1]} (${config.browser[0]})`
+							content: config.browser[0]
 						},
 						{
 							tag: 'link_code_pairing_nonce',

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -525,7 +525,7 @@ export const makeSocket = (config: SocketConfig) => {
 						{
 							tag: 'companion_platform_display',
 							attrs: {},
-							content: config.browser[0]
+							content: `${config.browser[1]} (${config.browser[0]})`
 						},
 						{
 							tag: 'link_code_pairing_nonce',

--- a/src/Utils/validate-connection.ts
+++ b/src/Utils/validate-connection.ts
@@ -79,6 +79,11 @@ export const generateLoginNode = (userJid: string, config: SocketConfig): proto.
 	return proto.ClientPayload.fromObject(payload)
 }
 
+const getPlatformType = (platform: string): proto.DeviceProps.PlatformType => {
+	const platformType = platform.toUpperCase()
+	return proto.DeviceProps.PlatformType[platformType] || proto.DeviceProps.PlatformType.DESKTOP
+}
+
 export const generateRegistrationNode = (
 	{ registrationId, signedPreKey, signedIdentityKey }: SignalCreds,
 	config: SocketConfig
@@ -91,7 +96,7 @@ export const generateRegistrationNode = (
 
 	const companion: proto.IDeviceProps = {
 		os: config.browser[0],
-		platformType: proto.DeviceProps.PlatformType.DESKTOP,
+		platformType: getPlatformType(config.browser[1]),
 		requireFullSync: config.syncFullHistory,
 	}
 


### PR DESCRIPTION
fix #481 #228

If we use
```js
browser: ['MyAwesomeApp', 'chrome', '22.5.0']
```
WhatsApp shows the browser's icon in **Linked Devices**
![Screenshot_2023-11-05-19-05-01-396_com whatsapp (1)](https://github.com/WhiskeySockets/Baileys/assets/4376814/6e41017b-c1ae-4895-a402-76c9672029fd)
