### PR TITLE
fix: build scripts for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build:all": "npm run build && npm run build:docs",
     "build:docs": "typedoc",
-    "build": "tsc -P tsconfig.build.json && tsc-esm-fix --tsconfig='tsconfig.build.json' --ext='.js'",
+    "build": "tsc -P tsconfig.build.json && tsc-esm-fix --tsconfig=tsconfig.build.json --ext=.js",
     "changelog:last": "conventional-changelog -p angular -r 2",
     "changelog:preview": "conventional-changelog -p angular -u",
     "changelog:update": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",


### PR DESCRIPTION
**Fix Windows path issue in `build` script**

**Issue**

The `build` script in `package.json` was written as:

```json
"build": "tsc -P tsconfig.build.json && tsc-esm-fix --tsconfig='tsconfig.build.json' --ext='.js'"
```

This works on Unix-based systems (macOS/Linux) but **breaks on Windows**, throwing an error:

```
Error: ENOENT: no such file or directory, open 'C:\path\to\project\'tsconfig.build.json''
```

> The single quotes `'` are treated **literally** on Windows CMD/PowerShell, resulting in a malformed path (e.g., `'tsconfig.build.json'` instead of `tsconfig.build.json`).

**Fixes**

Updated the script to remove single quotes around the `--tsconfig` and `--ext` arguments:

```json
"build": "tsc -P tsconfig.build.json && tsc-esm-fix --tsconfig=tsconfig.build.json --ext=.js"
```

**Result**

```
PS C:\Users\Astro\Documents\GitHub\Baileys> npm run build

> baileys@6.7.18 build
> tsc -P tsconfig.build.json && tsc-esm-fix --tsconfig=tsconfig.build.json --ext=.js

PS C:\Users\Astro\Documents\GitHub\Baileys>
```