### PR TITLE
feat: emit WAMessageStubType.GROUP_CHANGE_DESCRIPTION event

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -299,6 +299,11 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			msg.messageStubType = WAMessageStubType.GROUP_CHANGE_SUBJECT
 			msg.messageStubParameters = [ child.attrs.subject ]
 			break
+		case 'description':
+			const description = getBinaryNodeChild(child, 'body')?.content?.toString()
+			msg.messageStubType = WAMessageStubType.GROUP_CHANGE_DESCRIPTION
+			msg.messageStubParameters = description ? [ description ] : undefined
+			break
 		case 'announcement':
 		case 'not_announcement':
 			msg.messageStubType = WAMessageStubType.GROUP_CHANGE_ANNOUNCE

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -353,6 +353,11 @@ const processMessage = async(
 			chat.name = name
 			emitGroupUpdate({ subject: name })
 			break
+		case WAMessageStubType.GROUP_CHANGE_DESCRIPTION:
+			const description = message.messageStubParameters?.[0]
+			chat.description = description
+			emitGroupUpdate({ desc: description })
+			break
 		case WAMessageStubType.GROUP_CHANGE_INVITE_LINK:
 			const code = message.messageStubParameters?.[0]
 			emitGroupUpdate({ inviteCode: code })


### PR DESCRIPTION
this PR implements the `WAMessageStubType.GROUP_CHANGE_DESCRIPTION` event which is triggered by a description update of a group. it also works for community descriptions.