### PR TITLE
fix: handle invalid signatureKeyPublic types in sender-key-state AND fix handling chain key objects for skmsg group message decryption

### DIFF
--- a/src/Signal/Group/sender-chain-key.ts
+++ b/src/Signal/Group/sender-chain-key.ts
@@ -10,12 +10,14 @@ export class SenderChainKey {
 
 	constructor(iteration: number, chainKey: any) {
 		this.iteration = iteration
-		if (chainKey instanceof Buffer) {
+		if (Buffer.isBuffer(chainKey)) {
 			this.chainKey = chainKey
 		} else if (chainKey instanceof Uint8Array) {
 			this.chainKey = Buffer.from(chainKey)
+		} else if (chainKey && typeof chainKey === 'object') {
+			this.chainKey = Buffer.from(Object.values(chainKey))
 		} else {
-			this.chainKey = Buffer.from(chainKey || [])
+			this.chainKey = Buffer.alloc(0)
 		}
 	}
 

--- a/src/Signal/Group/sender-key-state.ts
+++ b/src/Signal/Group/sender-key-state.ts
@@ -59,8 +59,8 @@ export class SenderKeyState {
 				public:
 					typeof signatureKeyPublic === 'string'
 						? Buffer.from(signatureKeyPublic, 'base64')
-						: Buffer.isBuffer(signatureKeyPublic)
-							? signatureKeyPublic
+						: signatureKeyPublic instanceof Uint8Array
+							? Buffer.from(signatureKeyPublic)
 							: Buffer.alloc(0)
 			}
 

--- a/src/Signal/Group/sender-key-state.ts
+++ b/src/Signal/Group/sender-key-state.ts
@@ -59,7 +59,9 @@ export class SenderKeyState {
 				public:
 					typeof signatureKeyPublic === 'string'
 						? Buffer.from(signatureKeyPublic, 'base64')
-						: signatureKeyPublic || Buffer.alloc(0)
+						: Buffer.isBuffer(signatureKeyPublic)
+							? signatureKeyPublic
+							: Buffer.alloc(0)
 			}
 
 			if (signatureKeyPrivate) {

--- a/src/Signal/Group/sender-key-state.ts
+++ b/src/Signal/Group/sender-key-state.ts
@@ -96,16 +96,29 @@ export class SenderKeyState {
 	}
 
 	public getSigningKeyPublic(): Buffer {
-		const publicKey = this.senderKeyStateStructure.senderSigningKey.public
-		if (publicKey instanceof Buffer) {
-			return publicKey
-		} else if (publicKey instanceof Uint8Array) {
-			return Buffer.from(publicKey)
-		} else if (typeof publicKey === 'string') {
-			return Buffer.from(publicKey, 'base64')
+		let key = this.senderKeyStateStructure.senderSigningKey.public
+
+		// normalize into Buffer
+		if (!(key instanceof Buffer)) {
+			if (key instanceof Uint8Array) {
+				key = Buffer.from(key)
+			} else if (typeof key === 'string') {
+				key = Buffer.from(key, 'base64')
+			} else {
+				key = Buffer.from(key || [])
+			}
 		}
 
-		return Buffer.from(publicKey || [])
+		const publicKey = key as Buffer
+
+		if (publicKey.length === 32) {
+			const fixed = Buffer.alloc(33)
+			fixed[0] = 0x05
+			publicKey.copy(fixed, 1)
+			return fixed
+		}
+
+		return publicKey
 	}
 
 	public getSigningKeyPrivate(): Buffer | undefined {

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1159,11 +1159,11 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			const altServer = jidDecode(alt)?.server
 			const lidMapping = signalRepository.getLIDMappingStore()
 			if (altServer === 'lid') {
-				if (typeof await lidMapping.getPNForLID(alt) == "string") {
+				if (typeof (await lidMapping.getPNForLID(alt)) === 'string') {
 					await lidMapping.storeLIDPNMapping(alt, msg.key.participant || msg.key.remoteJid!)
 				}
 			} else {
-				if (typeof await lidMapping.getLIDForPN(alt) == "string") {
+				if (typeof (await lidMapping.getLIDForPN(alt)) === 'string') {
 					await lidMapping.storeLIDPNMapping(msg.key.participant || msg.key.remoteJid!, alt)
 				}
 			}


### PR DESCRIPTION
**first fix**
- added extra check to ensure signatureKeyPublic is either a base64 string or a Buffer
- fallback to empty buffer when unexpected object type is received
- prevents ERR_INVALID_ARG_TYPE error in Buffer.from

**second fix**
previously, some sender chain keys were stored or retrieved as plain objects
(e.g. { '0': 85, '1': 100, ... }) instead of Buffers. this caused
"ERR_INVALID_ARG_TYPE" during initial decryption of skmsg group messages.

fix ensures any chain key object is converted to a proper Buffer
before being passed to SenderChainKey.

**little extra detail lol**

before using this PR set your logger level to debug/warn, you'll notice for every group message you receive would have 2 errors caused by unparsed raw objects that weren't usable buffers or Unit8Array, and because of it they would be a little delay in decrypting group messages