### PR TITLE
feat: add peerRecipientLid

### DIFF
--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -14,6 +14,7 @@ export type WAMessageContent = proto.IMessage
 export type WAContactMessage = proto.Message.IContactMessage
 export type WAContactsArrayMessage = proto.Message.IContactsArrayMessage
 export type WAMessageKey = proto.IMessageKey & {
+	peerRecipientLid?: string
 	senderLid?: string
 	server_id?: string
 	senderPn?: string

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -110,6 +110,7 @@ export function decodeMessageNode(stanza: BinaryNode, meId: string, meLid: strin
 		remoteJid: chatId,
 		fromMe,
 		id: msgId,
+		peerRecipientLid: stanza?.attrs?.peer_recipient_lid,
 		senderLid: stanza?.attrs?.sender_lid,
 		senderPn: stanza?.attrs?.sender_pn,
 		participant,


### PR DESCRIPTION
### What was added?

This PR adds support for the `peerRecipientLid` field in message-related logic.

### Why?

WhatsApp Web started including the `peer_recipient_lid` attribute in some message stanzas, especially when sending messages between linked devices. This field is now extracted from the stanza and exposed via `peerRecipientLid`.

### Changes:
- Added `peerRecipientLid` to the message structure (optional field).
- Parsed `peer_recipient_lid` from stanza attributes, if present.