### PR TITLE
fix: do not fetch group metadata for status

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -393,7 +393,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 							let groupData = useCachedGroupMetadata && cachedGroupMetadata ? await cachedGroupMetadata(jid) : undefined
 							if(groupData && Array.isArray(groupData?.participants)) {
 								logger.trace({ jid, participants: groupData.participants.length }, 'using cached group metadata')
-							} else {
+							} else if(!isStatus) {
 								groupData = await groupMetadata(jid)
 							}
 


### PR DESCRIPTION
There's no metadata for `status@broadcast` basically

fixes #985