### PR TITLE
chore: fix linebreak style error in windows

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
         ],
         "keyword-spacing": [
             "warn"
-        ]
+        ],
+        "linebreak-style": "off"
     }
 }


### PR DESCRIPTION
lines are automatically formated to LF in commit/checkout in `.gitattributes` config, its impossible to code in windows with this option activated, and its unecessary