### PR TITLE
Fix sender resolution for LID users with senderPn in decodeMessageNode

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -759,10 +759,6 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	}
 
 	const handleMessage = async (node: BinaryNode) => {
-		if (node.attrs.from && node.attrs.from.includes('@lid') && node.attrs.sender_pn && node.attrs.sender_pn.includes('@s.whatsapp.net')) {
-			node.attrs.from = node.attrs.sender_pn;
-		}
-
 		if (shouldIgnoreJid(node.attrs.from) && node.attrs.from !== '@s.whatsapp.net') {
 			logger.debug({ key: node.attrs.key }, 'ignored message')
 			await sendMessageAck(node)

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -759,6 +759,10 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	}
 
 	const handleMessage = async (node: BinaryNode) => {
+		if (node.attrs.from && node.attrs.from.includes('@lid') && node.attrs.sender_pn && node.attrs.sender_pn.includes('@s.whatsapp.net')) {
+			node.attrs.from = node.attrs.sender_pn;
+		}
+
 		if (shouldIgnoreJid(node.attrs.from) && node.attrs.from !== '@s.whatsapp.net') {
 			logger.debug({ key: node.attrs.key }, 'ignored message')
 			await sendMessageAck(node)

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -52,10 +52,13 @@ export function decodeMessageNode(stanza: BinaryNode, meId: string, meLid: strin
 	let chatId: string
 	let author: string
 
+	const senderPn: string | undefined = stanza?.attrs?.sender_pn
+	const fromAttr: string = stanza?.attrs?.from
 	const msgId = stanza.attrs.id
-	const from = stanza.attrs.from
+	const from = isLidUser(fromAttr) && isJidUser(senderPn) ? senderPn : fromAttr
 	const participant: string | undefined = stanza.attrs.participant
 	const recipient: string | undefined = stanza.attrs.recipient
+	
 
 	const isMe = (jid: string) => areJidsSameUser(jid, meId)
 	const isMeLid = (jid: string) => areJidsSameUser(jid, meLid)


### PR DESCRIPTION
## 📝 Description

This PR updates the `decodeMessageNode` function to correctly resolve the sender (`from`) when receiving messages from LID users that include a `senderPn`.

Previously, such messages could be misinterpreted due to the use of the LID in the `from` field. The new logic ensures that when `from` is a LID and a valid `senderPn` is present (and is a JID), it is used as the effective sender.

---

## ✅ Changes

- Adjusted `from` resolution logic using `senderPn` for LID users.
- Preserved compatibility with JID, LID, group, broadcast, and newsletter messages.
- No changes to decryption behavior.

---

## 🎯 Motivation

Fixes incorrect attribution of the sender in edge cases where users migrated to LID but continue to send messages with a `senderPn` JID.

---

## 🧪 Test Plan

- ✅ Verified locally with messages from LID users including `senderPn`.
- ✅ Confirmed that regular messages from JIDs, groups, and newsletters remain unaffected.