### PR TITLE
Added message range to the clear chat action

### DIFF
--- a/src/Types/Chat.ts
+++ b/src/Types/Chat.ts
@@ -94,6 +94,7 @@ export type ChatModification =
 	  }
 	| {
 			clear: boolean
+			lastMessages: LastMessageList
 	  }
 	| {
 			deleteForMe: { deleteMedia: boolean; key: WAMessageKey; timestamp: number }

--- a/src/Utils/chat-utils.ts
+++ b/src/Utils/chat-utils.ts
@@ -582,9 +582,12 @@ export const chatModificationToAppPatch = (mod: ChatModification, jid: string) =
 			operation: OP.SET
 		}
 	} else if ('clear' in mod) {
+		
 		patch = {
 			syncAction: {
-				clearChatAction: {} // add message range later
+				clearChatAction: {
+					messageRange: getMessageRange(mod.lastMessages)
+				}
 			},
 			index: ['clearChat', jid, '1' /*the option here is 0 when keep starred messages is enabled*/, '0'],
 			type: 'regular_high',

--- a/src/Utils/chat-utils.ts
+++ b/src/Utils/chat-utils.ts
@@ -582,7 +582,6 @@ export const chatModificationToAppPatch = (mod: ChatModification, jid: string) =
 			operation: OP.SET
 		}
 	} else if ('clear' in mod) {
-		
 		patch = {
 			syncAction: {
 				clearChatAction: {


### PR DESCRIPTION
Add the message range to the clear chat action to allow the action to be made without error (you can't clear the chat without this range)