### PR TITLE
Use parseFile for audio file paths instead of converting to stream

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -184,17 +184,15 @@ export const mediaMessageSHA256B64 = (message: WAMessageContent) => {
 export async function getAudioDuration(buffer: Buffer | string | Readable) {
 	const musicMetadata = await import('music-metadata')
 	let metadata: IAudioMetadata
+	const options = {
+		duration: true
+	}
 	if (Buffer.isBuffer(buffer)) {
-		metadata = await musicMetadata.parseBuffer(buffer, undefined, { duration: true })
+		metadata = await musicMetadata.parseBuffer(buffer, undefined, options)
 	} else if (typeof buffer === 'string') {
-		const rStream = createReadStream(buffer)
-		try {
-			metadata = await musicMetadata.parseStream(rStream, undefined, { duration: true })
-		} finally {
-			rStream.destroy()
-		}
+		metadata = await musicMetadata.parseFile(buffer, options)
 	} else {
-		metadata = await musicMetadata.parseStream(buffer, undefined, { duration: true })
+		metadata = await musicMetadata.parseStream(buffer, undefined, options)
 	}
 
 	return metadata.format.duration


### PR DESCRIPTION
When extracting duration from an audio file provided as a file path, use [music-metadata](https://github.com/Borewit/music-metadata)'s parseFile method instead of manually creating a read stream and using parseStream.

parseFile utilizes random access, which can significantly improve performance over streaming in many cases. However, actual speed gains depend on the file format and the structure of tag headers.