### PR TITLE
fix: invalid children for header "companion_platform_id": 49 (number)

### DIFF
--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -29,7 +29,7 @@ export const Browsers: BrowsersMap = {
 
 export const getPlatformId = (browser: string) => {
 	const platformType = proto.DeviceProps.PlatformType[browser.toUpperCase()]
-	return platformType ? platformType.toString().charCodeAt(0) : '49' //chrome
+	return platformType ? platformType.toString().charCodeAt(0).toString() : '49' //chrome
 }
 
 export const BufferJSON = {


### PR DESCRIPTION
When using "requestPairingCode", "typeof platformType" is number, which throws an error