### PR TITLE
fix: fallback addressing_mode detection by sender suffix

### DIFF
--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -83,7 +83,7 @@ export const extractAddressingContext = (stanza: BinaryNode) => {
 	let recipientAlt: string | undefined
 
 	const sender = stanza.attrs.participant || stanza.attrs.from
-	const addressingMode = stanza.attrs.addressing_mode || (sender?.endsWith('lid') ? 'lid' : 'pn');
+	const addressingMode = stanza.attrs.addressing_mode || (sender?.endsWith('lid') ? 'lid' : 'pn')
 
 	if (addressingMode === 'lid') {
 		// Message is LID-addressed: sender is LID, extract corresponding PN


### PR DESCRIPTION
This commit is required because `remoteJidAlt` was not appearing. The issue happened since `addressing_mode` always defaulted to 'pn' when the ID was not a group, so the 'lid' path was never taken.