### PR TITLE
Add: LID support with lid-map and migrations of sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "jiti": "^2.4.2",
     "json": "^11.0.0",
     "link-preview-js": "^3.0.0",
+    "lru-cache": "^10.4.3",
     "open": "^8.4.2",
     "prettier": "^3.5.3",
     "protobufjs-cli": "^1.1.3",

--- a/src/Signal/libsignal.ts
+++ b/src/Signal/libsignal.ts
@@ -1,17 +1,27 @@
 /* @ts-ignore */
 import * as libsignal from 'libsignal'
-import type { SignalAuthState } from '../Types'
+/* @ts-ignore */
+import { LRUCache } from 'lru-cache'
+import type { SignalAuthState, SignalKeyStoreWithTransaction } from '../Types'
 import type { SignalRepository } from '../Types/Signal'
 import { generateSignalPubKey } from '../Utils'
 import { jidDecode } from '../WABinary'
+import { LIDMappingStore } from './lid-mapping'
 import type { SenderKeyStore } from './Group/group_cipher'
 import { SenderKeyName } from './Group/sender-key-name'
 import { SenderKeyRecord } from './Group/sender-key-record'
 import { GroupCipher, GroupSessionBuilder, SenderKeyDistributionMessage } from './Group'
 
 export function makeLibSignalRepository(auth: SignalAuthState): SignalRepository {
-	const storage: SenderKeyStore = signalStorage(auth)
-	return {
+	const lidMapping = new LIDMappingStore(auth.keys as SignalKeyStoreWithTransaction)
+	const storage = signalStorage(auth, lidMapping)
+	// Simple operation-level deduplication (5 minutes)
+	const recentMigrations = new LRUCache<string, boolean>({
+		max: 500,
+		ttl: 5 * 60 * 1000
+	})
+
+	const repository: SignalRepository = {
 		decryptGroupMessage({ group, authorJid, msg }) {
 			const senderName = jidToSignalSenderKeyName(group, authorJid)
 			const cipher = new GroupCipher(storage, senderName)
@@ -58,8 +68,40 @@ export function makeLibSignalRepository(auth: SignalAuthState): SignalRepository
 
 			return result
 		},
+
 		async encryptMessage({ jid, data }) {
-			const addr = jidToSignalProtocolAddress(jid)
+			// LID SINGLE SOURCE OF TRUTH: Always prefer LID when available
+			let encryptionJid = jid
+
+			// Check for LID mapping and use it if session exists
+			if (jid.includes('@s.whatsapp.net')) {
+				try {
+					const lidForPN = await lidMapping.getLIDForPN(jid)
+					if (lidForPN && lidForPN.includes('@lid')) {
+						const lidAddr = jidToSignalProtocolAddress(lidForPN)
+						const { [lidAddr.toString()]: lidSession } = await auth.keys.get('session', [lidAddr.toString()])
+
+						if (lidSession) {
+							// LID session exists, use it
+							encryptionJid = lidForPN
+						} else {
+							// Try to migrate if PN session exists
+							const pnAddr = jidToSignalProtocolAddress(jid)
+							const { [pnAddr.toString()]: pnSession } = await auth.keys.get('session', [pnAddr.toString()])
+
+							if (pnSession) {
+								// Migrate PN to LID
+								await repository.migrateSession(jid, lidForPN)
+								encryptionJid = lidForPN
+							}
+						}
+					}
+				} catch (error) {
+					// Fallback to original JID on any error
+				}
+			}
+
+			const addr = jidToSignalProtocolAddress(encryptionJid)
 			const cipher = new libsignal.SessionCipher(storage, addr)
 
 			const { type: sigType, body } = await cipher.encrypt(data)
@@ -91,26 +133,173 @@ export function makeLibSignalRepository(auth: SignalAuthState): SignalRepository
 		},
 		jidToSignalProtocolAddress(jid) {
 			return jidToSignalProtocolAddress(jid).toString()
+		},
+
+		async storeLIDPNMapping(lid: string, pn: string) {
+			await lidMapping.storeLIDPNMapping(lid, pn)
+		},
+
+		getLIDMappingStore() {
+			return lidMapping
+		},
+
+		async validateSession(jid: string) {
+			try {
+				const addr = jidToSignalProtocolAddress(jid)
+				const session = await storage.loadSession(addr.toString())
+
+				if (!session) {
+					return { exists: false, reason: 'no session' }
+				}
+
+				if (!session.haveOpenSession()) {
+					return { exists: false, reason: 'no open session' }
+				}
+
+				return { exists: true }
+			} catch (error) {
+				return { exists: false, reason: 'validation error' }
+			}
+		},
+
+		shouldRecreateSession(_jid: string, retryCount: number) {
+			// Simple threshold - let WhatsApp server dictate when recreation is needed
+			return retryCount >= 2
+				? { shouldRecreate: true, reason: 'retry threshold met' }
+				: { shouldRecreate: false, reason: 'retry count below threshold' }
+		},
+
+		async recreateSession(jid: string) {
+			const addr = jidToSignalProtocolAddress(jid)
+
+			return (auth.keys as SignalKeyStoreWithTransaction).transaction(async () => {
+				await auth.keys.set({ session: { [addr.toString()]: null } })
+			})
+		},
+
+		async deleteSession(jid: string) {
+			const addr = jidToSignalProtocolAddress(jid)
+
+			return (auth.keys as SignalKeyStoreWithTransaction).transaction(async () => {
+				await auth.keys.set({ session: { [addr.toString()]: null } })
+			})
+		},
+
+		async migrateSession(fromJid: string, toJid: string) {
+			// Only migrate PN → LID
+			if (!fromJid.includes('@s.whatsapp.net') || !toJid.includes('@lid')) {
+				return
+			}
+
+			const fromDecoded = jidDecode(fromJid)
+			const toDecoded = jidDecode(toJid)
+			if (!fromDecoded || !toDecoded) return
+
+			const deviceId = fromDecoded.device || 0
+			const migrationKey = `${fromDecoded.user}.${deviceId}→${toDecoded.user}.${deviceId}`
+
+			// Check if recently migrated (5 min window)
+			if (recentMigrations.has(migrationKey)) {
+				return
+			}
+
+			// Check if LID session already exists
+			const lidAddr = jidToSignalProtocolAddress(toJid)
+			const { [lidAddr.toString()]: lidExists } = await auth.keys.get('session', [lidAddr.toString()])
+			if (lidExists) {
+				recentMigrations.set(migrationKey, true)
+				return
+			}
+
+			return (auth.keys as SignalKeyStoreWithTransaction).transaction(async () => {
+				// Store mapping
+				await lidMapping.storeLIDPNMapping(toJid, fromJid)
+
+				// Load and copy session
+				const fromAddr = jidToSignalProtocolAddress(fromJid)
+				const fromSession = await storage.loadSession(fromAddr.toString())
+
+				if (fromSession && fromSession.haveOpenSession()) {
+					// Deep copy session to prevent reference issues
+					const sessionBytes = fromSession.serialize()
+					const copiedSession = libsignal.SessionRecord.deserialize(sessionBytes)
+
+					// Store at LID address
+					await storage.storeSession(lidAddr.toString(), copiedSession)
+
+					// Delete PN session - maintain single encryption layer
+					await auth.keys.set({ session: { [fromAddr.toString()]: null } })
+				}
+
+				recentMigrations.set(migrationKey, true)
+			})
+		},
+
+		async encryptMessageWithWire({ encryptionJid, wireJid, data }) {
+			const result = await repository.encryptMessage({ jid: encryptionJid, data })
+			return { ...result, wireJid }
+		},
+
+		destroy() {
+			recentMigrations.clear()
 		}
 	}
+
+	return repository
 }
 
 const jidToSignalProtocolAddress = (jid: string) => {
-	const { user, device } = jidDecode(jid)!
-	return new libsignal.ProtocolAddress(user, device || 0)
+	const decoded = jidDecode(jid)!
+	const { user, device, server } = decoded
+
+	// LID addresses get _1 suffix for Signal protocol
+	const signalUser = server === 'lid' ? `${user}_1` : user
+	const finalDevice = device || 0
+
+	return new libsignal.ProtocolAddress(signalUser, finalDevice)
 }
 
 const jidToSignalSenderKeyName = (group: string, user: string): SenderKeyName => {
 	return new SenderKeyName(group, jidToSignalProtocolAddress(user))
 }
 
-function signalStorage({ creds, keys }: SignalAuthState): SenderKeyStore & Record<string, any> {
+function signalStorage(
+	{ creds, keys }: SignalAuthState,
+	lidMapping: LIDMappingStore
+): SenderKeyStore & Record<string, any> {
 	return {
 		loadSession: async (id: string) => {
-			const { [id]: sess } = await keys.get('session', [id])
-			if (sess) {
-				return libsignal.SessionRecord.deserialize(sess)
+			try {
+				// LID SINGLE SOURCE OF TRUTH: Auto-redirect PN to LID if mapping exists
+				let actualId = id
+				if (id.includes('.') && !id.includes('_1')) {
+					// This is a PN signal address format (e.g., "1234567890.0")
+					// Convert back to JID to check for LID mapping
+					const parts = id.split('.')
+					const device = parts[1] || '0'
+					const pnJid = device === '0' ? `${parts[0]}@s.whatsapp.net` : `${parts[0]}:${device}@s.whatsapp.net`
+
+					const lidForPN = await lidMapping.getLIDForPN(pnJid)
+					if (lidForPN && lidForPN.includes('@lid')) {
+						const lidAddr = jidToSignalProtocolAddress(lidForPN)
+						const lidId = lidAddr.toString()
+
+						// Check if LID session exists
+						const { [lidId]: lidSession } = await keys.get('session', [lidId])
+						if (lidSession) {
+							actualId = lidId
+						}
+					}
+				}
+
+				const { [actualId]: sess } = await keys.get('session', [actualId])
+				if (sess) {
+					return libsignal.SessionRecord.deserialize(sess)
+				}
+			} catch (e) {
+				return null
 			}
+			return null
 		},
 		// TODO: Replace with libsignal.SessionRecord when type exports are added to libsignal
 		storeSession: async (id: string, session: any) => {

--- a/src/Signal/lid-mapping.ts
+++ b/src/Signal/lid-mapping.ts
@@ -1,0 +1,101 @@
+import type { SignalKeyStoreWithTransaction } from '../Types'
+import { isLidUser, isJidUser, jidDecode } from '../WABinary'
+import logger from '../Utils/logger'
+
+export class LIDMappingStore {
+	private readonly keys: SignalKeyStoreWithTransaction
+
+	constructor(keys: SignalKeyStoreWithTransaction) {
+		this.keys = keys
+	}
+
+	/**
+	 * Store LID-PN mapping - USER LEVEL
+	 */
+	async storeLIDPNMapping(lid: string, pn: string): Promise<void> {
+		// Validate inputs
+		if (!((isLidUser(lid) && isJidUser(pn)) || (isJidUser(lid) && isLidUser(pn)))) {
+			logger.warn(`Invalid LID-PN mapping: ${lid}, ${pn}`)
+			return
+		}
+
+		const [lidJid, pnJid] = isLidUser(lid) ? [lid, pn] : [pn, lid]
+
+		const lidDecoded = jidDecode(lidJid)
+		const pnDecoded = jidDecode(pnJid)
+
+		if (!lidDecoded || !pnDecoded) return
+
+		const pnUser = pnDecoded.user
+		const lidUser = lidDecoded.user
+
+		logger.info(`Storing USER LID mapping: PN ${pnUser} → LID ${lidUser}`)
+
+		await this.keys.transaction(async () => {
+			await this.keys.set({
+				'lid-mapping': {
+					[pnUser]: lidUser, // "554396160286" -> "102765716062358"
+					[`${lidUser}_reverse`]: pnUser // "102765716062358_reverse" -> "554396160286"
+				}
+			})
+		})
+
+		logger.info(`USER LID mapping stored: PN ${pnUser} → LID ${lidUser}`)
+	}
+
+	/**
+	 * Get LID for PN - Returns device-specific LID based on user mapping
+	 */
+	async getLIDForPN(pn: string): Promise<string | null> {
+		if (!isJidUser(pn)) return null
+
+		const decoded = jidDecode(pn)
+		if (!decoded) return null
+
+		// Look up user-level mapping (whatsmeow approach)
+		const pnUser = decoded.user
+		const stored = await this.keys.get('lid-mapping', [pnUser])
+		const lidUser = stored[pnUser]
+
+		if (!lidUser) {
+			logger.warn(`No LID mapping found for PN user ${pnUser}`)
+			return null
+		}
+
+		if (typeof lidUser !== 'string') return null
+
+		// Push the PN device ID to the LID to maintain device separation
+		const pnDevice = decoded.device !== undefined ? decoded.device : 0
+		const deviceSpecificLid = `${lidUser}:${pnDevice}@lid`
+
+		logger.info(`getLIDForPN: ${pn} → ${deviceSpecificLid} (user mapping with device ${pnDevice})`)
+		return deviceSpecificLid
+	}
+
+	/**
+	 * Get PN for LID - USER LEVEL with device construction
+	 */
+	async getPNForLID(lid: string): Promise<string | null> {
+		if (!isLidUser(lid)) return null
+
+		const decoded = jidDecode(lid)
+		if (!decoded) return null
+
+		// Look up reverse user mapping
+		const lidUser = decoded.user
+		const stored = await this.keys.get('lid-mapping', [`${lidUser}_reverse`])
+		const pnUser = stored[`${lidUser}_reverse`]
+
+		if (!pnUser || typeof pnUser !== 'string') {
+			logger.warn(`No reverse mapping found for LID user: ${lidUser}`)
+			return null
+		}
+
+		// Construct device-specific PN JID
+		const lidDevice = decoded.device !== undefined ? decoded.device : 0
+		const pnJid = `${pnUser}:${lidDevice}@s.whatsapp.net`
+
+		logger.info(`Found reverse mapping: ${lid} → ${pnJid}`)
+		return pnJid
+	}
+}

--- a/src/Signal/lid-mapping.ts
+++ b/src/Signal/lid-mapping.ts
@@ -1,6 +1,6 @@
 import type { SignalKeyStoreWithTransaction } from '../Types'
-import { isLidUser, isJidUser, jidDecode } from '../WABinary'
 import logger from '../Utils/logger'
+import { isJidUser, isLidUser, jidDecode } from '../WABinary'
 
 export class LIDMappingStore {
 	private readonly keys: SignalKeyStoreWithTransaction

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -842,18 +842,6 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 							},
 							'Stored server-provided PN-LID mapping'
 						)
-
-						// If latestLid differs from assignedLid, this is a LID refresh/migration
-						if (mapping.latestLid && mapping.latestLid !== mapping.assignedLid) {
-							logger.info(
-								{
-									pn,
-									oldLid: `${mapping.assignedLid}@lid`,
-									newLid: lid
-								},
-								'LID refresh detected - updated to latest LID'
-							)
-						}
 					}
 				}
 			} catch (error) {

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -810,6 +810,57 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			ev.emit('chats.phoneNumberShare', { lid: node.attrs.from!, jid: node.attrs.sender_pn })
 		}
 
+		if (msg.message?.protocolMessage?.lidMigrationMappingSyncMessage?.encodedMappingPayload) {
+			try {
+				const payload = msg.message.protocolMessage.lidMigrationMappingSyncMessage.encodedMappingPayload
+				const decoded = proto.LIDMigrationMappingSyncPayload.decode(payload)
+
+				logger.debug(
+					{
+						mappingCount: decoded.pnToLidMappings?.length || 0,
+						timestamp: decoded.chatDbMigrationTimestamp
+					},
+					'Received LID migration sync message from server'
+				)
+
+				const lidMapping = signalRepository.getLIDMappingStore()
+				if (decoded.pnToLidMappings && decoded.pnToLidMappings.length > 0) {
+					for (const mapping of decoded.pnToLidMappings) {
+						const pn = `${mapping.pn}@s.whatsapp.net`
+						// Use latestLid if available, otherwise assignedLid (proper LID refresh)
+						const lidValue = mapping.latestLid || mapping.assignedLid
+						const lid = `${lidValue}@lid`
+
+						await lidMapping.storeLIDPNMapping(lid, pn)
+						logger.debug(
+							{
+								pn,
+								lid,
+								assignedLid: mapping.assignedLid,
+								latestLid: mapping.latestLid,
+								usedLatest: !!mapping.latestLid
+							},
+							'Stored server-provided PN-LID mapping'
+						)
+
+						// If latestLid differs from assignedLid, this is a LID refresh/migration
+						if (mapping.latestLid && mapping.latestLid !== mapping.assignedLid) {
+							logger.info(
+								{
+									pn,
+									oldLid: `${mapping.assignedLid}@lid`,
+									newLid: lid
+								},
+								'LID refresh detected - updated to latest LID'
+							)
+						}
+					}
+				}
+			} catch (error) {
+				logger.error({ error }, 'Failed to process LID migration sync message')
+			}
+		}
+
 		try {
 			await Promise.all([
 				processingMutex.mutex(async () => {

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -503,7 +503,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 					// Delete PN session after successful migration
 					try {
 						await signalRepository.deleteSession(jid)
-						logger.debug({ deletedPNSession: jid }, '🗑️ Deleted PN session after migration')
+						logger.debug({ deletedPNSession: jid }, 'Deleted PN session after migration')
 					} catch (deleteError) {
 						logger.warn({ jid, error: deleteError }, 'Failed to delete PN session')
 					}
@@ -765,7 +765,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 
 						if (isOwnUser && !isExactSenderDevice) {
 							messageToEncrypt = dsmMessage
-							logger.debug({ wireJid, targetUser }, '📱 Using DSM for own device')
+							logger.debug({ wireJid, targetUser }, 'Using DSM for own device')
 						}
 					}
 

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -638,6 +638,25 @@ export const makeSocket = (config: SocketConfig) => {
 		ev.emit('creds.update', { me: { ...authState.creds.me!, lid: node.attrs.lid } })
 
 		ev.emit('connection.update', { connection: 'open' })
+
+		if (node.attrs.lid && authState.creds.me?.id) {
+			const myLID = node.attrs.lid as string // Safe cast since we checked it exists above
+			process.nextTick(async () => {
+				try {
+					const myPN = authState.creds.me!.id
+										
+					// Store our own LID-PN mapping
+					await signalRepository.storeLIDPNMapping(myLID, myPN)
+					
+					// Create LID session for ourselves (whatsmeow pattern)
+					await signalRepository.migrateSession(myPN, myLID)
+					
+					logger.info({ myPN, myLID }, 'Own LID session created successfully')
+				} catch (error) {
+					logger.error({ error, lid: myLID }, 'Failed to create own LID session')
+				}
+			})
+		}
 	})
 
 	ws.on('CB:stream:error', (node: BinaryNode) => {

--- a/src/Types/Auth.ts
+++ b/src/Types/Auth.ts
@@ -72,6 +72,7 @@ export type SignalDataTypeMap = {
 	'sender-key-memory': { [jid: string]: boolean }
 	'app-state-sync-key': proto.Message.IAppStateSyncKeyData
 	'app-state-sync-version': LTHashState
+	'lid-mapping': string
 }
 
 export type SignalDataSet = { [T in keyof SignalDataTypeMap]?: { [id: string]: SignalDataTypeMap[T] | null } }

--- a/src/Types/Signal.ts
+++ b/src/Types/Signal.ts
@@ -1,4 +1,5 @@
 import { proto } from '../../WAProto/index.js'
+import type { LIDMappingStore } from '../Signal/lid-mapping'
 
 type DecryptGroupSignalOpts = {
 	group: string
@@ -19,6 +20,12 @@ type DecryptSignalProtoOpts = {
 
 type EncryptMessageOpts = {
 	jid: string
+	data: Uint8Array
+}
+
+type EncryptMessageWithWireOpts = {
+	encryptionJid: string // JID used for session lookup (LID)
+	wireJid: string // JID used for envelope (PN)
 	data: Uint8Array
 }
 
@@ -57,10 +64,23 @@ export type SignalRepository = {
 		type: 'pkmsg' | 'msg'
 		ciphertext: Uint8Array
 	}>
+	encryptMessageWithWire(opts: EncryptMessageWithWireOpts): Promise<{
+		type: 'pkmsg' | 'msg'
+		ciphertext: Uint8Array
+		wireJid: string // Return the wire JID for envelope
+	}>
 	encryptGroupMessage(opts: EncryptGroupMessageOpts): Promise<{
 		senderKeyDistributionMessage: Uint8Array
 		ciphertext: Uint8Array
 	}>
 	injectE2ESession(opts: E2ESessionOpts): Promise<void>
 	jidToSignalProtocolAddress(jid: string): string
+	storeLIDPNMapping(lid: string, pn: string): Promise<void>
+	getLIDMappingStore(): LIDMappingStore
+	migrateSession(fromJid: string, toJid: string): Promise<void>
+	validateSession(jid: string): Promise<{ exists: boolean; reason?: string }>
+	shouldRecreateSession(jid: string, retryCount: number): { shouldRecreate: boolean; reason: string }
+	recreateSession(jid: string, reason?: string): Promise<void>
+	deleteSession(jid: string): Promise<void>
+	destroy(): void
 }

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -10,10 +10,50 @@ import {
 	isJidNewsletter,
 	isJidStatusBroadcast,
 	isJidUser,
-	isLidUser
+	isLidUser,
+	jidDecode,
+	jidEncode,
+	jidNormalizedUser
 } from '../WABinary'
 import { unpadRandomMax16 } from './generics'
 import type { ILogger } from './logger'
+
+const getDecryptionJid = async (sender: string, repository: SignalRepository): Promise<string> => {
+	if (!sender.includes('@s.whatsapp.net')) {
+		return sender
+	}
+
+	const lidMapping = repository.getLIDMappingStore()
+	const normalizedSender = jidNormalizedUser(sender)
+	const lidForPN = await lidMapping.getLIDForPN(normalizedSender)
+
+	if (lidForPN?.includes('@lid')) {
+		const senderDecoded = jidDecode(sender)
+		const deviceId = senderDecoded?.device || 0
+		return jidEncode(jidDecode(lidForPN)!.user, 'lid', deviceId)
+	}
+
+	return sender
+}
+
+const storeMappingFromEnvelope = async (
+	stanza: BinaryNode,
+	sender: string,
+	decryptionJid: string,
+	repository: SignalRepository,
+	logger: ILogger
+): Promise<void> => {
+	const { senderAlt } = extractAddressingContext(stanza, sender)
+
+	if (senderAlt && isLidUser(senderAlt) && isJidUser(sender) && decryptionJid === sender) {
+		try {
+			await repository.storeLIDPNMapping(senderAlt, sender)
+			logger.debug({ sender, senderAlt }, 'Stored LID mapping from envelope')
+		} catch (error) {
+			logger.warn({ sender, senderAlt, error }, 'Failed to store LID mapping')
+		}
+	}
+}
 
 export const NO_MESSAGE_FOUND_ERROR_TEXT = 'Message absent from node'
 export const MISSING_KEYS_ERROR_TEXT = 'Key used already or never filled'
@@ -42,6 +82,28 @@ type MessageType =
 	| 'direct_peer_status'
 	| 'other_status'
 	| 'newsletter'
+
+export const extractAddressingContext = (stanza: BinaryNode, _from: string, _participant?: string) => {
+	const addressingMode = stanza.attrs.addressing_mode || 'pn'
+	let senderAlt: string | undefined
+	let recipientAlt: string | undefined
+	
+	if (addressingMode === 'lid') {
+		// Message is LID-addressed: sender is LID, extract corresponding PN
+		senderAlt = stanza.attrs.participant_pn || stanza.attrs.sender_pn
+		recipientAlt = stanza.attrs.recipient_pn
+	} else {
+		// Message is PN-addressed: sender is PN, extract corresponding LID
+		senderAlt = stanza.attrs.participant_lid || stanza.attrs.sender_lid
+		recipientAlt = stanza.attrs.recipient_lid
+	}
+	
+	return {
+		addressingMode,
+		senderAlt,
+		recipientAlt
+	}
+}
 
 /**
  * Decode the received node as a message.
@@ -187,11 +249,15 @@ export const decryptMessageNode = (
 							case 'pkmsg':
 							case 'msg':
 								const user = isJidUser(sender) ? sender : author
+								const decryptionJid = await getDecryptionJid(user, repository)
+								
 								msgBuffer = await repository.decryptMessage({
-									jid: user,
+									jid: decryptionJid,
 									type: e2eType,
 									ciphertext: content
 								})
+								
+								await storeMappingFromEnvelope(stanza, user, decryptionJid, repository, logger)
 								break
 							case 'plaintext':
 								msgBuffer = content


### PR DESCRIPTION
(Note: I know that purp is already working on this, but I 'm sharing my implementation to help in some way)

Implements comprehensive LID migration support for WhatsApp's transition from Phone Number to Line ID addressing. Maintains **LID single source of truth** at encryption level while preserving wire format flexibility.

## Key Features

- **LID Mapping Store**: Bidirectional PN ↔ LID mapping with device preservation
- **Automatic Session Migration**: Seamless PN → LID migration during encryption
- **Smart Message Handling**: Transparent mixed PN/LID conversation support
- **Envelope Discovery**: LID mapping extraction from message attributes
- **Production Safety**: Atomic transactions, LRU cache, comprehensive error handling

## Architecture

```
Wire JID (envelope) ≠ Encryption JID (session)
```

This separation enables the same LID encryption session regardless of wire format.


## Implementation Flow

1. **Discovery**: Extract LID mappings from message envelopes
2. **Migration**: Atomic PN → LID session migration during encryption
3. **Deduplication**: LRU cache prevents duplicate operations (5min TTL)
4. **Fallback**: Graceful degradation to PN when LID unavailable


## Testing Checklist:

- PN ↔ LID message flow in both directions
- Mixed addressing in group conversations  
- Session migration atomicity and rollback
- Device-specific JID preservation
- Concurrent migration handling
- Storage corruption recovery