### PR TITLE
FIX: Messages with IDs starting with 66 and 67

### DIFF
--- a/src/WABinary/encode.ts
+++ b/src/WABinary/encode.ts
@@ -189,8 +189,6 @@ const encodeBinaryNodeInner = (
 			pushByte(tokenIndex.index)
 		} else if(isNibble(str)) {
 			writePackedBytes(str, 'nibble')
-		} else if(isHex(str)) {
-			writePackedBytes(str, 'hex')
 		} else if(str) {
 			const decodedJid = jidDecode(str)
 			if(decodedJid) {
@@ -198,6 +196,8 @@ const encodeBinaryNodeInner = (
 			} else {
 				writeStringRaw(str)
 			}
+		} else if(isHex(str)) {
+			writePackedBytes(str, 'hex')
 		}
 	}
 


### PR DESCRIPTION
🇧🇷 🇧🇷 🇧🇷 🇧🇷 🇧🇷

# Pull Request: Fixing encodeBinaryNode in Whiskeysockets

## Problem Description

The `encodeBinaryNode` method in the Whiskeysockets library had a bug in the `writeString` function. The issue stemmed from an incorrect order of type checks, causing strings that should be encoded as text to be misinterpreted as hexadecimal.

### Problematic Behavior

The `isHex(str)` check in `writeString` occurred before decoding as a JID or falling back to `writeStringRaw(str)`. As a result, strings with hexadecimal-like characters were treated as hex values, producing malformed nodes.

This affected the `sendMessageAck` function, which generates and sends acknowledgment nodes. Malformed nodes were not recognized by recipients, resulting in infinite resends and message flow blockages.

Example received message triggering the bug:
```json
{
  "key": {
    "remoteJid": "5527996073228@s.whatsapp.net",
    "fromMe": false,
    "id": "679d1b73e54738f418353c1f"
  },
  "messageTimestamp": 1738349428,
  "pushName": "Adcol  Contabilidade",
  "message": {
    "conversation": "Prezado(a)\n...",
    "messageContextInfo": {
      "deviceListMetadataVersion": 2
    }
  }
}
```

Malformed ACK node sent:
```json
{
  "tag": "ack",
  "attrs": {
    "id": "679d1b73e54738f418353c1f",
    "to": "556182615929:5@s.whatsapp.net",
    "class": "receipt"
  }
}
```

---

## Solution Implemented

The `writeString` function was updated to ensure:
1. Tokens from `TOKEN_MAP` are prioritized.
2. Nibble-encoded strings are processed appropriately.
3. Strings are decoded as JIDs if possible.
4. Non-JIDs default to raw text encoding with `writeStringRaw`.
5. Hexadecimal packing is the final fallback.

Updated `writeString` implementation:
```js
const writeString = (str) => {
    const tokenIndex = TOKEN_MAP[str];
    if (tokenIndex) {
        if (typeof tokenIndex.dict === 'number') {
            pushByte(TAGS.DICTIONARY_0 + tokenIndex.dict);
        }
        pushByte(tokenIndex.index);
    }
    else if (isNibble(str)) {
        writePackedBytes(str, 'nibble');
    }
    else {
        const decodedJid = (0, jid_utils_1.jidDecode)(str);
        if (decodedJid) {
            writeJid(decodedJid);
        }
        else {
            writeStringRaw(str);
        }
    }
};
```

### Benefits
- Correctly encodes strings resembling hexadecimal values but acting as identifiers.
- Resolves malformed nodes in `sendMessageAck`.
- Eliminates infinite ACK resend loops.

## Tests Performed

Tests included:
1. IDs starting with `66` and `67`.

All tests confirmed correct ACK formatting and server acceptance without retries.

## Conclusion

This PR resolves a critical encoding issue in `encodeBinaryNode`, ensuring reliable and efficient message handling. It eliminates malformed ACK nodes and improves library stability and communication performance.


THANKS to Renato (https://github.com/renatoiub) for providing me with numbers that send this type of message for testing.
