### PR TITLE
chore: ignore pack .proto files in production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib/*",
-    "WAProto/*",
+    "WAProto/*.ts",
+    "WAProto/*.js",
     "WASignalGroup/*.js",
     "engine-requirements.js"
   ],


### PR DESCRIPTION
The WAProto.proto file is not used in production, so we can save about ~135kb ignoring him