### PR TITLE
fix: message retries loop 

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "engine-requirements.js"
   ],
   "scripts": {
-    "build:all": "yarn build && yarn build:docs",
+    "build:all": "npm run build && npm run build:docs",
     "build:docs": "typedoc",
     "build": "tsc -P tsconfig.build.json && tsc-esm-fix --tsconfig='tsconfig.build.json' --ext='.js'",
     "changelog:last": "conventional-changelog -p angular -r 2",
@@ -31,9 +31,9 @@
     "gen:protobuf": "sh WAProto/GenerateStatics.sh",
     "format": "prettier --write \"src/**/*.{ts,js,json,md}\"",
     "lint": "tsc && eslint src --ext .js,.ts",
-    "lint:fix": "yarn format && yarn lint --fix",
-    "prepack": "yarn build",
-    "prepare": "yarn build",
+    "lint:fix": "npm run format && npm run lint --fix",
+    "prepack": "npm run build",
+    "prepare": "npm run build",
     "preinstall": "node ./engine-requirements.js",
     "release": "release-it",
     "test": "jest"

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -585,7 +585,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	const willSendMessageAgain = (id: string, participant: string) => {
 		const key = `${id}:${participant}`
 		const retryCount = msgRetryCache.get<number>(key) || 0
-		return retryCount < maxMsgRetryCount
+		return retryCount <= maxMsgRetryCount
 	}
 
 	const updateSendMessageAgainCount = (id: string, participant: string) => {

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -612,10 +612,8 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		logger.debug({ participant, sendToAll }, 'forced new session for retry recp')
 
 		for (const [i, msg] of msgs.entries()) {
-			if (!ids[i]) continue
-
-			if (msg && willSendMessageAgain(ids[i], participant)) {
-				updateSendMessageAgainCount(ids[i], participant)
+			if (msg) {
+				updateSendMessageAgainCount(ids[i]!, participant)
 				const msgRelayOpts: MessageRelayOptions = { messageId: ids[i] }
 
 				if (sendToAll) {
@@ -703,10 +701,9 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 						// correctly set who is asking for the retry
 						key.participant = key.participant || attrs.from
 						const retryNode = getBinaryNodeChild(node, 'retry')
-						if (ids[0] && key.participant && willSendMessageAgain(ids[0], key.participant!)) {
+						if (willSendMessageAgain(ids[0]!, key.participant!)) {
 							if (key.fromMe) {
 								try {
-									updateSendMessageAgainCount(ids[0], key.participant)
 									logger.debug({ attrs, key }, 'recv retry request')
 									await sendMessagesAgain(key, ids, retryNode!)
 								} catch (error: any) {

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -612,8 +612,10 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		logger.debug({ participant, sendToAll }, 'forced new session for retry recp')
 
 		for (const [i, msg] of msgs.entries()) {
-			if (msg) {
-				updateSendMessageAgainCount(ids[i]!, participant)
+			if (!ids[i]) continue
+
+			if (msg && willSendMessageAgain(ids[i], participant)) {
+				updateSendMessageAgainCount(ids[i], participant)
 				const msgRelayOpts: MessageRelayOptions = { messageId: ids[i] }
 
 				if (sendToAll) {
@@ -701,9 +703,10 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 						// correctly set who is asking for the retry
 						key.participant = key.participant || attrs.from
 						const retryNode = getBinaryNodeChild(node, 'retry')
-						if (willSendMessageAgain(ids[0]!, key.participant!)) {
+						if (ids[0] && key.participant && willSendMessageAgain(ids[0], key.participant!)) {
 							if (key.fromMe) {
 								try {
+									updateSendMessageAgainCount(ids[0], key.participant)
 									logger.debug({ attrs, key }, 'recv retry request')
 									await sendMessagesAgain(key, ids, retryNode!)
 								} catch (error: any) {


### PR DESCRIPTION
# Problem
When a message retry is triggered but the message is not in store (see implementation example), the retry process never stops. It keeps sending retries endlessly and doesn't respect maxRetriesCache.
_Additionally, I made a few more adjustments._


This only happens when message is not  found in the store.

## Implementation example
 ```
private async getMessage(key: proto.IMessageKey) {
		const messageId = `${key.remoteJid}@${key.id}`;

		if (!messageId) return proto.Message.fromObject({});

		const message = await this.messageHistory.get<WAMessage>(messageId);

		if (message?.message) {
			return proto.Message.fromObject(message.message);
		}

		logger.debug(
			`Message with key ${key.id} not found in memory storage. ${JSON.stringify(key)}`,
		);
		return proto.Message.fromObject({});
	}
```

I could't reproduce this locally. I have a bot that log these errors, and as soon as i applied the fix, the error rate dropped significantly (they still occur occasionally due to missing messages in the store, but it now respects the maxRetriesCache)

<img width="470" height="879" alt="image" src="https://github.com/user-attachments/assets/9bf361e4-46a8-4c54-a231-0d9cca86ac3a" />


<img width="356" height="427" alt="image" src="https://github.com/user-attachments/assets/531e8c44-56a5-4fb6-b59d-09c5e65d15a2" />
