### PR TITLE
fix: handle potential null values when creating Buffers from signing keys

### DIFF
--- a/src/Signal/Group/sender-key-state.ts
+++ b/src/Signal/Group/sender-key-state.ts
@@ -98,7 +98,7 @@ export class SenderKeyState {
 			return Buffer.from(publicKey, 'base64')
 		}
 
-		return Buffer.from(publicKey)
+		return Buffer.from(publicKey || [])
 	}
 
 	public getSigningKeyPrivate(): Buffer | undefined {
@@ -113,7 +113,7 @@ export class SenderKeyState {
 			return Buffer.from(privateKey, 'base64')
 		}
 
-		return Buffer.from(privateKey)
+		return Buffer.from(privateKey || [])
 	}
 
 	public hasSenderMessageKey(iteration: number): boolean {


### PR DESCRIPTION
This fix is to solve the following specific problem when the signing keys comes null: https://github.com/WhiskeySockets/Baileys/pull/1552#issuecomment-3004984369