### PR TITLE
feat: add Id support for desktop

### DIFF
--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -728,11 +728,11 @@ export const extractMessageContent = (content: WAMessageContent | undefined | nu
  * Returns the device predicted by message ID
  */
 export const getDevice = (id: string) =>
-	/^3A.{18}$/.test(id) ? 'ios' :
-	/^3E.{20}$/.test(id) ? 'web' :
-	/^(.{21}|.{32})$/.test(id) ? 'android' :
-	/^3F/.test(id) ? 'desktop' :
-	/^.{18}$/.test(id) ? 'desktop' : 'unknown'  
+    /^3A.{18}$/.test(id) ? 'ios' :
+    /^3E.{20}$/.test(id) ? 'web' :
+    /^(.{21}|.{32})$/.test(id) ? 'android' :
+    /^(3F|.{18}$)/.test(id) ? 'desktop' : 
+    'unknown'
 
 /** Upserts a receipt in the message */
 export const updateMessageWithReceipt = (msg: Pick<WAMessage, 'userReceipt'>, receipt: MessageUserReceipt) => {

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -727,7 +727,12 @@ export const extractMessageContent = (content: WAMessageContent | undefined | nu
 /**
  * Returns the device predicted by message ID
  */
-export const getDevice = (id: string) => /^3A.{18}$/.test(id) ? 'ios' : /^3E.{20}$/.test(id) ? 'web' : /^(.{21}|.{32})$/.test(id) ? 'android' : /^.{18}$/.test(id) ? 'desktop' : 'unknown'
+export const getDevice = (id: string) =>
+	/^3A.{18}$/.test(id) ? 'ios' :
+	/^3E.{20}$/.test(id) ? 'web' :
+	/^(.{21}|.{32})$/.test(id) ? 'android' :
+	/^3F/.test(id) ? 'desktop' :
+	/^.{18}$/.test(id) ? 'desktop' : 'unknown'  
 
 /** Upserts a receipt in the message */
 export const updateMessageWithReceipt = (msg: Pick<WAMessage, 'userReceipt'>, receipt: MessageUserReceipt) => {

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -727,12 +727,11 @@ export const extractMessageContent = (content: WAMessageContent | undefined | nu
 /**
  * Returns the device predicted by message ID
  */
-export const getDevice = (id: string) =>
-    /^3A.{18}$/.test(id) ? 'ios' :
-    /^3E.{20}$/.test(id) ? 'web' :
-    /^(.{21}|.{32})$/.test(id) ? 'android' :
-    /^(3F|.{18}$)/.test(id) ? 'desktop' : 
-    'unknown'
+export const getDevice = (id: string) => /^3A.{18}$/.test(id) ? 'ios' :
+	/^3E.{20}$/.test(id) ? 'web' :
+		/^(.{21}|.{32})$/.test(id) ? 'android' :
+			/^(3F|.{18}$)/.test(id) ? 'desktop' :
+				'unknown'
 
 /** Upserts a receipt in the message */
 export const updateMessageWithReceipt = (msg: Pick<WAMessage, 'userReceipt'>, receipt: MessageUserReceipt) => {


### PR DESCRIPTION
This commit adjusts the ID length check for desktop, fixing the issue where some desktop IDs were incorrectly classified as "unknown."

Baileys stopped identifying if a message was from WA Desktop (Based on my observations last Year).

This adjustment addresses this issue.

**Usage:**
```javascript
import { getDevice } from 'baileys'

console.log(getDevice('3FBBHEUFEUVUF783B839FB8F3')) // Test
```

**Result:**
```bash
desktop
```