### PR TITLE
[READY FOR MERGE] Show poll on the sender device

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -387,7 +387,8 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 			deviceSentMessage: {
 				destinationJid,
 				message
-			}
+			},
+			messageContextInfo: message.messageContextInfo
 		}
 
 		const extraAttrs = {}

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -475,11 +475,11 @@ export const generateWAMessageContent = async (
 			// poll v2 is for community announcement groups (single select and multiple)
 			m.pollCreationMessageV2 = pollCreationMessage
 		} else {
-			if (message.poll.selectableCount > 0) {
+			if (message.poll.selectableCount === 1) {
 				//poll v3 is for single select polls
 				m.pollCreationMessageV3 = pollCreationMessage
 			} else {
-				// poll v3 for multiple choice polls
+				// poll for multiple choice polls
 				m.pollCreationMessage = pollCreationMessage
 			}
 		}


### PR DESCRIPTION
fix #675
- `messageContextInfo` contains **message secret**, we need to send it to the device 
- Fix type - `pollCreationMessage` for **multiple** answers, `pollCreationMessageV3` for a **single** answer 