### PR TITLE
Added localAddress on SocketConfig

### DIFF
--- a/Example/example.ts
+++ b/Example/example.ts
@@ -55,6 +55,9 @@ const startSock = async() => {
 		// shouldIgnoreJid: jid => isJidBroadcast(jid),
 		// implement to handle retries & poll updates
 		getMessage,
+
+		// Use if your server has multiple IPs and you want to specify the local IP
+		// localAddress: "xxx.xxx.xxx.xxx",
 	})
 
 	store?.bind(sock.ev)

--- a/src/Socket/Client/mobile-socket-client.ts
+++ b/src/Socket/Client/mobile-socket-client.ts
@@ -28,7 +28,8 @@ export class MobileSocketClient extends AbstractSocketClient {
 		} else {
 			this.socket = connect({
 				host: this.url.hostname,
-				port: Number(this.url.port) || 443
+				port: Number(this.url.port) || 443,
+				localAddress: this.config.localAddress
 			})
 		}
 

--- a/src/Socket/Client/web-socket-client.ts
+++ b/src/Socket/Client/web-socket-client.ts
@@ -30,6 +30,7 @@ export class WebSocketClient extends AbstractSocketClient {
 			handshakeTimeout: this.config.connectTimeoutMs,
 			timeout: this.config.connectTimeoutMs,
 			agent: this.config.agent,
+			localAddress: this.config.localAddress
 		})
 
 		this.socket.setMaxListeners(0)

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -120,4 +120,7 @@ export type SocketConfig = {
 
     /** Socket passthrough */
     socket?: any
+
+    /** Use if your server has multiple IPs and you want to specify the local IP */
+    localAddress?: string,
 }


### PR DESCRIPTION
With this configuration, it will be much easier for servers with multiple IPs to rotate their connection IPs.

Below is an example of how to list the machine's current IPs:
```js
import { exec } from "child_process"

async function shell_exec(cmd: string): Promise<string> {
  return new Promise((resolve, reject) => {
    exec(cmd, (error, stdout, stderr) => error ? reject(error) : resolve(stdout ? stdout : stderr))
  })
}

// need "apt install iproute2 -y"
// await shell_exec('apt update -y && apt install iproute2 -y');

let localAddresses = [
  ...(await shell_exec('ip a')).matchAll(/inet (\d+\.\d+\.\d+\.\d+) peer/g)
].map(i => i[1])
	
let randAddress = localAddresses[Math.floor(Math.random() * localAddresses.length)]

makeWASocket({
  // ...
  localAddress: randAddress,
  // ...
);
```