### PR TITLE
fix: failed to send message to self, add checks for empty strings and invalid nodes

### DIFF
--- a/src/WABinary/encode.ts
+++ b/src/WABinary/encode.ts
@@ -150,6 +150,10 @@ const encodeBinaryNodeInner = (
 	}
 
 	const isNibble = (str: string) => {
+		if(!str) {
+			return false
+		}
+
 		if(str.length > TAGS.PACKED_MAX) {
 			return false
 		}
@@ -165,6 +169,10 @@ const encodeBinaryNodeInner = (
 	}
 
 	const isHex = (str: string) => {
+		if(!str) {
+			return false
+		}
+
 		if(str.length > TAGS.PACKED_MAX) {
 			return false
 		}
@@ -180,6 +188,11 @@ const encodeBinaryNodeInner = (
 	}
 
 	const writeString = (str: string) => {
+		if(str === undefined || str === null) {
+			pushByte(TAGS.LIST_EMPTY)
+			return
+		}
+
 		const tokenIndex = TOKEN_MAP[str]
 		if(tokenIndex) {
 			if(typeof tokenIndex.dict === 'number') {
@@ -212,7 +225,11 @@ const encodeBinaryNodeInner = (
 		}
 	}
 
-	const validAttributes = Object.keys(attrs).filter(k => (
+	if(!tag) {
+		throw new Error('Invalid node: tag cannot be undefined')
+	}
+
+	const validAttributes = Object.keys(attrs || {}).filter(k => (
 		typeof attrs[k] !== 'undefined' && attrs[k] !== null
 	))
 
@@ -232,8 +249,10 @@ const encodeBinaryNodeInner = (
 		writeByteLength(content.length)
 		pushBytes(content)
 	} else if(Array.isArray(content)) {
-		writeListStart(content.length)
-		for(const item of content) {
+		const validContent = content.filter(item => item && (item.tag || Buffer.isBuffer(item) || item instanceof Uint8Array || typeof item === 'string')
+		)
+		writeListStart(validContent.length)
+		for(const item of validContent) {
 			encodeBinaryNodeInner(item, opts, buffer)
 		}
 	} else if(typeof content === 'undefined') {

--- a/src/WABinary/encode.ts
+++ b/src/WABinary/encode.ts
@@ -149,12 +149,8 @@ const encodeBinaryNodeInner = (
 		}
 	}
 
-	const isNibble = (str: string) => {
-		if(!str) {
-			return false
-		}
-
-		if(str.length > TAGS.PACKED_MAX) {
+	const isNibble = (str?: string) => {
+		if(!str || str.length > TAGS.PACKED_MAX) {
 			return false
 		}
 
@@ -168,12 +164,8 @@ const encodeBinaryNodeInner = (
 		return true
 	}
 
-	const isHex = (str: string) => {
-		if(!str) {
-			return false
-		}
-
-		if(str.length > TAGS.PACKED_MAX) {
+	const isHex = (str?: string) => {
+		if(!str || str.length > TAGS.PACKED_MAX) {
 			return false
 		}
 
@@ -187,7 +179,7 @@ const encodeBinaryNodeInner = (
 		return true
 	}
 
-	const writeString = (str: string) => {
+	const writeString = (str?: string) => {
 		if(str === undefined || str === null) {
 			pushByte(TAGS.LIST_EMPTY)
 			return


### PR DESCRIPTION
This fix previne an error when you try to send message to yourself.
The only thing i changed is validate the node content early, before process.
The error throwed is:
```
/home/jlucaso/projects/Baileys2/src/WABinary/encode.ts:229
                throw new Error('Invalid node: tag cannot be undefined')
        ^
Error: Invalid node: tag cannot be undefined
    at encodeBinaryNodeInner (/home/jlucaso/projects/Baileys2/src/WABinary/encode.ts:229:9)
    at encodeBinaryNodeInner (/home/jlucaso/projects/Baileys2/src/WABinary/encode.ts:254:4)
    at encodeBinaryNodeInner (/home/jlucaso/projects/Baileys2/src/WABinary/encode.ts:254:4)
    at encodeBinaryNode (/home/jlucaso/projects/Baileys2/src/WABinary/encode.ts:11:18)
    at sendNode (/home/jlucaso/projects/Baileys2/src/Socket/socket.ts:138:32)
    at /home/jlucaso/projects/Baileys2/src/Socket/messages-send.ts:569:11
    at async Object.transaction (/home/jlucaso/projects/Baileys2/src/Utils/auth-utils.ts:153:14)
    at async relayMessage (/home/jlucaso/projects/Baileys2/src/Socket/messages-send.ts:370:3)
    at async Object.sendMessage (/home/jlucaso/projects/Baileys2/src/Socket/messages-send.ts:796:5)
    at async sendMessageWTyping (/home/jlucaso/projects/Baileys2/Example/example.ts:65:3)
```

fix https://github.com/WhiskeySockets/Baileys/issues/1314
fix https://github.com/WhiskeySockets/Baileys/issues/1326