### PR TITLE
fix: enable viewOnce messages to quote

### DIFF
--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -567,11 +567,27 @@ export const generateWAMessageFromContent = (
 		options.timestamp = new Date()
 	}
 
-	const key = Object.keys(message)[0]
+	let key = Object.keys(message)[0]
 	const timestamp = unixTimestampSeconds(options.timestamp)
 	const { quoted, userJid } = options
 
 	if(quoted) {
+		// type viewOnceMessage isn't compatible with quoted message.
+		// workaround: normalize viewOnceMessage. it already contains viewOnce = true
+		if ('viewOnceMessage' in message) {
+			const { viewOnceMessage, ...messageRest } = message
+			const { message: viewOnceContent, ...viewOnceRest } = viewOnceMessage!
+
+			const viewOnceMsg = normalizeMessageContent(viewOnceContent)!
+
+			message = messageRest
+			Object.assign(message, viewOnceRest)
+			Object.assign(message, viewOnceMsg)
+
+			// recalculate key
+			key = Object.keys(message)[0]
+		}
+
 		const participant = quoted.key.fromMe ? userJid : (quoted.participant || quoted.key.participant || quoted.key.remoteJid)
 
 		let quotedMsg = normalizeMessageContent(quoted.message)!


### PR DESCRIPTION
a `viewOnceMessage` cannot quote another message.

this PR fixes this by unwrapping the `viewOnceMessage` to get the original type, assuming that it has `viewOnce = true`.