### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@hapi/boom": "^9.1.3",
     "audio-decode": "^2.1.3",
     "axios": "^1.3.3",
-    "cache-manager": "^5.2.2",
+    "cache-manager": "4.0.1",
     "futoin-hkdf": "^1.5.1",
     "libphonenumber-js": "^1.10.20",
     "libsignal": "github:adiwajshing/libsignal-node",


### PR DESCRIPTION
Any version of cache-manager greater than 4.0.1 stopped coming with an index.js resulting to 

`@whiskeysockets/baileys/node_modules/cache-manager/dist/index.js'. Please verify that the package.json has a valid "main" entry` error