### PR TITLE
fix: connection error when add @ at start of your name

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -588,7 +588,7 @@ export const makeChatsSocket = (config: SocketConfig) => {
 			await sendNode({
 				tag: 'presence',
 				attrs: {
-					name: me.name,
+					name: me.name.replace(/@/g, ''),
 					type
 				}
 			})


### PR DESCRIPTION
**How to Reproduce**
Add @ at start of your whatsapp name, you will get this error: `xml-not-well-formed`. And you cannot reconnect again until you remove the @