### PR TITLE
Add restart method to socket client classes

### DIFF
--- a/src/Socket/Client/types.ts
+++ b/src/Socket/Client/types.ts
@@ -18,5 +18,6 @@ export abstract class AbstractSocketClient extends EventEmitter {
 
 	abstract connect(): Promise<void>
 	abstract close(): Promise<void>
+	abstract restart(): Promise<void>
 	abstract send(str: Uint8Array | string, cb?: (err?: Error) => void): boolean
 }

--- a/src/Socket/Client/websocket.ts
+++ b/src/Socket/Client/websocket.ts
@@ -48,6 +48,19 @@ export class WebSocketClient extends AbstractSocketClient {
 		this.socket.close()
 		this.socket = null
 	}
+
+	async restart(): Promise<void> {
+		if (this.socket) {
+			await new Promise(resolve => {
+				this.socket!.once('close', resolve)
+				this.socket!.terminate()
+			})
+			this.socket = null
+		}
+
+		await this.connect()
+	}
+
 	send(str: string | Uint8Array, cb?: (err?: Error) => void): boolean {
 		this.socket?.send(str, cb)
 


### PR DESCRIPTION
Introduces a restart() method to Socket. The restart method closes the existing socket connection and reconnects, providing a way to restart only the client connection without restarting the whole process.