### PR TITLE
Use message-receipt.update for status@broadcast events

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -32,7 +32,7 @@ import {
 	getBinaryNodeChild,
 	getBinaryNodeChildBuffer,
 	getBinaryNodeChildren,
-	isJidGroup,
+	isJidGroup, isJidStatusBroadcast,
 	isJidUser,
 	jidDecode,
 	jidNormalizedUser,
@@ -599,7 +599,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 							!isNodeFromMe
 						)
 					) {
-						if(isJidGroup(remoteJid)) {
+						if(isJidGroup(remoteJid) || isJidStatusBroadcast(remoteJid)) {
 							if(attrs.participant) {
 								const updateKey: keyof MessageUserReceipt = status === proto.WebMessageInfo.Status.DELIVERY_ACK ? 'receiptTimestamp' : 'readTimestamp'
 								ev.emit(


### PR DESCRIPTION
Right now, when we send a message to `status@broadcast` all "views" are sent as `message.update` events.
It leads to errors when handling it 

For instance, there's an error in memory store - you'll get the first ACK in "view" case, but for the rest it will `delete update.status`  from all feature events
https://github.com/WhiskeySockets/Baileys/blob/master/src/Store/make-in-memory-store.ts#L241-L248

The ideal case here - is to move all updates messages for `status@broadcast` to `message-receipt.update` as we do for groups.

It's the right way to do - right now `messaging-history.set` treat it this way and adds acks for broadcast to `userReceipt`