### PR TITLE
fix: proper send receipt to Meta Ia

### DIFF
--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -48,13 +48,13 @@ export function decodeMessageNode(
 	const isMeLid = (jid: string) => areJidsSameUser(jid, meLid)
 
 	if(isJidUser(from) || isLidUser(from)) {
-    if (recipient && !isJidMetaIa(recipient)) {
+		if(recipient && !isJidMetaIa(recipient)) {
 			if(!isMe(from) && !isMeLid(from)) {
 				throw new Boom('receipient present, but msg not from me', { data: stanza })
 			}
 
 			chatId = recipient
-    } else {
+		} else {
 			chatId = from
 		}
 
@@ -109,8 +109,8 @@ export function decodeMessageNode(
 
 	if(key.fromMe) {
 		fullMessage.status = proto.WebMessageInfo.Status.SERVER_ACK
-  }
-  
+	}
+
 	return {
 		fullMessage,
 		author,
@@ -170,7 +170,7 @@ export const decryptMessageNode = (
 								type: e2eType,
 								ciphertext: content
 							})
-                break
+							break
 						case 'plaintext':
 							msgBuffer = content
 							break
@@ -196,7 +196,7 @@ export const decryptMessageNode = (
 							Object.assign(fullMessage.message, msg)
 						} else {
 							fullMessage.message = msg
-            }
+						}
 					} catch(err) {
 						logger.error(
 							{ key: fullMessage.key, err },

--- a/src/WABinary/jid-utils.ts
+++ b/src/WABinary/jid-utils.ts
@@ -46,6 +46,8 @@ export const jidDecode = (jid: string | undefined): FullJid | undefined => {
 export const areJidsSameUser = (jid1: string | undefined, jid2: string | undefined) => (
 	jidDecode(jid1)?.user === jidDecode(jid2)?.user
 )
+/** is the jid Meta IA */
+export const isJidMetaIa = (jid: string | undefined) => (jid?.endsWith('@bot'))
 /** is the jid a user */
 export const isJidUser = (jid: string | undefined) => (jid?.endsWith('@s.whatsapp.net'))
 /** is the jid a group */


### PR DESCRIPTION
It fix socket hanging (stop receiving events) due to multiple offline pending notifications.

To test:
- Set log level to "info"
- Connect a normal Whatsapp account (not business)
- Send a few messages on the Meta IA chat
- Restart the socket and take a look on `handled 4 offline messages/notifications`. This number will increase for each message you send on the Meta Ia Chat
- Do the same test on this branch, it should have no offline notifications pending anymore.