### PR TITLE
[READY FOR MERGE] Add support for custom profile picture dimensions

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -257,7 +257,7 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	}
 
 	/** update the profile picture for yourself or a group */
-	const updateProfilePicture = async (jid: string, content: WAMediaUpload, dimensions?: { w: number; h: number }) => {
+	const updateProfilePicture = async (jid: string, content: WAMediaUpload, dimensions?: { width: number; height: number }) => {
 		let targetJid
 		if (!jid) {
 			throw new Boom(

--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -257,7 +257,11 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	}
 
 	/** update the profile picture for yourself or a group */
-	const updateProfilePicture = async (jid: string, content: WAMediaUpload, dimensions?: { width: number; height: number }) => {
+	const updateProfilePicture = async (
+		jid: string,
+		content: WAMediaUpload,
+		dimensions?: { width: number; height: number }
+	) => {
 		let targetJid
 		if (!jid) {
 			throw new Boom(

--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -257,7 +257,7 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	}
 
 	/** update the profile picture for yourself or a group */
-	const updateProfilePicture = async (jid: string, content: WAMediaUpload) => {
+	const updateProfilePicture = async (jid: string, content: WAMediaUpload, dimensions?: { w: number; h: number }) => {
 		let targetJid
 		if (!jid) {
 			throw new Boom(
@@ -269,7 +269,7 @@ export const makeChatsSocket = (config: SocketConfig) => {
 			targetJid = jidNormalizedUser(jid) // in case it is someone other than us
 		}
 
-		const { img } = await generateProfilePicture(content)
+		const { img } = await generateProfilePicture(content, dimensions)
 		await query({
 			tag: 'iq',
 			attrs: {

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -139,8 +139,8 @@ export const extractImageThumb = async (bufferOrFilePath: Readable | Buffer | st
 export const encodeBase64EncodedStringForUpload = (b64: string) =>
 	encodeURIComponent(b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/\=+$/, ''))
 
-export const generateProfilePicture = async (mediaUpload: WAMediaUpload, dimensions?: { w: number; h: number }) => {
-	const { w = 640, h = 640 } = dimensions || {}
+export const generateProfilePicture = async (mediaUpload: WAMediaUpload, dimensions?: { width: number; height: number }) => {
+	const { width: w = 640, height: h = 640 } = dimensions || {}
 
 	let bufferOrFilePath: Buffer | string
 	if (Buffer.isBuffer(mediaUpload)) {

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -139,7 +139,10 @@ export const extractImageThumb = async (bufferOrFilePath: Readable | Buffer | st
 export const encodeBase64EncodedStringForUpload = (b64: string) =>
 	encodeURIComponent(b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/\=+$/, ''))
 
-export const generateProfilePicture = async (mediaUpload: WAMediaUpload, dimensions?: { width: number; height: number }) => {
+export const generateProfilePicture = async (
+	mediaUpload: WAMediaUpload,
+	dimensions?: { width: number; height: number }
+) => {
 	const { width: w = 640, height: h = 640 } = dimensions || {}
 
 	let bufferOrFilePath: Buffer | string

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -139,7 +139,9 @@ export const extractImageThumb = async (bufferOrFilePath: Readable | Buffer | st
 export const encodeBase64EncodedStringForUpload = (b64: string) =>
 	encodeURIComponent(b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/\=+$/, ''))
 
-export const generateProfilePicture = async (mediaUpload: WAMediaUpload) => {
+export const generateProfilePicture = async (mediaUpload: WAMediaUpload, dimensions?: { w: number; h: number }) => {
+	const { w = 640, h = 640 } = dimensions || {}
+
 	let bufferOrFilePath: Buffer | string
 	if (Buffer.isBuffer(mediaUpload)) {
 		bufferOrFilePath = mediaUpload
@@ -154,7 +156,7 @@ export const generateProfilePicture = async (mediaUpload: WAMediaUpload) => {
 	if ('sharp' in lib && typeof lib.sharp?.default === 'function') {
 		img = lib.sharp
 			.default(bufferOrFilePath)
-			.resize(640, 640)
+			.resize(w, h)
 			.jpeg({
 				quality: 50
 			})
@@ -165,7 +167,7 @@ export const generateProfilePicture = async (mediaUpload: WAMediaUpload) => {
 		const min = Math.min(jimp.getWidth(), jimp.getHeight())
 		const cropped = jimp.crop(0, 0, min, min)
 
-		img = cropped.quality(50).resize(640, 640, RESIZE_BILINEAR).getBufferAsync(MIME_JPEG)
+		img = cropped.quality(50).resize(w, h, RESIZE_BILINEAR).getBufferAsync(MIME_JPEG)
 	} else {
 		throw new Boom('No image processing library available')
 	}


### PR DESCRIPTION
The updateProfilePicture and generateProfilePicture functions now accept an optional dimensions parameter, allowing custom width and height for profile pictures. This provides more flexibility for image resizing beyond the default 640x640 size.

*Usage:*

![image](https://github.com/user-attachments/assets/3aa90234-09bc-4a9c-9a5c-483cc6dc2f38)
