### PR TITLE
Fix logging of send/recv xml nodes with pino

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -129,7 +129,7 @@ export const makeSocket = (config: SocketConfig) => {
 	/** send a binary node */
 	const sendNode = (frame: BinaryNode) => {
 		if(logger.level === 'trace') {
-			logger.trace(binaryNodeToString(frame), 'xml send')
+			logger.trace({ xml: binaryNodeToString(frame), msg: 'xml send' })
 		}
 
 		const buff = encodeBinaryNode(frame)
@@ -319,7 +319,7 @@ export const makeSocket = (config: SocketConfig) => {
 				const msgId = frame.attrs.id
 
 				if(logger.level === 'trace') {
-					logger.trace(binaryNodeToString(frame), 'recv xml')
+					logger.trace({ xml: binaryNodeToString(frame), msg: 'recv xml' })
 				}
 
 				/* Check if this is a response to a message we sent */


### PR DESCRIPTION
`xml send` and `xml recv` where never printed to the log files because the `trace()` calls where not using the 
[pino logger method signature](https://getpino.io/#/docs/api?id=logger) correctly (see implementation of the [pino LOG function](https://github.com/pinojs/pino/blob/v7.11.0/lib/tools.js#L41-L63)), so it was impossible to distinguish received  from sent XML nodes in the logs.

With this change you can filter the Baileys output to create a log of received and send XML nodes using [jq](https://jqlang.github.io/jq/), something like this:


```
tail -f baileys.log | jq -r 'select(has("xml")) | if .msg == "recv xml" then "\u001b[32m← RECV\n\u001b[0m\(.xml)\n" elif .msg == "xml send" then "\u001b[31m→ SEND:\n\u001b[0m\(.xml)\n" else "" end'
```

<img width="517" alt="image" src="https://github.com/WhiskeySockets/Baileys/assets/855995/ac260953-599f-4b65-95b0-9b0cb546ddfd">
