### PR TITLE
feat: add last message in chat.update event if is real message

### DIFF
--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -169,6 +169,7 @@ const processMessage = async(
 	const isRealMsg = isRealMessage(message, meId)
 
 	if(isRealMsg) {
+		chat.messages = [{ message }]
 		chat.conversationTimestamp = toNumber(message.messageTimestamp)
 		// only increment unread count if not CIPHERTEXT and from another person
 		if(shouldIncrementChatUnread(message)) {


### PR DESCRIPTION
Currently the event `chats.update` dont receive the last message.
