### PR TITLE
fix: makeCacheableSignalKeyStore logger optional

### DIFF
--- a/src/Utils/auth-utils.ts
+++ b/src/Utils/auth-utils.ts
@@ -14,7 +14,7 @@ import { ILogger } from './logger'
  */
 export function makeCacheableSignalKeyStore(
 	store: SignalKeyStore,
-	logger: ILogger,
+	logger?: ILogger,
 	_cache?: CacheStore
 ): SignalKeyStore {
 	const cache = _cache || new NodeCache({
@@ -41,7 +41,7 @@ export function makeCacheableSignalKeyStore(
 			}
 
 			if(idsToFetch.length) {
-				logger.trace({ items: idsToFetch.length }, 'loading from store')
+				logger?.trace({ items: idsToFetch.length }, 'loading from store')
 				const fetched = await store.get(type, idsToFetch)
 				for(const id of idsToFetch) {
 					const item = fetched[id]
@@ -63,7 +63,7 @@ export function makeCacheableSignalKeyStore(
 				}
 			}
 
-			logger.trace({ keys }, 'updated cache')
+			logger?.trace({ keys }, 'updated cache')
 
 			await store.set(data)
 		},


### PR DESCRIPTION
Not everyone like me wants to log what our keystore is doing