### PR TITLE
remove duplicated call reject event / add terminate tag

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -908,8 +908,13 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			call.isGroup = existingCall.isGroup
 		}
 
+		if(status === 'accept') {
+			call.startedAt = new Date(+attrs.t * 1000)
+			callOfferCache.set(call.id, call)
+		}
+		
 		// delete data once call has ended
-		if(status === 'reject' || status === 'accept' || status === 'timeout') {
+		if(status === 'reject' || status === 'timeout' || status == 'terminate') {
 			callOfferCache.del(call.id)
 		}
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -909,7 +909,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 
 		// delete data once call has ended
-		if(status === 'reject' || status === 'accept' || status === 'timeout' || status === 'terminate' ) {
+		if(status === 'reject' || status === 'accept' || status === 'timeout' || status === 'terminate') {
 			callOfferCache.del(call.id)
 		}
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -907,7 +907,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			call.isVideo = existingCall.isVideo
 			call.isGroup = existingCall.isGroup
 		}
-		
+
 		// delete data once call has ended
 		if(status === 'reject' || status === 'timeout' || status === 'terminate' || status === 'accept') {
 			callOfferCache.del(call.id)

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -907,14 +907,9 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			call.isVideo = existingCall.isVideo
 			call.isGroup = existingCall.isGroup
 		}
-
-		if(status === 'accept') {
-			call.startedAt = new Date(+attrs.t * 1000)
-			callOfferCache.set(call.id, call)
-		}
 		
 		// delete data once call has ended
-		if(status === 'reject' || status === 'timeout' || status == 'terminate') {
+		if(status === 'reject' || status === 'timeout' || status === 'terminate' || status === 'accept') {
 			callOfferCache.del(call.id)
 		}
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -909,7 +909,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 
 		// delete data once call has ended
-		if(status === 'reject' || status === 'timeout' || status === 'terminate' || status === 'accept') {
+		if(status === 'reject' || status === 'accept' || status === 'timeout' || status === 'terminate' ) {
 			callOfferCache.del(call.id)
 		}
 

--- a/src/Types/Call.ts
+++ b/src/Types/Call.ts
@@ -8,7 +8,6 @@ export type WACallEvent = {
 	groupJid?: string
 	id: string
 	date: Date
-	startedAt?: Date
 	isVideo?: boolean
 	status: WACallUpdateType
 	offline: boolean

--- a/src/Types/Call.ts
+++ b/src/Types/Call.ts
@@ -1,5 +1,5 @@
 
-export type WACallUpdateType = 'offer' | 'ringing' | 'timeout' | 'reject' | 'accept'
+export type WACallUpdateType = 'offer' | 'ringing' | 'timeout' | 'reject' | 'accept' | 'terminate'
 
 export type WACallEvent = {
 	chatId: string
@@ -8,6 +8,7 @@ export type WACallEvent = {
 	groupJid?: string
 	id: string
 	date: Date
+	startedAt?: Date
 	isVideo?: boolean
 	status: WACallUpdateType
 	offline: boolean

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -354,7 +354,7 @@ export const getErrorCodeFromStreamError = (node: BinaryNode) => {
 }
 
 export const getCallStatusFromNode = ({ tag, attrs }: BinaryNode) => {
-	let status: WACallUpdateType | undefined
+	let status: WACallUpdateType
 	switch (tag) {
 	case 'offer':
 	case 'offer_notice':

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -367,6 +367,7 @@ export const getCallStatusFromNode = ({ tag, attrs }: BinaryNode) => {
 			//fired when accepted/rejected/timeout/caller hangs up
 			status = 'terminate'
 		}
+
 		break
 	case 'reject':
 		status = 'reject'

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -354,7 +354,7 @@ export const getErrorCodeFromStreamError = (node: BinaryNode) => {
 }
 
 export const getCallStatusFromNode = ({ tag, attrs }: BinaryNode) => {
-	let status: WACallUpdateType
+	let status: WACallUpdateType | undefined
 	switch (tag) {
 	case 'offer':
 	case 'offer_notice':
@@ -364,9 +364,9 @@ export const getCallStatusFromNode = ({ tag, attrs }: BinaryNode) => {
 		if(attrs.reason === 'timeout') {
 			status = 'timeout'
 		} else {
+			//fired when accepted/rejected/timeout/caller hangs up
 			status = 'terminate'
 		}
-
 		break
 	case 'reject':
 		status = 'reject'

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -364,7 +364,7 @@ export const getCallStatusFromNode = ({ tag, attrs }: BinaryNode) => {
 		if(attrs.reason === 'timeout') {
 			status = 'timeout'
 		} else {
-			status = 'reject'
+			status = 'terminate'
 		}
 
 		break


### PR DESCRIPTION
- When a call is rejected, Baileys fires the `reject` event twice.

- When a call is accepted, Baileys fires both the `accept` and `reject` events, which is incorrect.

- When a call times out, Baileys fires the `reject` event, which is also incorrect

Terminate tag represents that whatsapp web dont have access to this call anymore, or is timed out or caller hung up, isn't rejected