### PR TITLE
Fix group size metadata

### DIFF
--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -331,7 +331,7 @@ export const extractGroupMetadata = (result: BinaryNode) => {
 		subjectOwner: group.attrs.s_o,
 		subjectOwnerJid: group.attrs.s_o_pn,
 		subjectTime: +group.attrs.s_t,
-		size: getBinaryNodeChildren(group, 'participant').length,
+		size: group.attrs.size ? +group.attrs.size : getBinaryNodeChildren(group, 'participant').length,
 		creation: +group.attrs.creation,
 		owner: group.attrs.creator ? jidNormalizedUser(group.attrs.creator) : undefined,
 		ownerJid: group.attrs.creator_pn ? jidNormalizedUser(group.attrs.creator_pn) : undefined,


### PR DESCRIPTION
So when using groupGetInviteInfo the total number of members counted are only the contacts we save.

Before
```js
{
    size: 4
}
```

After
```js
{
    size: 520
}
```