### PR TITLE
Update decode-wa-message.ts (peer_recipient_pn)

### DIFF
--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -111,7 +111,7 @@ export function decodeMessageNode(stanza: BinaryNode, meId: string, meLid: strin
 		fromMe,
 		id: msgId,
 		senderLid: stanza?.attrs?.sender_lid,
-		senderPn: stanza?.attrs?.sender_pn,
+		senderPn: stanza?.attrs?.sender_pn || stanza?.attrs?.peer_recipient_pn,
 		participant,
 		participantPn: stanza?.attrs?.participant_pn,
 		participantLid: stanza?.attrs?.participant_lid,


### PR DESCRIPTION
When the cell phone connected to the instance (Baileys) sends a message to a contact (fromMe = true), the senderPn comes as undefined. This fix fixes this problem temporarily.