### PR TITLE
Fix catch unhandled timeout error

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -187,7 +187,7 @@ export const makeSocket = (config: SocketConfig) => {
 		let onRecv: (json) => void
 		let onErr: (err) => void
 		try {
-			return await promiseTimeout<T>(timeoutMs,
+			const result = await promiseTimeout<T>(timeoutMs,
 				(resolve, reject) => {
 					onRecv = resolve
 					onErr = err => {
@@ -199,6 +199,8 @@ export const makeSocket = (config: SocketConfig) => {
 					ws.off('error', onErr)
 				},
 			)
+
+			return result as any
 		} finally {
 			ws.off(`TAG:${msgId}`, onRecv!)
 			ws.off('close', onErr!) // if the socket closes, you'll never receive the message
@@ -213,11 +215,13 @@ export const makeSocket = (config: SocketConfig) => {
 		}
 
 		const msgId = node.attrs.id
-		const wait = waitForMessage(msgId, timeoutMs)
 
-		await sendNode(node)
+		const [result] = await Promise.all([
+			waitForMessage(msgId, timeoutMs),
+			await sendNode(node)
+		])
 
-		const result = await (wait as Promise<BinaryNode>)
+
 		if('tag' in result) {
 			assertNodeErrorFree(result)
 		}

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -221,7 +221,6 @@ export const makeSocket = (config: SocketConfig) => {
 			await sendNode(node)
 		])
 
-
 		if('tag' in result) {
 			assertNodeErrorFree(result)
 		}

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -218,7 +218,7 @@ export const makeSocket = (config: SocketConfig) => {
 
 		const [result] = await Promise.all([
 			waitForMessage(msgId, timeoutMs),
-			await sendNode(node)
+			sendNode(node)
 		])
 
 		if('tag' in result) {


### PR DESCRIPTION
This avoid `unhandledRejection` errors due to timeout.

To test it:

- Turn your computer internet off
- Start baileys
- Send a message through baileys
- You will get an "Connection closed" handled error
- A 60 seconds later (defaultQueryTimeoutMs) you will get an unhandled Time out error and the process will die.
- Try the same with this branch, the Timeout error should never show up and the processing should keep running.

Address:
https://github.com/WhiskeySockets/Baileys/issues/1269
https://github.com/WhiskeySockets/Baileys/issues/1136
https://github.com/WhiskeySockets/Baileys/issues/1078
https://github.com/WhiskeySockets/Baileys/issues/573
https://github.com/WhiskeySockets/Baileys/issues/567
https://github.com/WhiskeySockets/Baileys/issues/34
#1363 