### PR TITLE
fix: add registered when connect with qr too

### DIFF
--- a/src/Utils/validate-connection.ts
+++ b/src/Utils/validate-connection.ts
@@ -179,6 +179,7 @@ export const configureSuccessfulPairing = (
 			...(signalIdentities || []),
 			identity
 		],
+		registered: true,
 		platform: platformNode?.attrs.name
 	}
 


### PR DESCRIPTION
if you connect with qr code, registered key will be false
if you connect with pairing code, registered will be true

```sock.authState.creds.registered```

This fix set true if you connect with qr code too