### PR TITLE
Fix Removed Reactions Events: Emit a Socket Event in "messages.reaction"

### DIFF
--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -747,13 +747,10 @@ export const updateMessageWithReceipt = (msg: Pick<WAMessage, 'userReceipt'>, re
 /** Update the message with a new reaction */
 export const updateMessageWithReaction = (msg: Pick<WAMessage, 'reactions'>, reaction: proto.IReaction) => {
 	const authorID = getKeyAuthor(reaction.key)
-
 	const reactions = (msg.reactions || [])
-		.filter(r => getKeyAuthor(r.key) !== authorID)
-	if(reaction.text) {
-		reactions.push(reaction)
-	}
-
+		.filter(r => getKeyAuthor(r.key) !== authorID)	
+	reaction.text = reaction.text || ""
+	reactions.push(reaction)
 	msg.reactions = reactions
 }
 


### PR DESCRIPTION
The changes I've made basically emit a socket event even when reaction.text is empty. However, before pushing it into the array, it assigns an empty string to maintain JSON consistency instead of pushing without the text key.

The new expected behavior is:

Empty Reaction received -> filter the array excluding the author reaction (if it exists) -> create a new entry with reaction.text as an empty string to keep the JSON consistency.