### PR TITLE
fix: send message to LID addressing_mode groups

### DIFF
--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -339,6 +339,7 @@ export const extractGroupMetadata = (result: BinaryNode) => {
 	const memberAddMode = getBinaryNodeChildString(group, 'member_add_mode') === 'all_member_add'
 	const metadata: GroupMetadata = {
 		id: groupId,
+		addressingMode: group.attrs.addressing_mode,
 		subject: group.attrs.subject,
 		subjectOwner: group.attrs.s_o,
 		subjectTime: +group.attrs.s_t,

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -406,6 +406,13 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 							participantsList.push(...statusJidList)
 						}
 
+						if(!isStatus) {
+							additionalAttributes = {
+								...additionalAttributes,
+								addressing_mode: groupData?.addressingMode || 'pn'
+							}
+						}
+
 						const additionalDevices = await getUSyncDevices(participantsList, !!useUserDevicesCache, false)
 						devices.push(...additionalDevices)
 					}
@@ -429,7 +436,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 					const senderKeyJids: string[] = []
 					// ensure a connection is established with every device
 					for(const { user, device } of devices) {
-						const jid = jidEncode(user, isLid ? 'lid' : 's.whatsapp.net', device)
+						const jid = jidEncode(user, groupData?.addressingMode ? 'lid' : 's.whatsapp.net', device)
 						if(!senderKeyMap[jid] || !!participant) {
 							senderKeyJids.push(jid)
 							// store that this person has had the sender keys sent to them

--- a/src/Types/GroupMetadata.ts
+++ b/src/Types/GroupMetadata.ts
@@ -10,6 +10,8 @@ export type RequestJoinMethod = 'invite_link' | 'linked_group_join' | 'non_admin
 
 export interface GroupMetadata {
     id: string
+    /** group uses 'lid' or 'pn' to send messages */
+    addressingMode: string
     owner: string | undefined
     subject: string
     /** group subject owner */


### PR DESCRIPTION
It allows sending message to groups that now have a `addressing_mode` set to `lid`.