### PR TITLE
Ignore and do not decrypt received messages when offline, saving resources and increasing performance

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -66,6 +66,7 @@ export const DEFAULT_CONNECTION_CONFIG: SocketConfig = {
 	retryRequestDelayMs: 250,
 	maxMsgRetryCount: 5,
 	fireInitQueries: true,
+	ignoreOfflineMessages: false,
 	auth: undefined as unknown as AuthenticationState,
 	markOnlineOnConnect: true,
 	syncFullHistory: false,

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -47,6 +47,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		retryRequestDelayMs,
 		maxMsgRetryCount,
 		getMessage,
+		ignoreOfflineMessages,
 		shouldIgnoreJid
 	} = config
 	const sock = makeMessagesSocket(config)
@@ -693,6 +694,12 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	}
 
 	const handleMessage = async(node: BinaryNode) => {
+		if(ignoreOfflineMessages && node.attrs.offline) {
+			logger.debug({ key: node.attrs.key }, 'ignored offline message')
+			await sendMessageAck(node)
+			return
+		}
+
 		if(shouldIgnoreJid(node.attrs.from!) && node.attrs.from! !== '@s.whatsapp.net') {
 			logger.debug({ key: node.attrs.key }, 'ignored message')
 			await sendMessageAck(node)

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -78,6 +78,8 @@ export type SocketConfig = {
     linkPreviewImageThumbnailWidth: number
     /** Should Baileys ask the phone for full history, will be received async */
     syncFullHistory: boolean
+    /** Ignore and do not decrypt received messages when offline, default false */
+    ignoreOfflineMessages: boolean
     /** Should baileys fire init queries automatically, default true */
     fireInitQueries: boolean
     /**


### PR DESCRIPTION
### Does NOT DECRYPT the message, saving resources and increasing performance

In this PR, the variable "ignoreOfflineMessages" is included in socket, by default being false. If marked as true, it will ignore all messages received while offline.