### PR TITLE
fix: remove buffering logic for missing myAppStateKeyId on connection…

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -1034,17 +1034,6 @@ export const makeChatsSocket = (config: SocketConfig) => {
 				onUnexpectedError(error, 'presence update requests')
 			)
 		}
-
-		if (
-			receivedPendingNotifications && // if we don't have the app state key
-			// we keep buffering events until we finally have
-			// the key and can sync the messages
-			// todo scrutinize
-			!authState.creds?.myAppStateKeyId
-		) {
-			ev.buffer()
-			needToFlushWithAppStateSync = true
-		}
 	})
 
 	return {


### PR DESCRIPTION
… update

The 'myAppStateKeyId' credential no longer exists in the current authState structure. This commit removes outdated buffering logic that was preventing events like 'chats.update' from being emitted due to an unflushed event buffer.