### PR TITLE
fix makeCacheableSignalKeyStore await cache get

### DIFF
--- a/src/Utils/auth-utils.ts
+++ b/src/Utils/auth-utils.ts
@@ -48,7 +48,7 @@ export function makeCacheableSignalKeyStore(
 				const data: { [_: string]: SignalDataTypeMap[typeof type] } = {}
 				const idsToFetch: string[] = []
 				for (const id of ids) {
-					const item = cache.get<SignalDataTypeMap[typeof type]>(getUniqueId(type, id)) as any
+					const item = await cache.get<SignalDataTypeMap[typeof type]>(getUniqueId(type, id)) as any
 					if (typeof item !== 'undefined') {
 						data[id] = item
 					} else {


### PR DESCRIPTION
When using a custom implementation of CacheStore on makeCacheableSignalKeyStore, the cache "get" calls not using await.

Just add the "await" fix the problem, without problems with default NodeCache implementation.