### PR TITLE
Deprecation of buttons

### DIFF
--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -4,6 +4,7 @@ import type { Readable } from 'stream'
 import type { URL } from 'url'
 import { proto } from '../../WAProto'
 import { MEDIA_HKDF_KEY_MAPPING } from '../Defaults'
+import { BinaryNode } from '../WABinary'
 import type { GroupMetadata } from './GroupMetadata'
 import { CacheStore } from './Socket'
 
@@ -60,28 +61,8 @@ type ViewOnce = {
     viewOnce?: boolean
 }
 
-type Buttonable = {
-    /** add buttons to the message  */
-    buttons?: proto.Message.ButtonsMessage.IButton[]
-}
-type Templatable = {
-    /** add buttons to the message (conflicts with normal buttons)*/
-    templateButtons?: proto.IHydratedTemplateButton[]
-
-    footer?: string
-}
 type Editable = {
   edit?: WAMessageKey
-}
-type Listable = {
-    /** Sections of the List */
-    sections?: proto.Message.ListMessage.ISection[]
-
-    /** Title of a List Message only */
-    title?: string
-
-    /** Text of the bnutton on the list (required) */
-    buttonText?: string
 }
 type WithDimensions = {
     width?: number
@@ -110,7 +91,7 @@ export type AnyMediaMessageContent = (
         image: WAMediaUpload
         caption?: string
         jpegThumbnail?: string
-    } & Mentionable & Contextable & Buttonable & Templatable & WithDimensions)
+    } & Mentionable & Contextable & WithDimensions)
     | ({
         video: WAMediaUpload
         caption?: string
@@ -118,7 +99,7 @@ export type AnyMediaMessageContent = (
         jpegThumbnail?: string
         /** if set to true, will send as a `video note` */
         ptv?: boolean
-    } & Mentionable & Contextable & Buttonable & Templatable & WithDimensions)
+    } & Mentionable & Contextable & WithDimensions)
     | {
         audio: WAMediaUpload
         /** if set to true, will send as a `voice note` */
@@ -134,7 +115,7 @@ export type AnyMediaMessageContent = (
         mimetype: string
         fileName?: string
         caption?: string
-    } & Contextable & Buttonable & Templatable))
+    } & Contextable))
     & { mimetype?: string } & Editable
 
 export type ButtonReplyInfo = {
@@ -152,11 +133,11 @@ export type AnyRegularMessageContent = (
 	    text: string
         linkPreview?: WAUrlInfo | null
     }
-    & Mentionable & Contextable & Buttonable & Templatable & Listable & Editable)
+    & Mentionable & Contextable & Editable)
     | AnyMediaMessageContent
     | ({
         poll: PollMessageOptions
-    } & Mentionable & Contextable & Buttonable & Templatable & Editable)
+    } & Mentionable & Contextable & Editable)
     | {
         contacts: {
             displayName?: string
@@ -206,6 +187,7 @@ export type MessageRelayOptions = MinimalRelayOptions & {
     participant?: { jid: string, count: number }
     /** additional attributes to add to the WA binary node */
     additionalAttributes?: { [_: string]: string }
+    additionalNodes?: BinaryNode[]
     /** should we use the devices cache, or fetch afresh from the server; default assumed to be "true" */
     useUserDevicesCache?: boolean
     /** jid list of participants for status@broadcast */

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -62,8 +62,6 @@ const MessageTypeProto = {
    	'document': WAProto.Message.DocumentMessage,
 } as const
 
-const ButtonType = proto.Message.ButtonsMessage.HeaderType
-
 /**
  * Uses a regex to test whether the string contains a URL, and returns the URL if it does.
  * @param text eg. hello https://google.com
@@ -471,70 +469,6 @@ export const generateWAMessageContent = async(
 			message,
 			options
 		)
-	}
-
-	if('buttons' in message && !!message.buttons) {
-		const buttonsMessage: proto.Message.IButtonsMessage = {
-			buttons: message.buttons!.map(b => ({ ...b, type: proto.Message.ButtonsMessage.Button.Type.RESPONSE }))
-		}
-		if('text' in message) {
-			buttonsMessage.contentText = message.text
-			buttonsMessage.headerType = ButtonType.EMPTY
-		} else {
-			if('caption' in message) {
-				buttonsMessage.contentText = message.caption
-			}
-
-			const type = Object.keys(m)[0].replace('Message', '').toUpperCase()
-			buttonsMessage.headerType = ButtonType[type]
-
-			Object.assign(buttonsMessage, m)
-		}
-
-		if('footer' in message && !!message.footer) {
-			buttonsMessage.footerText = message.footer
-		}
-
-		m = { buttonsMessage }
-	} else if('templateButtons' in message && !!message.templateButtons) {
-		const msg: proto.Message.TemplateMessage.IHydratedFourRowTemplate = {
-			hydratedButtons: message.templateButtons
-		}
-
-		if('text' in message) {
-			msg.hydratedContentText = message.text
-		} else {
-
-			if('caption' in message) {
-				msg.hydratedContentText = message.caption
-			}
-
-			Object.assign(msg, m)
-		}
-
-		if('footer' in message && !!message.footer) {
-			msg.hydratedFooterText = message.footer
-		}
-
-		m = {
-			templateMessage: {
-				fourRowTemplate: msg,
-				hydratedTemplate: msg
-			}
-		}
-	}
-
-	if('sections' in message && !!message.sections) {
-		const listMessage: proto.Message.IListMessage = {
-			sections: message.sections,
-			buttonText: message.buttonText,
-			title: message.title,
-			footerText: message.footer,
-			description: message.text,
-			listType: proto.Message.ListMessage.ListType.SINGLE_SELECT
-		}
-
-		m = { listMessage }
 	}
 
 	if('viewOnce' in message && !!message.viewOnce) {


### PR DESCRIPTION
[![Support my work on GitHub Sponsors](https://sponsor-spotlight.vercel.app/sponsor?login=PurpShell)](https://github.com/sponsors/PurpShell)

# Deprecation of Buttons, Lists, Templates
We will now remove all references in code and built-in capability to send buttons or Lists. We announced the deprecation a year and a few months ago.

This PR allows you to add custom Nodes to the outgoing <message> as well. Do with that information what you will!