### PR TITLE
fix: preserve chat attributes in history sync processor

### DIFF
--- a/src/Utils/history.ts
+++ b/src/Utils/history.ts
@@ -46,9 +46,6 @@ export const processHistoryMessage = (item: proto.IHistorySync) => {
 
 				const msgs = chat.messages || []
 				delete chat.messages
-				delete chat.archived
-				delete chat.muteEndTime
-				delete chat.pinned
 
 				for (const item of msgs) {
 					const message = item.message!
@@ -73,10 +70,6 @@ export const processHistoryMessage = (item: proto.IHistorySync) => {
 							verifiedName: message.messageStubParameters?.[0]
 						})
 					}
-				}
-
-				if (isJidUser(chat.id) && chat.readOnly && chat.archived) {
-					delete chat.readOnly
 				}
 
 				chats.push({ ...chat })


### PR DESCRIPTION
For certain phone numbers or devices, I'm noticing that certain chat attributes such as `archived` were not available during the initial history sync.

Removing these `delete` lines in `history.ts` makes them available for devs to actually know the initial state of these chat attributes when going through the linking process.

I'm not sure why these lines were present in the first place or what side-effects they have, but I've been testing with these lines removed and they are working as expected.

Potentially fixes #1070 