### PR TITLE
fix: convert from object on getMediaKeys to avoid decryption error

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -104,6 +104,10 @@ export async function getMediaKeys(
 		buffer = Buffer.from(buffer.replace('data:;base64,', ''), 'base64')
 	}
 
+	if (typeof buffer === 'object') {
+		buffer = Buffer.from(Object.values(buffer))
+	}
+
 	// expand using HKDF to 112 bytes, also pass in the relevant app info
 	const expandedMediaKey = await hkdf(buffer, 112, { info: hkdfInfoKey(mediaType) })
 	return {


### PR DESCRIPTION
This PR makes sure we prevent decryption fails from the messages media utils (DownloadContentFromMessage) when the mediaKey is an object and properly convert to a Buffer