### PR TITLE
fix: messaging-history.set event not emitting syncType and progress / add PDO request id

### DIFF
--- a/src/Types/Events.ts
+++ b/src/Types/Events.ts
@@ -23,6 +23,7 @@ export type BaileysEventMap = {
         isLatest?: boolean
         progress?: number | null
         syncType?: proto.HistorySync.HistorySyncType
+        peerDataRequestSessionId?: string
     }
     /** upsert chats */
     'chats.upsert': Chat[]
@@ -73,6 +74,9 @@ export type BufferedEventData = {
         messages: { [uqId: string]: WAMessage }
         empty: boolean
         isLatest: boolean
+        progress?: number | null
+        syncType?: proto.HistorySync.HistorySyncType
+        peerDataRequestSessionId?: string
     }
     chatUpserts: { [jid: string]: Chat }
     chatUpdates: { [jid: string]: ChatUpdate }

--- a/src/Types/Events.ts
+++ b/src/Types/Events.ts
@@ -23,7 +23,7 @@ export type BaileysEventMap = {
         isLatest?: boolean
         progress?: number | null
         syncType?: proto.HistorySync.HistorySyncType
-        peerDataRequestSessionId?: string
+        peerDataRequestSessionId?: string | null
     }
     /** upsert chats */
     'chats.upsert': Chat[]

--- a/src/Utils/event-buffer.ts
+++ b/src/Utils/event-buffer.ts
@@ -230,6 +230,9 @@ function append<E extends BufferableEvent>(
 		}
 
 		data.historySets.empty = false
+		data.historySets.syncType = eventData.syncType
+		data.historySets.progress = eventData.progress
+		data.historySets.peerDataRequestSessionId = eventData.peerDataRequestSessionId
 		data.historySets.isLatest = eventData.isLatest || data.historySets.isLatest
 
 		break
@@ -521,7 +524,10 @@ function consolidateEvents(data: BufferedEventData) {
 			chats: Object.values(data.historySets.chats),
 			messages: Object.values(data.historySets.messages),
 			contacts: Object.values(data.historySets.contacts),
-			isLatest: data.historySets.isLatest
+			syncType: data.historySets.syncType,
+			progress: data.historySets.progress,
+			isLatest: data.historySets.isLatest,
+			peerDataRequestSessionId: data.historySets.peerDataRequestSessionId
 		}
 	}
 

--- a/src/Utils/history.ts
+++ b/src/Utils/history.ts
@@ -95,7 +95,7 @@ export const processHistoryMessage = (item: proto.IHistorySync) => {
 		contacts,
 		messages,
 		syncType: item.syncType,
-		progress: item.progress,
+		progress: item.progress
 	}
 }
 

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -223,7 +223,8 @@ const processMessage = async(
 					isLatest:
 						histNotification.syncType !== proto.HistorySync.HistorySyncType.ON_DEMAND
 							? isLatest
-							: undefined
+							: undefined,
+					peerDataRequestSessionId: histNotification.peerDataRequestSessionId
 				})
 			}
 


### PR DESCRIPTION
The common `messaging-history.set` event when you have buffered events in progress is:

```typescript
{
        chats: []
        contacts: []
        messages: []
        isLatest?: boolean
}
```

This event is missing `syncType` and `progress`, and the PDO request id if you requested history.
The new event will be:

```typescript
{
        chats: []
        contacts: []
        messages: []
        isLatest?: boolean
        progress?: number
        syncType?: HistorySyncType
        peerDataRequestSessionId?: string | null
}
```