### PR TITLE
Feat: others browsers in requestPairingCode()

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -29,10 +29,11 @@ import {
 	getCodeFromWSError,
 	getErrorCodeFromStreamError,
 	getNextPreKeysNode,
+	getPlatformId,
 	makeEventBuffer,
 	makeNoiseHandler,
 	printQRIfNecessaryListener,
-	promiseTimeout
+	promiseTimeout,
 } from '../Utils'
 import {
 	assertNodeErrorFree,
@@ -525,7 +526,7 @@ export const makeSocket = (config: SocketConfig) => {
 						{
 							tag: 'companion_platform_id',
 							attrs: {},
-							content: '49' // Chrome
+							content: getPlatformId(browser[1])
 						},
 						{
 							tag: 'companion_platform_display',

--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -15,6 +15,14 @@ import { SocketConfig } from './Socket'
 
 export type UserFacingSocketConfig = Partial<SocketConfig> & { auth: AuthenticationState }
 
+export type BrowsersMap = {
+    ubuntu(browser: string): [string, string, string]
+    macOS(browser: string): [string, string, string]
+    baileys(browser: string): [string, string, string]
+    windows(browser: string): [string, string, string]
+    appropriate(browser: string): [string, string, string]
+}
+
 export enum DisconnectReason {
     connectionClosed = 428,
     connectionLost = 408,

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -12,7 +12,8 @@ const COMPANION_PLATFORM_MAP = {
 	'Chrome': '49',
 	'Edge': '50',
 	'Firefox': '51',
-	'Opera': '53'
+	'Opera': '53',
+	'Safari': '54'
 }
 
 const PLATFORM_MAP = {

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -8,6 +8,13 @@ import { version as baileysVersion } from '../Defaults/baileys-version.json'
 import { BaileysEventEmitter, BaileysEventMap, BrowsersMap, DisconnectReason, WACallUpdateType, WAVersion } from '../Types'
 import { BinaryNode, getAllBinaryNodeChildren, jidDecode } from '../WABinary'
 
+const COMPANION_PLATFORM_MAP = {
+	'Chrome': 49,
+	'Edge': 50,
+	'Firefox': 51,
+	'Opera': 53
+}
+
 const PLATFORM_MAP = {
 	'aix': 'AIX',
 	'darwin': 'Mac OS',
@@ -16,13 +23,6 @@ const PLATFORM_MAP = {
 	'freebsd': 'FreeBSD',
 	'openbsd': 'OpenBSD',
 	'sunos': 'Solaris'
-}
-
-const COMPANION_PLATFORM_MAP = {
-	'Chrome': 49,
-	'Edge': 50,
-	'Firefox': 51,
-	'Opera': 53
 }
 
 export const Browsers: BrowsersMap = {

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -8,14 +8,6 @@ import { version as baileysVersion } from '../Defaults/baileys-version.json'
 import { BaileysEventEmitter, BaileysEventMap, BrowsersMap, DisconnectReason, WACallUpdateType, WAVersion } from '../Types'
 import { BinaryNode, getAllBinaryNodeChildren, jidDecode } from '../WABinary'
 
-const COMPANION_PLATFORM_MAP = {
-	'Chrome': '49',
-	'Edge': '50',
-	'Firefox': '51',
-	'Opera': '53',
-	'Safari': '54'
-}
-
 const PLATFORM_MAP = {
 	'aix': 'AIX',
 	'darwin': 'Mac OS',
@@ -36,7 +28,8 @@ export const Browsers: BrowsersMap = {
 }
 
 export const getPlatformId = (browser: string) => {
-	return COMPANION_PLATFORM_MAP[browser] || '49'
+	const platformType = proto.DeviceProps.PlatformType[browser.toUpperCase()]
+	return platformType ? platformType.charCodeAt(0) : '49' //chrome
 }
 
 export const BufferJSON = {

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -5,23 +5,37 @@ import { platform, release } from 'os'
 import { Logger } from 'pino'
 import { proto } from '../../WAProto'
 import { version as baileysVersion } from '../Defaults/baileys-version.json'
-import { BaileysEventEmitter, BaileysEventMap, DisconnectReason, WACallUpdateType, WAVersion } from '../Types'
+import { BaileysEventEmitter, BaileysEventMap, BrowsersMap, DisconnectReason, WACallUpdateType, WAVersion } from '../Types'
 import { BinaryNode, getAllBinaryNodeChildren, jidDecode } from '../WABinary'
 
 const PLATFORM_MAP = {
 	'aix': 'AIX',
 	'darwin': 'Mac OS',
 	'win32': 'Windows',
-	'android': 'Android'
+	'android': 'Android',
+	'freebsd': 'FreeBSD',
+	'openbsd': 'OpenBSD',
+	'sunos': 'Solaris'
 }
 
-export const Browsers = {
-	ubuntu: browser => ['Ubuntu', browser, '20.0.04'] as [string, string, string],
-	macOS: browser => ['Mac OS', browser, '10.15.7'] as [string, string, string],
-	baileys: browser => ['Baileys', browser, '4.0.0'] as [string, string, string],
-	windows: browser => ['Windows', browser, '10.0.22621'] as [string, string, string],
+const COMPANION_PLATFORM_MAP = {
+	'Chrome': 49,
+	'Edge': 50,
+	'Firefox': 51,
+	'Opera': 53
+}
+
+export const Browsers: BrowsersMap = {
+	ubuntu: (browser) => ['Ubuntu', browser, '22.04.4'],
+	macOS: (browser) => ['Mac OS', browser, '14.4.1'],
+	baileys: (browser) => ['Baileys', browser, '6.5.0'],
+	windows: (browser) => ['Windows', browser, '10.0.22631'],
 	/** The appropriate browser based on your OS & release */
-	appropriate: browser => [ PLATFORM_MAP[platform()] || 'Ubuntu', browser, release() ] as [string, string, string]
+	appropriate: (browser) => [ PLATFORM_MAP[platform()] || 'Ubuntu', browser, release() ]
+}
+
+export const getPlatformId = (browser: string) => {
+	return COMPANION_PLATFORM_MAP[browser] || 49
 }
 
 export const BufferJSON = {

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -9,10 +9,10 @@ import { BaileysEventEmitter, BaileysEventMap, BrowsersMap, DisconnectReason, WA
 import { BinaryNode, getAllBinaryNodeChildren, jidDecode } from '../WABinary'
 
 const COMPANION_PLATFORM_MAP = {
-	'Chrome': 49,
-	'Edge': 50,
-	'Firefox': 51,
-	'Opera': 53
+	'Chrome': '49',
+	'Edge': '50',
+	'Firefox': '51',
+	'Opera': '53'
 }
 
 const PLATFORM_MAP = {
@@ -35,7 +35,7 @@ export const Browsers: BrowsersMap = {
 }
 
 export const getPlatformId = (browser: string) => {
-	return COMPANION_PLATFORM_MAP[browser] || 49
+	return COMPANION_PLATFORM_MAP[browser] || '49'
 }
 
 export const BufferJSON = {

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -29,7 +29,7 @@ export const Browsers: BrowsersMap = {
 
 export const getPlatformId = (browser: string) => {
 	const platformType = proto.DeviceProps.PlatformType[browser.toUpperCase()]
-	return platformType ? platformType.charCodeAt(0) : '49' //chrome
+	return platformType ? platformType.toString().charCodeAt(0) : '49' //chrome
 }
 
 export const BufferJSON = {


### PR DESCRIPTION
Added: Edge, Firefox, Opera and Safari (by default Chrome) with getPlatformId()

Added FreeBSD, OpenBSD and Solaris in PLATFORM_MAP (use with appropriate)

Updated versions of Ubuntu, MacOS, Baileys and Windows

Feat: In requestPairingCode, the default was just chrome, now it is possible to use Edge, Firefox, Opera and more