### PR TITLE
fix(groups): update group size extraction

### DIFF
--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -334,6 +334,7 @@ export const extractGroupMetadata = (result: BinaryNode) => {
 		descId = descChild.attrs.id
 	}
 
+	const groupSize = group.attrs.size ? Number(group.attrs.size) : undefined
 	const groupId = group.attrs.id.includes('@') ? group.attrs.id : jidEncode(group.attrs.id, 'g.us')
 	const eph = getBinaryNodeChild(group, 'ephemeral')?.attrs.expiration
 	const memberAddMode = getBinaryNodeChildString(group, 'member_add_mode') === 'all_member_add'
@@ -342,7 +343,7 @@ export const extractGroupMetadata = (result: BinaryNode) => {
 		subject: group.attrs.subject,
 		subjectOwner: group.attrs.s_o,
 		subjectTime: +group.attrs.s_t,
-		size: getBinaryNodeChildren(group, 'participant').length,
+		size: groupSize || getBinaryNodeChildren(group, 'participant').length,
 		creation: +group.attrs.creation,
 		owner: group.attrs.creator ? jidNormalizedUser(group.attrs.creator) : undefined,
 		desc,


### PR DESCRIPTION
This pull request includes updates to the `extractGroupMetadata` function in the `src/Socket/groups.ts` file to improve the extraction of group metadata. The most important changes include the addition of a new `groupSize` variable and its integration into the group size calculation.

Improvements to group metadata extraction:

* [`src/Socket/groups.ts`](diffhunk://#diff-b9f9dc430959ba914716817f210fa83198d2a70e6be1c33a23d41a633ed17826R337): Added a new variable `groupSize` to extract the group size from `group.attrs.size`, defaulting to `undefined` if not present.
* [`src/Socket/groups.ts`](diffhunk://#diff-b9f9dc430959ba914716817f210fa83198d2a70e6be1c33a23d41a633ed17826L345-R346): Updated the `size` property to use the new `groupSize` variable if available, otherwise falling back to the length of `getBinaryNodeChildren(group, 'participant')`.

This update addresses the issue of retrieving group information through [`groupGetInviteInfo`](https://github.com/WhiskeySockets/Baileys/blob/master/src/Socket/groups.ts#L303), which only provides the group admin in the `participants` properties.