### PR TITLE
Fix: sharp vulnerability in libwebp dependency (analyzing, don't merge)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "jimp": "^0.16.1",
     "link-preview-js": "^3.0.0",
     "qrcode-terminal": "^0.12.0",
-    "sharp": "^0.32.2"
+    "sharp": "^0.32.6"
   },
   "peerDependenciesMeta": {
     "jimp": {


### PR DESCRIPTION
Sharp uses libwebp to decode WebP images and versions prior to the latest 0.32.6 are vulnerable to the high severity https://github.com/advisories/GHSA-j7hp-h8jx-5ppr

Or implement `sharp.block({ operation: ["VipsForeignLoadWebp"] });` in the code in messages-media.ts