### PR TITLE
added personal bot support

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -47,7 +47,8 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		retryRequestDelayMs,
 		maxMsgRetryCount,
 		getMessage,
-		shouldIgnoreJid
+		shouldIgnoreJid,
+		personalBot
 	} = config
 	const sock = makeMessagesSocket(config)
 	const {
@@ -695,6 +696,12 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			if(node.attrs.sender_pn) {
 				ev.emit('chats.phoneNumberShare', { lid: node.attrs.from, jid: node.attrs.sender_pn })
 			}
+		}
+
+		if (personalBot && !(msg.key.fromMe)) {
+			logger.debug( {key: msg.key}, 'not-self message')
+			await sendMessageAck(node);
+			return
 		}
 
 		if(shouldIgnoreJid(msg.key.remoteJid!)) {

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -94,6 +94,12 @@ export type SocketConfig = {
     shouldIgnoreJid: (jid: string) => boolean | undefined
 
     /**
+     * This will make the bot only decrypt own-messages.
+     * This is the way to go, to create a personal bot.
+     */
+    personalBot: boolean
+    
+    /**
      * Optionally patch the message before sending out
      * */
     patchMessageBeforeSending: (


### PR DESCRIPTION
This will make the bot decrypt only self-messages, meaning, it will only listen to your own commands,
those with msg.key.fromMe === true. This is extremely useful to performance on large-scale personal bots, i.e 10 super groups.

