### PR TITLE
add linkedParent in groupMetadata

### DIFF
--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -335,6 +335,7 @@ export const extractGroupMetadata = (result: BinaryNode) => {
 		owner: group.attrs.creator ? jidNormalizedUser(group.attrs.creator) : undefined,
 		desc,
 		descId,
+		linkedParent: getBinaryNodeChild(group, 'linked_parent')?.attrs.jid || undefined,
 		restrict: !!getBinaryNodeChild(group, 'locked'),
 		announce: !!getBinaryNodeChild(group, 'announcement'),
 		isCommunity: !!getBinaryNodeChild(group, 'parent'),

--- a/src/Types/GroupMetadata.ts
+++ b/src/Types/GroupMetadata.ts
@@ -16,6 +16,8 @@ export interface GroupMetadata {
     desc?: string
     descOwner?: string
     descId?: string
+    /** if this group is part of a community, it returns the jid of the community to which it belongs */
+    linkedParent?: string
     /** is set when the group only allows admins to change group settings */
     restrict?: boolean
     /** is set when the group only allows admins to write messages */


### PR DESCRIPTION
If the group is part of a community, the linkedParent returns the jid of the community to which the group belongs.