### PR TITLE
Support poll v2 and v3 sending

### DIFF
--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -94,6 +94,7 @@ export type PollMessageOptions = {
     values: string[]
     /** 32 byte message secret to encrypt poll selections */
     messageSecret?: Uint8Array
+    toAnnouncementGroup?: boolean
 }
 
 type SharePhoneNumber = {


### PR DESCRIPTION
[![Support my work on GitHub Sponsors](https://sponsor-spotlight.vercel.app/sponsor?login=PurpShell)](https://github.com/sponsors/PurpShell)

# Poll V2/V3
WhatsApp uses pollCreationMessageV2 in communities and community announcements.
They use pollCreationMessage for multiple choices and pollCreationMessageV3 for single select (personal, groups, newsletter)