### PR TITLE
chore: Comment out unnecessary/forgotten console.log

### DIFF
--- a/src/WAM/encode.ts
+++ b/src/WAM/encode.ts
@@ -11,7 +11,7 @@ export const encodeWAM = (binaryInfo: BinaryInfo) => {
 	encodeWAMHeader(binaryInfo)
 	encodeEvents(binaryInfo)
 
-	console.log(binaryInfo.buffer)
+	//console.log(binaryInfo.buffer)
 	const totalSize = binaryInfo.buffer
 		.map((a) => a.length)
 		.reduce((a, b) => a + b)


### PR DESCRIPTION
I noticed a fat output being printed for no reason,
which is so annoying