### PR TITLE
Fix: prevent zero padding in writeRandomPadMax16 causing message delivery failures

### DIFF
--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -70,12 +70,9 @@ export const getKeyAuthor = (key: proto.IMessageKey | undefined | null, meId = '
 
 export const writeRandomPadMax16 = (msg: Uint8Array) => {
 	const pad = randomBytes(1)
-	pad[0]! &= 0xf
-	if (!pad[0]) {
-		pad[0] = 0xf
-	}
+	const padLength = (pad[0]! & 0x0f) + 1
 
-	return Buffer.concat([msg, Buffer.alloc(pad[0], pad[0])])
+	return Buffer.concat([msg, Buffer.alloc(padLength, padLength)])
 }
 
 export const unpadRandomMax16 = (e: Uint8Array | Buffer) => {

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -70,10 +70,8 @@ export const getKeyAuthor = (key: proto.IMessageKey | undefined | null, meId = '
 
 export const writeRandomPadMax16 = (msg: Uint8Array) => {
 	const pad = randomBytes(1)
-
-	if (pad[0]) {
-		pad[0] &= 0xf
-	} else {
+	pad[0]! &= 0xf
+	if (!pad[0]) {
 		pad[0] = 0xf
 	}
 


### PR DESCRIPTION
The current padding logic in `writeRandomPadMax16` checks the original random byte before applying the mask, which can result in zero padding values that violate the Signal protocol specification and cause message delivery failures.

## Problem Analysis
When a random byte like `0x10`, `0x20`, `0x30`, etc. is generated:
1. Original value is non-zero, so we apply the mask: `0x10 & 0xf = 0x00`
2. This results in zero padding, which violates Signal protocol requirements (padding must be 1-16 bytes)
3. Recipients reject messages with invalid padding, leading to delivery failures

This affects approximately 6.25% of messages (16 out of 256 possible random byte values).

## Solution
Reorder the operations to mask first, then validate:
- Apply mask to get value in range 0-15
- Add +1
- This ensures padding is always in the valid range of 1-16 bytes

## Impact
- Eliminates random message delivery failures
- Ensures Signal protocol compliance

Fixes intermittent message delivery issues reported in production.