### PR TITLE
fix: readAdJid domainType

### DIFF
--- a/src/WABinary/decode.ts
+++ b/src/WABinary/decode.ts
@@ -1,9 +1,9 @@
 import { promisify } from 'util'
 import { inflate } from 'zlib'
+import logger from '../Utils/logger'
 import * as constants from './constants'
 import { jidEncode } from './jid-utils'
 import type { BinaryNode, BinaryNodeCodingOptions } from './types'
-import logger from '../Utils/logger'
 
 const inflatePromise = promisify(inflate)
 

--- a/src/WABinary/decode.ts
+++ b/src/WABinary/decode.ts
@@ -149,10 +149,7 @@ export const decodeDecompressedBinaryNode = (
 
 	const readAdJid = () => {
 		const rawDomainType = readByte()
-		const domainType = typeof rawDomainType === 'number'
-		  ? rawDomainType
-		  : Number(rawDomainType)
-
+		const domainType = Number(rawDomainType)
 
 		const device = readByte()
 		const user = readString(readByte())


### PR DESCRIPTION
jid = 0 and 128
lid = 1 and 129

![image](https://github.com/user-attachments/assets/48e5635c-4f6d-4b5c-a61b-a70d5f54ecf3)


Participants involved in the analysis of the problem. @canove @viniciusgdr 

This commit solves the problem that when the domain type is different from 0 it is also a jid