### PR TITLE
Fix: _logger undefined and Fix: contact undefined sometimes | make-in-memory-store.ts

### DIFF
--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -29,7 +29,7 @@ export const waLabelAssociationKey: Comparable<LabelAssociation, string> = {
 export type BaileysInMemoryStoreConfig = {
 	chatKey?: Comparable<Chat, string>
 	labelAssociationKey?: Comparable<LabelAssociation, string>
-	logger?: Logger
+	logger: Logger
 	socket?: WASocket
 }
 
@@ -74,12 +74,11 @@ const predefinedLabels = Object.freeze<Record<string, Label>>({
 })
 
 export default (
-	{ logger: _logger, chatKey, labelAssociationKey, socket }: BaileysInMemoryStoreConfig
+	{ logger, chatKey, labelAssociationKey, socket }: BaileysInMemoryStoreConfig
 ) => {
-	// const logger = _logger || DEFAULT_CONNECTION_CONFIG.logger.child({ stream: 'in-mem-store' })
 	chatKey = chatKey || waChatKey(true)
 	labelAssociationKey = labelAssociationKey || waLabelAssociationKey
-	const logger = _logger || DEFAULT_CONNECTION_CONFIG.logger.child({ stream: 'in-mem-store' })
+	logger = _logger || DEFAULT_CONNECTION_CONFIG.logger.child({ stream: 'in-mem-store' })
 	const KeyedDB = require('@adiwajshing/keyed-db').default
 
 	const chats = new KeyedDB(chatKey, c => c.id) as KeyedDB<Chat, string>
@@ -192,7 +191,10 @@ export default (
 					}
 				}
 
-				Object.assign(contacts[update.id!], contact)
+				contacts[contact.id] = Object.assign(
+					contacts[contact.id] || {},
+					contact
+				)
 			}
 		})
 		ev.on('chats.upsert', newChats => {

--- a/src/Store/make-in-memory-store.ts
+++ b/src/Store/make-in-memory-store.ts
@@ -78,7 +78,7 @@ export default (
 ) => {
 	chatKey = chatKey || waChatKey(true)
 	labelAssociationKey = labelAssociationKey || waLabelAssociationKey
-	logger = _logger || DEFAULT_CONNECTION_CONFIG.logger.child({ stream: 'in-mem-store' })
+	logger = logger || DEFAULT_CONNECTION_CONFIG.logger.child({ stream: 'in-mem-store' })
 	const KeyedDB = require('@adiwajshing/keyed-db').default
 
 	const chats = new KeyedDB(chatKey, c => c.id) as KeyedDB<Chat, string>

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -175,7 +175,7 @@ export const decryptMessageNode = (
 									authorJid: author,
 									item: msg.senderKeyDistributionMessage
 								})
-							}catch (err) {
+							} catch(err) {
 								logger.error({ key: fullMessage.key, err }, 'failed to decrypt message')
 						        }
 						}


### PR DESCRIPTION
FIX 2 ERRORS:
    exports.default = ({ logger: _logger, chatKey, labelAssociationKey, socket }) => {
    -> TypeError: Cannot destructure property 'logger' of 'undefined' as it is undefined.

    Object.assign(contacts[update.id], contact)
    -> TypeError: Cannot convert undefined or null to object.