### PR TITLE
fix: inefficient method of extracting url from text

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -40,7 +40,7 @@ export const PROTOCOL_VERSION = [5, 2]
 export const MOBILE_NOISE_HEADER = Buffer.concat([Buffer.from('WA'), Buffer.from(PROTOCOL_VERSION)])
 /** from: https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url */
 export const URL_REGEX = /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/
-export const URL_EXCLUDE_REGEX = /.*@.*/
+export const URL_EXCLUDE_REGEX = /[\w-\.]+@([\w-]+\.)+[\w-]{2,4}/
 
 export const WA_CERT_DETAILS = {
 	SERIAL: 0,

--- a/src/Utils/link-preview.ts
+++ b/src/Utils/link-preview.ts
@@ -54,7 +54,7 @@ export const getUrlInfo = async(
 
 		const info = await getLinkPreview(previewLink, {
 			...opts.fetchOpts,
-			followRedirects: 'manual',
+			followRedirects: 'follow',
 			handleRedirects: (baseURL: string, forwardedURL: string) => {
 				const urlObj = new URL(baseURL)
 				const forwardedURLObj = new URL(forwardedURL)

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -68,7 +68,7 @@ const ButtonType = proto.Message.ButtonsMessage.HeaderType
  * @returns the URL, eg. https://google.com
  */
 export const extractUrlFromText = (text: string) => (
-	!URL_EXCLUDE_REGEX.test(text) ? text.match(URL_REGEX)?.[0] : undefined
+	text.split(' ').find(word => URL_REGEX.test(word) && !URL_EXCLUDE_REGEX.test(word)) || undefined
 )
 
 export const generateLinkPreviewIfRequired = async(text: string, getUrlInfo: MessageGenerationOptions['getUrlInfo'], logger: MessageGenerationOptions['logger']) => {


### PR DESCRIPTION
This fixes the thumbnail error when submitting a
Google Maps link.