### PR TITLE
fix: Fixed contacts.update when received changed picture event (close #931)

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -414,7 +414,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			const delPicture = getBinaryNodeChild(node, 'delete')
 
 			ev.emit('contacts.update', [{
-				id: jidNormalizedUser(node?.attrs?.jid) || ((setPicture || delPicture)?.attrs?.hash) || '',
+				id: jidNormalizedUser(node?.attrs?.from) || ((setPicture || delPicture)?.attrs?.hash) || '',
 				imgUrl: setPicture ? 'changed' : 'removed'
 			}])
 


### PR DESCRIPTION
I was running some tests with Baileys and noticed this simple bug. 
They previously fixed the `processProfilePic` function, but when receiving the contact update event, the ID that came was blank. 

By making this simple fix, the event was corrected.

Cited in https://github.com/WhiskeySockets/Baileys/issues/931