### PR TITLE
fix: sync pre-keys on socket start and add specific pre-key error approach

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -107,6 +107,9 @@ export const MIN_PREKEY_COUNT = 5
 
 export const INITIAL_PREKEY_COUNT = 30
 
+export const UPLOAD_TIMEOUT = 30000 // 30 seconds
+export const MIN_UPLOAD_INTERVAL = 5000 // 5 seconds minimum between uploads
+
 export const DEFAULT_CACHE_TTLS = {
 	SIGNAL_STORE: 5 * 60, // 5 minutes
 	MSG_RETRY: 60 * 60, // 1 hour

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -706,8 +706,11 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 								try {
 									logger.debug({ attrs, key }, 'recv retry request')
 									await sendMessagesAgain(key, ids, retryNode!)
-								} catch (error: any) {
-									logger.error({ key, ids, trace: error.stack }, 'error in sending message again')
+								} catch (error: unknown) {
+									logger.error(
+										{ key, ids, trace: error instanceof Error ? error.stack : 'Unknown error' },
+										'error in sending message again'
+									)
 								}
 							} else {
 								logger.info({ attrs, key }, 'recv retry for not fromMe message')
@@ -817,7 +820,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 						if (msg?.messageStubParameters?.[0] === MISSING_KEYS_ERROR_TEXT) {
 							return sendMessageAck(node, NACK_REASONS.ParsingError)
 						}
-						
+
 						const errorMessage = msg?.messageStubParameters?.[0] || ''
 						const isPreKeyError = errorMessage.includes('PreKey')
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -817,11 +817,37 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 						if (msg?.messageStubParameters?.[0] === MISSING_KEYS_ERROR_TEXT) {
 							return sendMessageAck(node, NACK_REASONS.ParsingError)
 						}
+						
+						const errorMessage = msg?.messageStubParameters?.[0] || ''
+						const isPreKeyError = errorMessage.includes('PreKey')
 
+						console.debug(`[handleMessage] Attempting retry request for failed decryption`)
+
+						// Handle both pre-key and normal retries in single mutex
 						retryMutex.mutex(async () => {
-							if (ws.isOpen) {
-								if (getBinaryNodeChild(node, 'unavailable')) {
+							try {
+								if (!ws.isOpen) {
+									logger.debug({ node }, 'Connection closed, skipping retry')
 									return
+								}
+
+								if (getBinaryNodeChild(node, 'unavailable')) {
+									logger.debug('Message unavailable, skipping retry')
+									return
+								}
+
+								// Handle pre-key errors with upload and delay
+								if (isPreKeyError) {
+									logger.info({ error: errorMessage }, 'PreKey error detected, uploading and retrying')
+
+									try {
+										logger.debug('Uploading pre-keys for error recovery')
+										await uploadPreKeys(5)
+										logger.debug('Waiting for server to process new pre-keys')
+										await delay(1000)
+									} catch (uploadErr) {
+										logger.error({ uploadErr }, 'Pre-key upload failed, proceeding with retry anyway')
+									}
 								}
 
 								const encNode = getBinaryNodeChild(node, 'enc')
@@ -829,8 +855,15 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 								if (retryRequestDelayMs) {
 									await delay(retryRequestDelayMs)
 								}
-							} else {
-								logger.debug({ node }, 'connection closed, ignoring retry req')
+							} catch (err) {
+								logger.error({ err, isPreKeyError }, 'Failed to handle retry, attempting basic retry')
+								// Still attempt retry even if pre-key upload failed
+								try {
+									const encNode = getBinaryNodeChild(node, 'enc')
+									await sendRetryRequest(node, !encNode)
+								} catch (retryErr) {
+									logger.error({ retryErr }, 'Failed to send retry after error handling')
+								}
 							}
 						})
 					} else {

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -8,9 +8,9 @@ import {
 	DEF_TAG_PREFIX,
 	INITIAL_PREKEY_COUNT,
 	MIN_PREKEY_COUNT,
+	MIN_UPLOAD_INTERVAL,
 	NOISE_WA_HEADER,
-	UPLOAD_TIMEOUT,
-	MIN_UPLOAD_INTERVAL
+	UPLOAD_TIMEOUT
 } from '../Defaults'
 import type { SocketConfig } from '../Types'
 import { DisconnectReason } from '../Types'
@@ -369,6 +369,11 @@ export const makeSocket = (config: SocketConfig) => {
 			const shouldUpload = lowServerCount || missingCurrentPreKey
 
 			if (shouldUpload) {
+				const reasons = []
+				if (lowServerCount) reasons.push(`server count low (${preKeyCount})`)
+				if (missingCurrentPreKey) reasons.push(`current prekey ${currentPreKeyId} missing from storage`)
+
+				logger.info(`Uploading PreKeys due to: ${reasons.join(', ')}`)
 				await uploadPreKeys()
 			} else {
 				logger.info(`PreKey validation passed - Server: ${preKeyCount}, Current prekey ${currentPreKeyId} exists`)


### PR DESCRIPTION
1 - Socket start validation:

Ensures local pre-key storage is properly aligned with the server by verifying that the current pre-key (referenced in `creds`) actually exists in local storage.

Triggers a fresh upload of pre-keys when:
- The server's pre-key count is below the minimum threshold (existing behavior)
- The latest local pre-key referenced in `creds` is missing (new behavior)

2 - Pre-key specific error approach:

Check if the error resulting in CHIPERTEXT was caused by a pre-key. If so, upload 5 new pre-keys to the WhatsApp server to ensure the new pre-keys are recognized in the pool when calling sendRetryRequest, preventing it from retrying with the same pre-key.

### How to test

Pre-key storage:

1. Delete all your pre-keys from local storage.
2. Restart your socket.
3. Observe that pre-keys are regenerated and uploaded automatically.

Pre-key error:

1. Restart your socket.
2. Delete all your pre-keys from local storage.
3. Send a message to the baileys connected phone.
4. Observe when the PreKey error is triggered from libsignal if it generate new pre-keys and upload.