### PR TITLE
Fix: axios vulnerability (analyzing, don't merge)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@hapi/boom": "^9.1.3",
     "async-lock": "^1.4.1",
     "audio-decode": "^2.1.3",
-    "axios": "^1.3.3",
+    "axios": "^1.6.0",
     "cache-manager": "4.0.1",
     "futoin-hkdf": "^1.5.1",
     "libphonenumber-js": "^1.10.20",


### PR DESCRIPTION
An issue in Axios 0.8.1 to 1.5.1 reveals the confidential XSRF-TOKEN stored in cookies, including it in the X-XSRF-TOKEN HTTP header for every request made to ANY HOST, allowing attackers to view useful information.