### PR TITLE
fix: Handle data: URIs in getStream to prevent server crash

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -271,7 +271,14 @@ export const getStream = async (item: WAMediaUpload, opts?: AxiosRequestConfig) 
 		return { stream: item.stream, type: 'readable' } as const
 	}
 
-	if (item.url.toString().startsWith('http://') || item.url.toString().startsWith('https://')) {
+	const urlStr = item.url.toString()
+
+	if (urlStr.startsWith('data:')) {
+		const buffer = Buffer.from(urlStr.split(',')[1], 'base64')
+		return { stream: toReadable(buffer), type: 'buffer' } as const
+	}
+
+	if (urlStr.startsWith('http://') || urlStr.startsWith('https://')) {
 		return { stream: await getHttpStream(item.url, opts), type: 'remote' } as const
 	}
 


### PR DESCRIPTION
The `getStream` utility in `messages-media.ts` did not correctly handle `data:` URIs. When a link preview was generated for a URL whose thumbnail was a `data:` URI, the `getStream` function would incorrectly treat the URI string as a local file path.

This led to an unhandled exception (`ENAMETOOLONG` or `ENOENT`) in `fs.createReadStream`, causing the entire server process to crash.

fix #1486