### PR TITLE
fix: bump mobile wa version to avoid `old_version` when registering (2.24.16.78)

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -20,7 +20,7 @@ export const PHONE_CONNECTION_CB = 'CB:Pong'
 
 export const WA_DEFAULT_EPHEMERAL = 7 * 24 * 60 * 60
 
-const WA_VERSION = '2.24.6.77'
+const WA_VERSION = '2.24.16.78'
 
 const WA_VERSION_HASH = createHash('md5').update(WA_VERSION).digest('hex')
 export const MOBILE_TOKEN = Buffer.from('0a1mLfGUIBVrMKF1RdvLI5lkRBvof6vn0fD2QRSM' + WA_VERSION_HASH)

--- a/src/Utils/validate-connection.ts
+++ b/src/Utils/validate-connection.ts
@@ -10,7 +10,7 @@ import { createSignalIdentity } from './signal'
 
 const getUserAgent = (config: SocketConfig): proto.ClientPayload.IUserAgent => {
 	const osVersion = config.mobile ? '15.3.1' : '0.1'
-	const version = config.mobile ? [2, 24, 6] : config.version
+	const version = config.mobile ? [2, 24, 16] : config.version
 	const device = config.mobile ? 'iPhone_7' : 'Desktop'
 	const manufacturer = config.mobile ? 'Apple' : ''
 	const platform = config.mobile ? proto.ClientPayload.UserAgent.Platform.IOS : proto.ClientPayload.UserAgent.Platform.WEB


### PR DESCRIPTION
updating mobile wa version to 2.24.16.78 (latest version)