### PR TITLE
Fix spelling error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use at your own discretion. Do not spam people with this. We discourage any stal
 ##
 
 - Baileys does not require Selenium or any other browser to be interface with WhatsApp Web, it does so directly using a **WebSocket**. 
-- Not running Selenium or Chromimum saves you like **half a gig** of ram :/ 
+- Not running Selenium or Chromium saves you like **half a gig** of ram :/ 
 - Baileys supports interacting with the multi-device & web versions of WhatsApp.
 - Thank you to [@pokearaujo](https://github.com/pokearaujo/multidevice) for writing his observations on the workings of WhatsApp Multi-Device. Also, thank you to [@Sigalor](https://github.com/sigalor/whatsapp-web-reveng) for writing his observations on the workings of WhatsApp Web and thanks to [@Rhymen](https://github.com/Rhymen/go-whatsapp/) for the __go__ implementation.
 


### PR DESCRIPTION
## Description
This PR fixes a spelling error found in the README.md file to improve documentation quality and readability.

## Changes Made
- **Line 31**: Fixed "Chromimum" to "Chromium" 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [ ] New feature
- [ ] Breaking change

## Testing
- [x] Verified spelling correction is accurate
- [x] Confirmed no other instances of this typo exist in the file
- [x] Checked that the change doesn't affect any functionality

## Additional Context
This is a minor documentation improvement that enhances the professional appearance of the project documentation. "Chromium" is the correct spelling for the open-source browser project.

## Additional Note
This is my first contribution to this project, but I wanted to make a small contribution by fixing this typo to help improve the project. 😊