### PR TITLE
add default delay in requestPairingCode to avoid errors

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -129,3 +129,5 @@ export const DEFAULT_CACHE_TTLS = {
 	CALL_OFFER: 5 * 60, // 5 minutes
 	USER_DEVICES: 5 * 60, // 5 minutes
 }
+
+export const DEFAULT_DELAY_PAIRINGCODE = 2000 // 2 seconds

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -6,13 +6,13 @@ import { proto } from '../../WAProto'
 import {
 	DEF_CALLBACK_PREFIX,
 	DEF_TAG_PREFIX,
+	DEFAULT_DELAY_PAIRINGCODE,
 	INITIAL_PREKEY_COUNT,
 	MIN_PREKEY_COUNT,
 	MOBILE_ENDPOINT,
 	MOBILE_NOISE_HEADER,
 	MOBILE_PORT,
-	NOISE_WA_HEADER,
-	DEFAULT_DELAY_PAIRINGCODE
+	NOISE_WA_HEADER
 } from '../Defaults'
 import { DisconnectReason, SocketConfig } from '../Types'
 import {
@@ -497,6 +497,7 @@ export const makeSocket = (config: SocketConfig) => {
 		if(delayMs) {
 			await delay(delayMs)
 		}
+		
 		authState.creds.pairingCode = bytesToCrockford(randomBytes(5))
 		authState.creds.me = {
 			id: jidEncode(phoneNumber, 's.whatsapp.net'),

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -497,7 +497,7 @@ export const makeSocket = (config: SocketConfig) => {
 		if(delayMs) {
 			await delay(delayMs)
 		}
-		
+
 		authState.creds.pairingCode = bytesToCrockford(randomBytes(5))
 		authState.creds.me = {
 			id: jidEncode(phoneNumber, 's.whatsapp.net'),

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -11,7 +11,8 @@ import {
 	MOBILE_ENDPOINT,
 	MOBILE_NOISE_HEADER,
 	MOBILE_PORT,
-	NOISE_WA_HEADER
+	NOISE_WA_HEADER,
+	DEFAULT_DELAY_PAIRINGCODE
 } from '../Defaults'
 import { DisconnectReason, SocketConfig } from '../Types'
 import {
@@ -21,6 +22,7 @@ import {
 	bytesToCrockford,
 	configureSuccessfulPairing,
 	Curve,
+	delay,
 	derivePairingCodeKey,
 	generateLoginNode,
 	generateMdTagPrefix,
@@ -488,7 +490,13 @@ export const makeSocket = (config: SocketConfig) => {
 		end(new Boom(msg || 'Intentional Logout', { statusCode: DisconnectReason.loggedOut }))
 	}
 
-	const requestPairingCode = async(phoneNumber: string): Promise<string> => {
+	const requestPairingCode = async(
+		phoneNumber: string,
+		delayMs: number | null = DEFAULT_DELAY_PAIRINGCODE
+	): Promise<string> => {
+		if(delayMs) {
+			await delay(delayMs)
+		}
 		authState.creds.pairingCode = bytesToCrockford(randomBytes(5))
 		authState.creds.me = {
 			id: jidEncode(phoneNumber, 's.whatsapp.net'),


### PR DESCRIPTION
sometimes its necessary to set a delay to avoid error requesting a pairing code when connection was not estabilished yet, the delay can be changed or removed