### PR TITLE
Change the example of chatModify

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,15 +824,7 @@ await sock.chatModify({ markRead: false, lastMessages: [lastMsgInChat] }, jid)
 ```ts
 await sock.chatModify(
     {
-        clear: {
-            messages: [
-                {
-                    id: 'ATWYHDNNWU81732J',
-                    fromMe: true, 
-                    timestamp: '1654823909'
-                }
-            ]
-        }
+        clear: true
     }, 
     jid
 )


### PR DESCRIPTION
The current example of chatModify doesn't reflect it's current typing and functionality.
Updated it to reflect it's new syntax.