### PR TITLE
Update size calculation in extractGroupMetadata function

### DIFF
--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -324,7 +324,7 @@ export const extractGroupMetadata = (result: BinaryNode) => {
 		subject: group.attrs.subject,
 		subjectOwner: group.attrs.s_o,
 		subjectTime: +group.attrs.s_t,
-		size: +group.attrs.size,
+		size: getBinaryNodeChildren(group, 'participant').length,
 		creation: +group.attrs.creation,
 		owner: group.attrs.creator ? jidNormalizedUser(group.attrs.creator) : undefined,
 		desc,


### PR DESCRIPTION
This change corrects the retrieval of the total number of participants within the group.

![image](https://github.com/WhiskeySockets/Baileys/assets/1123103/17b61133-55c5-4cc9-839c-a023feada15e)
