### PR TITLE
FIX: crypo subtle not working on older nodejs version

### DIFF
--- a/src/Utils/crypto.ts
+++ b/src/Utils/crypto.ts
@@ -1,10 +1,10 @@
-import { createCipheriv, createDecipheriv, createHash, createHmac, randomBytes, webcrypto } from 'crypto'
+import { createCipheriv, createDecipheriv, createHash, createHmac, randomBytes } from 'crypto'
 import * as libsignal from 'libsignal'
 import { KEY_BUNDLE_TYPE } from '../Defaults'
 import { KeyPair } from '../Types'
 
 // insure browser & node compatibility
-const subtle = globalThis?.crypto?.subtle || webcrypto?.subtle;
+const subtle  = globalThis.crypto?.subtle || crypto.subtle;
 
 /** prefix version byte to the pub keys, required for some curve crypto functions */
 export const generateSignalPubKey = (pubKey: Uint8Array | Buffer) => (

--- a/src/Utils/crypto.ts
+++ b/src/Utils/crypto.ts
@@ -4,11 +4,7 @@ import { KEY_BUNDLE_TYPE } from '../Defaults'
 import { KeyPair } from '../Types'
 
 // insure browser & node compatibility
-if (typeof globalThis.crypto === 'undefined') {
-    globalThis.crypto = webcrypto;
-}
-
-const { subtle } = globalThis.crypto
+const subtle = globalThis?.crypto?.subtle || webcrypto?.subtle;
 
 /** prefix version byte to the pub keys, required for some curve crypto functions */
 export const generateSignalPubKey = (pubKey: Uint8Array | Buffer) => (

--- a/src/Utils/crypto.ts
+++ b/src/Utils/crypto.ts
@@ -1,9 +1,13 @@
-import { createCipheriv, createDecipheriv, createHash, createHmac, randomBytes } from 'crypto'
+import { createCipheriv, createDecipheriv, createHash, createHmac, randomBytes, webcrypto } from 'crypto'
 import * as libsignal from 'libsignal'
 import { KEY_BUNDLE_TYPE } from '../Defaults'
 import { KeyPair } from '../Types'
 
 // insure browser & node compatibility
+if (typeof globalThis.crypto === 'undefined') {
+    globalThis.crypto = webcrypto;
+}
+
 const { subtle } = globalThis.crypto
 
 /** prefix version byte to the pub keys, required for some curve crypto functions */

--- a/src/Utils/crypto.ts
+++ b/src/Utils/crypto.ts
@@ -3,8 +3,7 @@ import * as libsignal from 'libsignal'
 import { KEY_BUNDLE_TYPE } from '../Defaults'
 import { KeyPair } from '../Types'
 
-// insure browser & node compatibility
-const subtle  = globalThis.crypto?.subtle || crypto.subtle;
+let globalSubtle  = globalThis.crypto?.subtle;
 
 /** prefix version byte to the pub keys, required for some curve crypto functions */
 export const generateSignalPubKey = (pubKey: Uint8Array | Buffer) => (
@@ -129,6 +128,7 @@ export async function hkdf(
 	expandedLength: number,
 	info: { salt?: Buffer, info?: string }
 ): Promise<Buffer> {
+    const subtle = globalSubtle || globalThis.crypto?.subtle;
 	// Ensure we have a Uint8Array for the key material
 	const inputKeyMaterial = buffer instanceof Uint8Array
 		? buffer
@@ -167,6 +167,7 @@ export async function hkdf(
 
 export async function derivePairingCodeKey(pairingCode: string, salt: Buffer): Promise<Buffer> {
 	// Convert inputs to formats Web Crypto API can work with
+    const subtle = globalSubtle || globalThis.crypto?.subtle;
 	const encoder = new TextEncoder()
 	const pairingCodeBuffer = encoder.encode(pairingCode)
 	const saltBuffer = salt instanceof Uint8Array ? salt : new Uint8Array(salt)

--- a/src/Utils/crypto.ts
+++ b/src/Utils/crypto.ts
@@ -128,7 +128,7 @@ export async function hkdf(
 	expandedLength: number,
 	info: { salt?: Buffer, info?: string }
 ): Promise<Buffer> {
-    const subtle = globalSubtle || globalThis.crypto?.subtle;
+    const subtle = globalSubtle || crypto?.subtle;
 	// Ensure we have a Uint8Array for the key material
 	const inputKeyMaterial = buffer instanceof Uint8Array
 		? buffer
@@ -167,7 +167,7 @@ export async function hkdf(
 
 export async function derivePairingCodeKey(pairingCode: string, salt: Buffer): Promise<Buffer> {
 	// Convert inputs to formats Web Crypto API can work with
-    const subtle = globalSubtle || globalThis.crypto?.subtle;
+    const subtle = globalSubtle || crypto?.subtle;
 	const encoder = new TextEncoder()
 	const pairingCodeBuffer = encoder.encode(pairingCode)
 	const saltBuffer = salt instanceof Uint8Array ? salt : new Uint8Array(salt)


### PR DESCRIPTION
On operating systems where it's not possible to update node to v20 it is required to have a crypto fix like this