### PR TITLE
fix: fallback to sender_pn when 'from' is a linked ID (@lid)

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -759,6 +759,10 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	}
 
 	const handleMessage = async (node: BinaryNode) => {
+		if (node.attrs.from && node.attrs.from.includes('@lid') && node.attrs.sender_pn && node.attrs.sender_pn.includes('@s.whatsapp.net')) {
+			node.attrs.from = node.attrs.sender_pn;
+		}
+
 		if (shouldIgnoreJid(node.attrs.from) && node.attrs.from !== '@s.whatsapp.net') {
 			logger.debug({ key: node.attrs.key }, 'ignored message')
 			await sendMessageAck(node)


### PR DESCRIPTION
## Context
In some message events, particularly when the message comes from a Linked ID (LID), the `from` field contains a `@lid` value instead of the actual sender's phone-based JID. This causes issues when trying to identify or reply to the message sender.

## What This PR Does
- Adds a fallback: if `node.attrs.from` includes `@lid` and `node.attrs.sender_pn` includes `@s.whatsapp.net`, then replaces `from` with `sender_pn`.

```ts
if (node.attrs.from && node.attrs.from.includes('@lid') && node.attrs.sender_pn && node.attrs.sender_pn.includes('@s.whatsapp.net')) {
    node.attrs.from = node.attrs.sender_pn;
}