### PR TITLE
Fix: getUSyncDevices

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -159,7 +159,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				users.push({ tag: 'user', attrs: { jid } })
 			}
 		}
-		
+
 		if(!users.length) {
 			return deviceResults
 		}

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -159,6 +159,10 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				users.push({ tag: 'user', attrs: { jid } })
 			}
 		}
+		
+		if (!users.length){
+			return deviceResults
+		}
 
 		const iq: BinaryNode = {
 			tag: 'iq',
@@ -193,8 +197,8 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				},
 			],
 		}
-		const result = users.length ? await query(iq) : { tag: '', attrs: {}, content: [] }
-		const extracted = users.length ? extractDeviceJids(result, authState.creds.me!.id, ignoreZeroDevices) : []
+		const result = await query(iq)
+		const extracted = extractDeviceJids(result, authState.creds.me!.id, ignoreZeroDevices)
 		const deviceMap: { [_: string]: JidWithDevice[] } = {}
 
 		for(const item of extracted) {

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -160,7 +160,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 			}
 		}
 		
-		if (!users.length){
+		if(!users.length) {
 			return deviceResults
 		}
 

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -193,8 +193,8 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				},
 			],
 		}
-		const result = await query(iq)
-		const extracted = extractDeviceJids(result, authState.creds.me!.id, ignoreZeroDevices)
+		const result = users.length ? await query(iq) : []
+		const extracted = users.length ? extractDeviceJids(result, authState.creds.me!.id, ignoreZeroDevices) : []
 		const deviceMap: { [_: string]: JidWithDevice[] } = {}
 
 		for(const item of extracted) {

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -193,7 +193,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				},
 			],
 		}
-		const result = users.length ? await query(iq) : []
+		const result = users.length ? await query(iq) : { tag: '', attrs: {}, content: [] }
 		const extracted = users.length ? extractDeviceJids(result, authState.creds.me!.id, ignoreZeroDevices) : []
 		const deviceMap: { [_: string]: JidWithDevice[] } = {}
 


### PR DESCRIPTION
If there are no users to search for, the query is executed anyway, leaving it 100ms ~ 500ms slower, decreasing performance and consuming unnecessary resources