### PR TITLE
fix: prevent TypeError when accessing 'cachedGroupMetadata' in sendMe…

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -793,7 +793,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 					} as BinaryNode)
 				}
 
-				if('cachedGroupMetadata' in options) {
+				if(options && typeof options === 'object' && 'cachedGroupMetadata' in options) {
 					console.warn('cachedGroupMetadata in sendMessage are deprecated, now cachedGroupMetadata is part of the socket config.')
 				}
 


### PR DESCRIPTION
This PR fixes a TypeError that occurred when trying to check for 'cachedGroupMetadata' in the 'sendMessage' function options.

The error was caused by attempting to use the 'in' operator on an undefined or null value. This fix adds a type check to ensure 'options' is an object before using the 'in' operator.

### Changes:
- Add a type check for 'options' to avoid errors when 'options' is undefined.

### Why:
- This prevents crashes and unexpected behavior when 'sendMessage' is called with invalid options.