### PR TITLE
Issue messages.update on MESSAGE_EDIT protocol messages

### DIFF
--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -258,6 +258,17 @@ const processMessage = async(
 				}
 			])
 			break
+		case proto.Message.ProtocolMessage.Type.MESSAGE_EDIT:
+			ev.emit('messages.update', [
+				{
+					key: {
+						...message.key,
+						id: protocolMsg.key!.id
+					},
+					update: { message: protocolMsg.editedMessage }
+				}
+			])
+			break
 		case proto.Message.ProtocolMessage.Type.EPHEMERAL_SETTING:
 			Object.assign(chat, {
 				ephemeralSettingTimestamp: toNumber(message.messageTimestamp),


### PR DESCRIPTION
Issue `messages.update` on MESSAGE_EDIT **in addition to `messages.upsert`**, but with the better structure to easily use it as `Object.assign`.

Right now users have to handle edit message event in `message.upsert`events on apps side.
It'd be great to have a simple way of telling - "This message has been update with this content" - exactly what `messages.update` is for! 

We handle `MESSAGE_REVOKE` the similar way, so we have two events at the end - `message.upsert` with the original content (protocol message) and `message.update` with "easy to use" structure - just find the original message and replace update all fields.
https://github.com/WhiskeySockets/Baileys/blob/92ef6dc091a239d52732910be73bc8e936f106dd/src/Utils/process-message.ts#L250-L260

Not sure if it's the right place to handle such messages, but looks like it's!