### PR TITLE
 Updates for groups -  infinite pre-keys

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -72,6 +72,7 @@ export const DEFAULT_CONNECTION_CONFIG: SocketConfig = {
 	patchMessageBeforeSending: msg => msg,
 	shouldSyncHistoryMessage: () => true,
 	shouldIgnoreJid: () => false,
+	forceGroupsPrekeys: true,
 	linkPreviewImageThumbnailWidth: 192,
 	transactionOpts: { maxCommitRetries: 10, delayBetweenTriesMs: 3000 },
 	generateHighQualityLinkPreview: false,

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -642,7 +642,8 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 							if(key.fromMe) {
 								try {
 									logger.debug({ attrs, key }, 'recv retry request')
-									await sendMessagesAgain(key, ids, retryNode!)
+									//await sendMessagesAgain(key, ids, retryNode!)
+									///This function slows down sending messages to groups and increases memory consumption.
 								} catch(error) {
 									logger.error({ key, ids, trace: error.stack }, 'error in sending message again')
 								}

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -39,6 +39,8 @@ export type SocketConfig = {
     logger: Logger
     /** version to connect with */
     version: WAVersion
+    /** Force the use of prekeys in groups */
+    forceGroupsPrekeys:	boolean
     /** override browser config */
     browser: WABrowserDescription
     /** agent used for fetch requests -- uploading/downloading media */


### PR DESCRIPTION
Fixed: Infinite pre-keys issue when sending messages to groups, especially those with more than 500 members.
Improved timeout handling and reduced memory and processing consumption.
