### PR TITLE
fix: duplicate lid chat

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -53,7 +53,8 @@ import {
 	isLidUser,
 	jidDecode,
 	jidNormalizedUser,
-	S_WHATSAPP_NET
+	S_WHATSAPP_NET,
+	swapLidJidAttrs
 } from '../WABinary'
 import { extractGroupMetadata } from './groups'
 import { makeMessagesSocket } from './messages-send'
@@ -1450,6 +1451,9 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		identifier: string,
 		exec: (node: BinaryNode) => Promise<void>
 	) => {
+
+		swapLidJidAttrs(node.attrs)
+
 		const isOffline = !!node.attrs.offline
 
 		if (isOffline) {

--- a/src/WABinary/jid-utils.ts
+++ b/src/WABinary/jid-utils.ts
@@ -79,3 +79,32 @@ export const transferDevice = (fromJid: string, toJid: string) => {
 	const { server, user } = jidDecode(toJid)!
 	return jidEncode(user, server, deviceId)
 }
+
+/**
+ * Swaps LID (Linked ID) JID attributes in the provided attributes object.
+ *
+ * - If the `from` attribute ends with '@lid' and `sender_pn` exists,
+ *   it moves the LID JID to `sender_lid`, replaces `from` with `sender_pn`
+ * - If the `recipient` attribute ends with '@lid', `peer_recipient_pn` exists,
+ *   and `peer_recipient_pn` does not end with '@lid', it moves the LID JID to `peer_recipient_lid`,
+ *   replaces `recipient` with `peer_recipient_pn`
+ *
+ * @param attrs - The attributes object containing JID fields to be swapped.
+ */
+export const swapLidJidAttrs = (attrs: Record<string, string>) => {
+	if(
+		attrs.from?.endsWith('@lid') && attrs.sender_pn
+	) {
+		attrs['sender_lid'] = attrs.from
+		attrs.from = attrs.sender_pn
+	}
+
+	if (
+		attrs.recipient?.endsWith('@lid') &&
+		attrs.peer_recipient_pn &&
+		!attrs.peer_recipient_pn.endsWith?.('@lid')
+	) {
+		attrs['peer_recipient_lid'] = attrs.recipient
+		attrs.recipient = attrs.peer_recipient_pn
+	}
+}


### PR DESCRIPTION
Addresses Issue #1768: Lid related 


When a new messsage comes in, sometimes Whatsapp will just give us the event with the Lid in the `from` field.
In such an event, if the sender_pn exists, we can swap it with the Jid to ensure incoming events follow a uniform jid pattern