### PR TITLE
Support for receiving "view once" audio messages

### DIFF
--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -685,6 +685,7 @@ export const normalizeMessageContent = (content: WAMessageContent | null | undef
 			 || message?.viewOnceMessage
 			 || message?.documentWithCaptionMessage
 			 || message?.viewOnceMessageV2
+			 || message?.viewOnceMessageV2Extension
 			 || message?.editedMessage
 		 )
 	 }


### PR DESCRIPTION
Support for "view once" audio messages was recently added to Whatsapp (~December 2023).

While this audio messages are not rendered in the web version ("You received a view once voice message. For added privacy, you can only open it on your phone."), they are still accessible in the message received as part of `viewOnceMessageV2Extension`.

This was originally requested in #590.