### PR TITLE
fix: process crash due to socket closed while opening

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -345,7 +345,6 @@ export const makeSocket = (config: SocketConfig) => {
 		clearTimeout(qrTimer)
 
 		ws.removeAllListeners('close')
-		ws.removeAllListeners('error')
 		ws.removeAllListeners('open')
 		ws.removeAllListeners('message')
 


### PR DESCRIPTION
### Why?
When the connection restarts for any reason while opening, it may throw an unhandled rejection and crash the process, due to missing ws error handling.
`Error: WebSocket was closed before the connection was established`

![image](https://github.com/user-attachments/assets/b8872dde-0587-4f3b-ab04-e1a5c0683233)
 
 
 ### What's wrong?
 The `catch {}` line should catch the error, but it doesn't because we removed the listeners:
 
![image](https://github.com/user-attachments/assets/ed8e827d-7f0d-4d8a-8bf8-88e8313a156a)

 
 ### How to test?
 - Set a fake proxy on connection settings, so your connection keep "connecting" until timeout
 - call `sock.end()` before the timeout
 - Without this PR, this will crash your entire process
 - After this PR, the process should keep going.
 
 ### Related
 https://github.com/discordjs/discord.js/issues/7964#issuecomment-1135590782
 https://github.com/EvolutionAPI/evolution-api/issues/1302