### PR TITLE
Feat: Modified number action in group-participants.update

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -268,6 +268,11 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				}
 			}
 			break
+		case 'modify':
+			const oldNumber = getBinaryNodeChildren(child, 'participant').map(p => p.attrs.jid)
+			msg.messageStubParameters = oldNumber || []
+			msg.messageStubType = WAMessageStubType.GROUP_PARTICIPANT_CHANGE_NUMBER
+			break
 		case 'promote':
 		case 'demote':
 		case 'remove':

--- a/src/Types/GroupMetadata.ts
+++ b/src/Types/GroupMetadata.ts
@@ -2,7 +2,7 @@ import { Contact } from './Contact'
 
 export type GroupParticipant = (Contact & { isAdmin?: boolean, isSuperAdmin?: boolean, admin?: 'admin' | 'superadmin' | null })
 
-export type ParticipantAction = 'add' | 'remove' | 'promote' | 'demote'
+export type ParticipantAction = 'add' | 'remove' | 'promote' | 'demote' | 'modify'
 
 export type RequestJoinAction = 'created' | 'revoked' | 'rejected'
 

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -308,6 +308,10 @@ const processMessage = async(
 		const participantsIncludesMe = () => participants.find(jid => areJidsSameUser(meId, jid))
 
 		switch (message.messageStubType) {
+		case WAMessageStubType.GROUP_PARTICIPANT_CHANGE_NUMBER:
+			participants = message.messageStubParameters || []
+			emitParticipantsUpdate('modify')
+			break
 		case WAMessageStubType.GROUP_PARTICIPANT_LEAVE:
 		case WAMessageStubType.GROUP_PARTICIPANT_REMOVE:
 			participants = message.messageStubParameters || []


### PR DESCRIPTION
Added stubType GROUP_PARTICIPANT_CHANGE_NUMBER

When a user changed their number, it was not output in group-participants.update, for people who use caching, this is a problem.

```ts
sock.ev.on('group-participants.update', async({ id, participants, action, author }) => {
    if (action === 'modify'){
        const newNumber = participants[0]
        const oldNumber = author
    }
})
```