### PR TITLE
Fix: Compile error because of untyped spread argument in audioDecode utility function

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -209,7 +209,7 @@ export async function getAudioDuration(buffer: Buffer | string | Readable) {
  */
 export async function getAudioWaveform(buffer: Buffer | string | Readable, logger?: Logger) {
 	try {
-		const audioDecode = (...args) => import('audio-decode').then(({ default: audioDecode }) => audioDecode(...args))
+		const audioDecode = (buffer: Buffer | ArrayBuffer | Uint8Array) => import('audio-decode').then(({ default: audioDecode }) => audioDecode(buffer))
 		let audioData: Buffer
 		if(Buffer.isBuffer(buffer)) {
 			audioData = buffer


### PR DESCRIPTION
Hi there. First time Baileys user here.

As per the README file, I followed the instructions and tried to compile the project using yarn, however, I encountered an error when compiling: 

`src/Utils/messages-media.ts:212:106 - error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.`
<img width="1087" alt="Screenshot 2024-01-20 at 12 09 22" src="https://github.com/WhiskeySockets/Baileys/assets/55008869/33fe00f3-4ae2-4dae-b9a6-806fe184efdf">

Delving deeper into the code, I found out that the audioDecode function actually accepts only one buffer parameter, instead of all parameter values.
<img width="881" alt="Screenshot 2024-01-20 at 12 17 41" src="https://github.com/WhiskeySockets/Baileys/assets/55008869/a486e125-70f0-492a-a89b-305a2c660fdf">

Therefore, this fix changes the passing of ...args to pass only the buffer instead.

After fixing that, I was able to compile and use Baileys. Have also tested it by trying to send myself an audio file.
<img width="674" alt="Screenshot 2024-01-20 at 12 12 51" src="https://github.com/WhiskeySockets/Baileys/assets/55008869/5830d37e-2a3f-4457-baf7-55354cb7ae34">

Screenshots of errors and compilation attached.