### PR TITLE
fix(socket): Prevent crashes from timeouts and fix memory leak

### DIFF
--- a/src/Signal/Group/queue-job.ts
+++ b/src/Signal/Group/queue-job.ts
@@ -5,6 +5,11 @@ interface QueueJob<T> {
 }
 
 const _queueAsyncBuckets = new Map<string | number, Array<QueueJob<any>>>()
+
+export function cleanupQueues() {
+	_queueAsyncBuckets.clear()
+}
+
 const _gcLimit = 10000
 
 async function _asyncQueueExecutor(queue: Array<QueueJob<any>>, cleanup: () => void): Promise<void> {


### PR DESCRIPTION
Addresses a critical stability issue where network timeouts (408 errors) would cause an unhandled promise rejection, crashing the entire Node.js process. It also fixes a related memory leak that occurred due to frequent, uncontrolled restarts.

related to https://github.com/WhiskeySockets/Baileys/issues/1361 and private dm messages of a user that has multiple instances running in the same machine.

The risky of this changes is low.

### Key Changes

1.  **Graceful Timeout Handling in `waitForMessage`:**
    -   Modified `waitForMessage` in `src/Socket/socket.ts` to include a `try...catch` block.
    -   It now specifically catches `Boom: Timed Out` errors, logs a warning, and returns `undefined`. All other errors are still thrown.
    -   This prevents a timeout from becoming a fatal unhandled rejection and allows calling functions (like `query`) to handle the timeout as a non-crash failure state.

2.  **Resilient Connection Startup:**
    -   Wrapped the calls to `uploadPreKeysToServerIfRequired()` and `sendPassiveIq()` within the `CB:success` event handler in a `try...catch` block.
    -   This ensures that if these non-critical startup operations fail (e.g., due to a timeout), the connection process can still complete successfully without crashing.

3.  **Memory Leak Fix in `queue-job.ts`:**
    -   Introduced an exported `cleanupQueues()` function that clears the global `_queueAsyncBuckets` map.
    -   This function is now called from the socket's `end()` method, ensuring that any data from a terminated session is properly garbage collected and does not persist across restarts.


### How to Test

1.  In `src/Defaults/index.ts`, temporarily set `defaultQueryTimeoutMs` to a very low value (e.g., `20`).
2.  Run the example application (`yarn example`).
3.  **Expected Behavior:** The application will no longer crash. Instead, it will log warnings for the timed-out operations and proceed to establish a connection successfully.
