### PR TITLE
fix: update/remove profile picture

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -219,12 +219,12 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	}
 
 	/** update the profile picture for yourself or a group */
-	const updateProfilePicture = async(jid: string | undefined, content: WAMediaUpload) => {
+	const updateProfilePicture = async(jid: string, content: WAMediaUpload) => {
 		const { img } = await generateProfilePicture(content)
 		await query({
 			tag: 'iq',
 			attrs: {
-				target: jid,
+				target: jid!,
 				to: S_WHATSAPP_NET,
 				type: 'set',
 				xmlns: 'w:profile:picture'
@@ -240,11 +240,11 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	}
 
 	/** remove the profile picture for yourself or a group */
-	const removeProfilePicture = async(jid: string | undefined) => {
+	const removeProfilePicture = async(jid: string) => {
 		await query({
 			tag: 'iq',
 			attrs: {
-				target: jid,
+				target: jid!,
 				to: S_WHATSAPP_NET,
 				type: 'set',
 				xmlns: 'w:profile:picture'

--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -219,12 +219,13 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	}
 
 	/** update the profile picture for yourself or a group */
-	const updateProfilePicture = async(jid: string, content: WAMediaUpload) => {
+	const updateProfilePicture = async(jid: string | undefined, content: WAMediaUpload) => {
 		const { img } = await generateProfilePicture(content)
 		await query({
 			tag: 'iq',
 			attrs: {
-				to: jidNormalizedUser(jid),
+				target: jid,
+				to: S_WHATSAPP_NET,
 				type: 'set',
 				xmlns: 'w:profile:picture'
 			},
@@ -239,11 +240,12 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	}
 
 	/** remove the profile picture for yourself or a group */
-	const removeProfilePicture = async(jid: string) => {
+	const removeProfilePicture = async(jid: string | undefined) => {
 		await query({
 			tag: 'iq',
 			attrs: {
-				to: jidNormalizedUser(jid),
+				target: jid,
+				to: S_WHATSAPP_NET,
 				type: 'set',
 				xmlns: 'w:profile:picture'
 			}


### PR DESCRIPTION
Fix timeout error when tried to update/remove profile picture

```js
// empty jid for updating/removing our own profile picture
sock.removeProfilePicture(undefined)
sock.updateProfilePicture(undefined, content)

// or group jid for updating/removing group picture
sock.removeProfilePicture('xxx@g.us')
sock.updateProfilePicture('xxx@g.us', content)
```