### PR TITLE
Feat: Fetch all groups from a community given a JID

### DIFF
--- a/src/Socket/communities.ts
+++ b/src/Socket/communities.ts
@@ -211,6 +211,46 @@ export const makeCommunitiesSocket = (config: SocketConfig) => {
 				}
 			])
 		},
+		communityFetchLinkedGroups: async (jid: string) => {
+			let communityJid = jid
+			let isCommunity = false
+
+			// Try to determine if it is a subgroup or a community
+			const metadata = await sock.groupMetadata(jid)
+			if (metadata.linkedParent) {
+				// It is a subgroup, get the community jid
+				communityJid = metadata.linkedParent
+			} else {
+				// It is a community
+				isCommunity = true
+			}
+
+			// Fetch all subgroups of the community
+			const result = await communityQuery(communityJid, 'get', [
+				{ tag: 'sub_groups', attrs: {} }
+			])
+
+			const linkedGroupsData = []
+			const subGroupsNode = getBinaryNodeChild(result, 'sub_groups')
+			if (subGroupsNode) {
+				const groupNodes = getBinaryNodeChildren(subGroupsNode, 'group')
+				for (const groupNode of groupNodes) {
+					linkedGroupsData.push({
+						id: groupNode.attrs.id ? jidEncode(groupNode.attrs.id, 'g.us') : undefined,
+						subject: groupNode.attrs.subject || '',
+						creation: groupNode.attrs.creation ? Number(groupNode.attrs.creation) : undefined,
+						owner: groupNode.attrs.creator ? jidNormalizedUser(groupNode.attrs.creator) : undefined,
+						size: groupNode.attrs.size ? Number(groupNode.attrs.size) : undefined,
+					})
+				}
+			}
+
+			return {
+				communityJid,
+				isCommunity,
+				linkedGroups: linkedGroupsData
+			}
+		},
 		communityRequestParticipantsList: async (jid: string) => {
 			const result = await communityQuery(jid, 'get', [
 				{

--- a/src/Socket/communities.ts
+++ b/src/Socket/communities.ts
@@ -226,9 +226,7 @@ export const makeCommunitiesSocket = (config: SocketConfig) => {
 			}
 
 			// Fetch all subgroups of the community
-			const result = await communityQuery(communityJid, 'get', [
-				{ tag: 'sub_groups', attrs: {} }
-			])
+			const result = await communityQuery(communityJid, 'get', [{ tag: 'sub_groups', attrs: {} }])
 
 			const linkedGroupsData = []
 			const subGroupsNode = getBinaryNodeChild(result, 'sub_groups')
@@ -240,7 +238,7 @@ export const makeCommunitiesSocket = (config: SocketConfig) => {
 						subject: groupNode.attrs.subject || '',
 						creation: groupNode.attrs.creation ? Number(groupNode.attrs.creation) : undefined,
 						owner: groupNode.attrs.creator ? jidNormalizedUser(groupNode.attrs.creator) : undefined,
-						size: groupNode.attrs.size ? Number(groupNode.attrs.size) : undefined,
+						size: groupNode.attrs.size ? Number(groupNode.attrs.size) : undefined
 					})
 				}
 			}

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1159,11 +1159,11 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			const altServer = jidDecode(alt)?.server
 			const lidMapping = signalRepository.getLIDMappingStore()
 			if (altServer === 'lid') {
-				if (typeof (await lidMapping.getPNForLID(alt)) == 'string') {
+				if (typeof (await lidMapping.getPNForLID(alt)) === 'string') {
 					await lidMapping.storeLIDPNMapping(alt, msg.key.participant || msg.key.remoteJid!)
 				}
 			} else {
-				if (typeof (await lidMapping.getLIDForPN(alt)) == 'string') {
+				if (typeof (await lidMapping.getLIDForPN(alt)) === 'string') {
 					await lidMapping.storeLIDPNMapping(msg.key.participant || msg.key.remoteJid!, alt)
 				}
 			}

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1159,11 +1159,11 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			const altServer = jidDecode(alt)?.server
 			const lidMapping = signalRepository.getLIDMappingStore()
 			if (altServer === 'lid') {
-				if (typeof await lidMapping.getPNForLID(alt) == "string") {
+				if (typeof (await lidMapping.getPNForLID(alt)) == 'string') {
 					await lidMapping.storeLIDPNMapping(alt, msg.key.participant || msg.key.remoteJid!)
 				}
 			} else {
-				if (typeof await lidMapping.getLIDForPN(alt) == "string") {
+				if (typeof (await lidMapping.getLIDForPN(alt)) == 'string') {
 					await lidMapping.storeLIDPNMapping(msg.key.participant || msg.key.remoteJid!, alt)
 				}
 			}


### PR DESCRIPTION
This PR introduces the new sock `communityFetchLinkedGroups` function, designed to fetch all linked groups from a WhatsApp community.

* **New Function:** Adds the `communityFetchLinkedGroups(jid)` function.
* **Flexible Input:** It accepts a `jid` that can belong to either the parent community or any of its subgroups.
* **Output:** Regardless of the input `jid`, the function identifies the parent community and returns the complete list of all associated groups.
