### PR TITLE
Fix: sending ptv if true

### DIFF
--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -413,7 +413,7 @@ export const generateWAMessageContent = async(
 			}
 			break
 		}
-	} else if('ptv' in message) {
+	} else if('ptv' in message && message.ptv) {
 		const { videoMessage } = await prepareWAMessageMedia(
 			{ video: message.video },
 			options


### PR DESCRIPTION
Sorry, the previous PR had an issue where it was still sent as ptv even though the value was false.