### PR TITLE
fix: fix message content type detection

### DIFF
--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -645,7 +645,7 @@ export const generateWAMessage = async(
 export const getContentType = (content: WAProto.IMessage | undefined) => {
 	if(content) {
 		const keys = Object.keys(content)
-		const key = keys.find(k => (k === 'conversation' || k.endsWith('Message')) && k !== 'senderKeyDistributionMessage')
+		const key = keys.find(k => (k === 'conversation' || k.includes('Message')) && k !== 'senderKeyDistributionMessage')
 		return key as keyof typeof content
 	}
 }


### PR DESCRIPTION
Resolved the function that detects the type of message received.

Previously, the function checked if the message ended with "Message" but we need to see if it includes "Message" because of some messages that contain a suffix after "Message"

ex:
```
pollCreationMessageV2
pollCreationMessageV3
viewOnceMessageV2
viewOnceMessageV2Extension
```