### PR TITLE
feat: exporting getUSyncDevices and createNodeParticipants to socket-send api

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -659,6 +659,8 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		waUploadToServer,
 		fetchPrivacySettings,
 		sendPeerDataOperationMessage,
+		createParticipantNodes,
+		getUSyncDevices,
 		updateMediaMessage: async(message: proto.IWebMessageInfo) => {
 			const content = assertMediaContent(message.message)
 			const mediaKey = content.mediaKey!


### PR DESCRIPTION
this PR implements the getUSyncDevices and createNodeParticipants functions to baileys socket object, can be called and structured within the scope of the backend code