### PR TITLE
Fixing Timed Out error on connection initialization

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -624,15 +624,20 @@ export const makeSocket = (config: SocketConfig) => {
 	})
 	// login complete
 	ws.on('CB:success', async(node: BinaryNode) => {
-		await uploadPreKeysToServerIfRequired()
-		await sendPassiveIq('active')
-
-		logger.info('opened connection to WA')
-		clearTimeout(qrTimer) // will never happen in all likelyhood -- but just in case WA sends success on first try
-
-		ev.emit('creds.update', { me: { ...authState.creds.me!, lid: node.attrs.lid } })
-
-		ev.emit('connection.update', { connection: 'open' })
+		try {
+			await uploadPreKeysToServerIfRequired()
+			await sendPassiveIq('active')
+			
+			logger.info('opened connection to WA')
+			clearTimeout(qrTimer) // will never happen in all likelyhood -- but just in case WA sends success on first try
+			
+			ev.emit('creds.update', { me: { ...authState.creds.me!, lid: node.attrs.lid } })
+			
+			ev.emit('connection.update', { connection: 'open' })
+		} catch (error) {
+			logger.info({ trace: error.stack }, 'error opening connection')
+			end(error)
+		}
 	})
 
 	ws.on('CB:stream:error', (node: BinaryNode) => {


### PR DESCRIPTION
Fixes the timed out error when initializing the connection, this error occurs because when connecting, a query is sent to the socket, which in turn breaks the application when it fails.

The solution suggested in the code is to close the connection in case of an error instead of popping the error.