### PR TITLE
fix: glob pattern for package.json `files` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
-    "lib/*",
-    "WAProto/*",
+    "lib/**/*",
+    "WAProto/**/*",
     "engine-requirements.js"
   ],
   "scripts": {


### PR DESCRIPTION
This PR fixes the glob pattern for the `files` field to include all subdirectories in the `lib` and `WAProto` since the yarn package manager version was updated from v1.22.19 to v4.9.2 in https://github.com/WhiskeySockets/Baileys/commit/90781ce0f25f3bbaa2c3d0f7846e51e2af71a67e

I'm trying to install Baileys using the GitHub repo directly via: `yarn add baileys@git@github.com:WhiskeySockets/Baileys.git`
This currently does not produce a proper package and is missing a few files in the `lib` directory.

This is because yarn uses the `yarn pack` command to prepare the repo for installation (https://yarnpkg.com/protocol/git#packing). The glob pattern for the `files` field was updated to follow a similar syntax to .gitignore (https://yarnpkg.com/configuration/manifest#files), which means that `lib/*` would not include files in subdirectories while `lib/**/*` will include all files in all subdirectories.

You can reproduce this by running `yarn pack` and you will notice that it will only include `lib/index.js`. No other files in subdirectories of `lib` are included in the `package.tgz` artifact produced.

