### PR TITLE
refactor: Change Sync Functions to Promises to Prevent Blocking Event Loop

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -440,7 +440,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			const ref = toRequiredBuffer(getBinaryNodeChildBuffer(linkCodeCompanionReg, 'link_code_pairing_ref'))
 			const primaryIdentityPublicKey = toRequiredBuffer(getBinaryNodeChildBuffer(linkCodeCompanionReg, 'primary_identity_pub'))
 			const primaryEphemeralPublicKeyWrapped = toRequiredBuffer(getBinaryNodeChildBuffer(linkCodeCompanionReg, 'link_code_pairing_wrapped_primary_ephemeral_pub'))
-			const codePairingPublicKey = decipherLinkPublicKey(primaryEphemeralPublicKeyWrapped)
+			const codePairingPublicKey = await decipherLinkPublicKey(primaryEphemeralPublicKeyWrapped)
 			const companionSharedKey = Curve.sharedKey(authState.creds.pairingEphemeralKeyPair.private, codePairingPublicKey)
 			const random = randomBytes(32)
 			const linkCodeSalt = randomBytes(32)
@@ -499,10 +499,10 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 	}
 
-	function decipherLinkPublicKey(data: Uint8Array | Buffer) {
+	async function decipherLinkPublicKey(data: Uint8Array | Buffer) {
 		const buffer = toRequiredBuffer(data)
 		const salt = buffer.slice(0, 32)
-		const secretKey = derivePairingCodeKey(authState.creds.pairingCode!, salt)
+		const secretKey = await derivePairingCodeKey(authState.creds.pairingCode!, salt)
 		const iv = buffer.slice(32, 48)
 		const payload = buffer.slice(48, 80)
 		return aesDecryptCTR(payload, secretKey, iv)

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -547,7 +547,7 @@ export const makeSocket = (config: SocketConfig) => {
 	async function generatePairingKey() {
 		const salt = randomBytes(32)
 		const randomIv = randomBytes(16)
-		const key = derivePairingCodeKey(authState.creds.pairingCode!, salt)
+		const key = await derivePairingCodeKey(authState.creds.pairingCode!, salt)
 		const ciphered = aesEncryptCTR(authState.creds.pairingEphemeralKeyPair.public, key, randomIv)
 		return Buffer.concat([salt, randomIv, ciphered])
 	}

--- a/src/Utils/crypto.ts
+++ b/src/Utils/crypto.ts
@@ -1,8 +1,11 @@
-import { createCipheriv, createDecipheriv, createHash, createHmac, pbkdf2Sync, randomBytes } from 'crypto'
+import { createCipheriv, createDecipheriv, createHash, createHmac, pbkdf2, randomBytes } from 'crypto'
 import HKDF from 'futoin-hkdf'
 import * as libsignal from 'libsignal'
+import { promisify } from 'util'
 import { KEY_BUNDLE_TYPE } from '../Defaults'
 import { KeyPair } from '../Types'
+
+const pbkdf2Promise = promisify(pbkdf2)
 
 /** prefix version byte to the pub keys, required for some curve crypto functions */
 export const generateSignalPubKey = (pubKey: Uint8Array | Buffer) => (
@@ -126,6 +129,6 @@ export function hkdf(buffer: Uint8Array | Buffer, expandedLength: number, info: 
 	return HKDF(!Buffer.isBuffer(buffer) ? Buffer.from(buffer) : buffer, expandedLength, info)
 }
 
-export function derivePairingCodeKey(pairingCode: string, salt: Buffer) {
-	return pbkdf2Sync(pairingCode, salt, 2 << 16, 32, 'sha256')
+export async function derivePairingCodeKey(pairingCode: string, salt: Buffer) {
+	return await pbkdf2Promise(pairingCode, salt, 2 << 16, 32, 'sha256')
 }

--- a/src/Utils/noise-handler.ts
+++ b/src/Utils/noise-handler.ts
@@ -163,7 +163,7 @@ export const makeNoiseHandler = ({
 
 			return frame
 		},
-		decodeFrame: async (newData: Buffer | Uint8Array, onFrame: (buff: Uint8Array | BinaryNode) => void) => {
+		decodeFrame: async(newData: Buffer | Uint8Array, onFrame: (buff: Uint8Array | BinaryNode) => void) => {
 			// the binary protocol uses its own framing mechanism
 			// on top of the WS frames
 			// so we get this data and separate out the frames

--- a/src/Utils/noise-handler.ts
+++ b/src/Utils/noise-handler.ts
@@ -163,7 +163,7 @@ export const makeNoiseHandler = ({
 
 			return frame
 		},
-		decodeFrame: (newData: Buffer | Uint8Array, onFrame: (buff: Uint8Array | BinaryNode) => void) => {
+		decodeFrame: async (newData: Buffer | Uint8Array, onFrame: (buff: Uint8Array | BinaryNode) => void) => {
 			// the binary protocol uses its own framing mechanism
 			// on top of the WS frames
 			// so we get this data and separate out the frames
@@ -184,7 +184,7 @@ export const makeNoiseHandler = ({
 
 				if(isFinished) {
 					const result = decrypt(frame as Uint8Array)
-					frame = decodeBinaryNode(result)
+					frame = await decodeBinaryNode(result)
 				}
 
 				logger.trace({ msg: (frame as any)?.attrs?.id }, 'recv frame')

--- a/src/WABinary/decode.ts
+++ b/src/WABinary/decode.ts
@@ -1,11 +1,14 @@
-import { inflateSync } from 'zlib'
+import { inflate } from 'zlib'
+import { promisify } from 'util'
 import * as constants from './constants'
 import { jidEncode } from './jid-utils'
 import type { BinaryNode, BinaryNodeCodingOptions } from './types'
 
-export const decompressingIfRequired = (buffer: Buffer) => {
+const inflatePromise = promisify(inflate)
+
+export const decompressingIfRequired = async (buffer: Buffer) => {
 	if(2 & buffer.readUInt8()) {
-		buffer = inflateSync(buffer.slice(1))
+		buffer = await inflatePromise(buffer.slice(1))
 	} else { // nodes with no compression have a 0x00 prefix, we remove that
 		buffer = buffer.slice(1)
 	}
@@ -259,7 +262,7 @@ export const decodeDecompressedBinaryNode = (
 	}
 }
 
-export const decodeBinaryNode = (buff: Buffer): BinaryNode => {
-	const decompBuff = decompressingIfRequired(buff)
+export const decodeBinaryNode = async (buff: Buffer): Promise<BinaryNode> => {
+	const decompBuff = await decompressingIfRequired(buff)
 	return decodeDecompressedBinaryNode(decompBuff, constants)
 }

--- a/src/WABinary/decode.ts
+++ b/src/WABinary/decode.ts
@@ -1,12 +1,12 @@
-import { inflate } from 'zlib'
 import { promisify } from 'util'
+import { inflate } from 'zlib'
 import * as constants from './constants'
 import { jidEncode } from './jid-utils'
 import type { BinaryNode, BinaryNodeCodingOptions } from './types'
 
 const inflatePromise = promisify(inflate)
 
-export const decompressingIfRequired = async (buffer: Buffer) => {
+export const decompressingIfRequired = async(buffer: Buffer) => {
 	if(2 & buffer.readUInt8()) {
 		buffer = await inflatePromise(buffer.slice(1))
 	} else { // nodes with no compression have a 0x00 prefix, we remove that

--- a/src/WABinary/decode.ts
+++ b/src/WABinary/decode.ts
@@ -262,7 +262,7 @@ export const decodeDecompressedBinaryNode = (
 	}
 }
 
-export const decodeBinaryNode = async (buff: Buffer): Promise<BinaryNode> => {
+export const decodeBinaryNode = async(buff: Buffer): Promise<BinaryNode> => {
 	const decompBuff = await decompressingIfRequired(buff)
 	return decodeDecompressedBinaryNode(decompBuff, constants)
 }


### PR DESCRIPTION
This PR changes `inflateSync` and `pbkdf2Sync` to `inflate` and `pbkdf` functions with promisify to prevent blocking event loop