### PR TITLE
fix: add lid sutff to message.key type

### DIFF
--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -9,7 +9,7 @@ import { CacheStore } from './Socket'
 
 // export the WAMessage Prototypes
 export { proto as WAProto }
-export type WAMessage = proto.IWebMessageInfo
+export type WAMessage = proto.IWebMessageInfo & { key: WAMessageKey }
 export type WAMessageContent = proto.IMessage
 export type WAContactMessage = proto.Message.IContactMessage
 export type WAContactsArrayMessage = proto.Message.IContactsArrayMessage

--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -19,6 +19,7 @@ export type WAMessageKey = proto.IMessageKey & {
 	senderPn?: string
 	participantLid?: string
 	participantPn?: string
+	isViewOnce?: boolean
 }
 export type WATextMessage = proto.Message.IExtendedTextMessage
 export type WAContextInfo = proto.IContextInfo

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -158,6 +158,10 @@ export const decryptMessageNode = (
 						fullMessage.verifiedBizName = details.verifiedName
 					}
 
+					if (tag === 'unavailable' && attrs.type === 'view_once') {
+						fullMessage.key.isViewOnce = true
+					}
+
 					if (tag !== 'enc' && tag !== 'plaintext') {
 						continue
 					}

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -1,6 +1,6 @@
 import { Boom } from '@hapi/boom'
 import { proto } from '../../WAProto'
-import { SignalRepository, WAMessageKey } from '../Types'
+import { SignalRepository, WAMessage, WAMessageKey } from '../Types'
 import {
 	areJidsSameUser,
 	BinaryNode,
@@ -118,7 +118,7 @@ export function decodeMessageNode(stanza: BinaryNode, meId: string, meLid: strin
 		...(msgType === 'newsletter' && stanza.attrs.server_id ? { server_id: stanza.attrs.server_id } : {})
 	}
 
-	const fullMessage: proto.IWebMessageInfo = {
+	const fullMessage: WAMessage = {
 		key,
 		messageTimestamp: +stanza.attrs.t,
 		pushName: pushname,


### PR DESCRIPTION
### Why? 
Because new properties are not appearing when trying to access `message.key` on `messages.upsert` event.


before:
![image](https://github.com/user-attachments/assets/4c9da3eb-1a17-49d7-964c-e9d65b1e7625)


after: 
![image](https://github.com/user-attachments/assets/b39af689-6e14-4a3f-9ca0-841c044c964d)

Also, I've added a new "isViewOnce" property to message.key, indicating when its a view once message (atm we are "missing" it due to WhatsApp privacy stuff)