### PR TITLE
Speed up encodeBinaryNode in x100 times if encoding many items in content

### DIFF
--- a/src/WABinary/encode.ts
+++ b/src/WABinary/encode.ts
@@ -4,10 +4,19 @@ import { FullJid, jidDecode } from './jid-utils'
 import type { BinaryNode, BinaryNodeCodingOptions } from './types'
 
 export const encodeBinaryNode = (
-	{ tag, attrs, content }: BinaryNode,
+	node: BinaryNode,
 	opts: Pick<BinaryNodeCodingOptions, 'TAGS' | 'TOKEN_MAP'> = constants,
 	buffer: number[] = [0]
-) => {
+): Buffer => {
+	const encoded = encodeBinaryNodeInner(node, opts, buffer)
+	return Buffer.from(encoded)
+}
+
+const encodeBinaryNodeInner = (
+	{ tag, attrs, content }: BinaryNode,
+	opts: Pick<BinaryNodeCodingOptions, 'TAGS' | 'TOKEN_MAP'>,
+	buffer: number[]
+): number[] => {
 	const { TAGS, TOKEN_MAP } = opts
 
 	const pushByte = (value: number) => buffer.push(value & 0xff)
@@ -224,7 +233,7 @@ export const encodeBinaryNode = (
 	} else if(Array.isArray(content)) {
 		writeListStart(content.length)
 		for(const item of content) {
-			encodeBinaryNode(item, opts, buffer)
+			encodeBinaryNodeInner(item, opts, buffer)
 		}
 	} else if(typeof content === 'undefined') {
 		// do nothing
@@ -232,5 +241,5 @@ export const encodeBinaryNode = (
 		throw new Error(`invalid children for header "${tag}": ${content} (${typeof content})`)
 	}
 
-	return Buffer.from(buffer)
+	return buffer
 }


### PR DESCRIPTION
Speed up encodeBinaryNode in **x100 times** if encoding many items in content

The problem was that when we use `encodeBinaryNode(item, opts, buffer)` in for loop we actually don't use the result, but we DO convert it to `Buffer.from`

Here:
https://github.com/WhiskeySockets/Baileys/blob/f25f83656a7cadbcdaf66b7fea72b9d4b3a72aa0/src/WABinary/encode.ts#L227

I've moved `Buffer.from` to `sendNode` function, so it converts the array to Buffer only when required (at the end), but not in the middle of the inner loop


```
encodeBinaryNode NEW - 1 - 74ms
encodeBinaryNode NEW - 2 - 68ms
encodeBinaryNode NEW - 3 - 88ms
encodeBinaryNode NEW - 4 - 45ms
encodeBinaryNode NEW - 5 - 34ms
encodeBinaryNode NEW - 6 - 33ms
encodeBinaryNode NEW - 7 - 38ms
encodeBinaryNode NEW - 8 - 30ms
encodeBinaryNode NEW - 9 - 31ms
encodeBinaryNode ORIGINAL - 1 - 4846ms
encodeBinaryNode ORIGINAL - 2 - 4562ms
# I didn't wait the original 10 times, too long
```

With the fix it took **3 seconds**  to send status to **3K contacts** (including IO communication staff with store and WA servers)