### PR TITLE
Retain existing authState.creds.me properties and add lid

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -630,7 +630,7 @@ export const makeSocket = (config: SocketConfig) => {
 		logger.info('opened connection to WA')
 		clearTimeout(qrTimer) // will never happen in all likelyhood -- but just in case WA sends success on first try
 
-		ev.emit('creds.update', { me: { id: authState.creds.me!.id, lid: node.attrs.lid } })
+		ev.emit('creds.update', { me: { ...authState.creds.me!, lid: node.attrs.lid } })
 
 		ev.emit('connection.update', { connection: 'open' })
 	})


### PR DESCRIPTION
Previously adding lid does not consider current property values of authState.creds.me which would lost on the next socket reconnect. This fix ensure current values are maintained