### PR TITLE
Fix: groups pn messages-send

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -362,7 +362,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		const uniqueJids = [...new Set(jids)] // Deduplicate JIDs
 		const jidsRequiringFetch: string[] = []
 
-		// Check peerSessionsCache and authState.keys
+		// Check peerSessionsCache and validate sessions using libsignal loadSession
 		for (const jid of uniqueJids) {
 			const signalId = signalRepository.jidToSignalProtocolAddress(jid)
 			const cachedSession = peerSessionsCache.get(signalId)
@@ -371,8 +371,8 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 					continue // Session exists in cache
 				}
 			} else {
-				const sessions = await authState.keys.get('session', [signalId])
-				const hasSession = !!sessions[signalId]
+				const sessionValidation = await signalRepository.validateSession(jid)
+				const hasSession = sessionValidation.exists
 				peerSessionsCache.set(signalId, hasSession)
 				if (hasSession) {
 					continue

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -383,7 +383,6 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		}
 
 		if (jidsRequiringFetch.length) {
-			
 			// LID if mapped, otherwise original
 			const wireJids = await Promise.all(
 				jidsRequiringFetch.map(async jid => {
@@ -391,6 +390,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 						const lid = await signalRepository.lidMapping.getLIDForPN(jid)
 						return lid ? lid : jid
 					}
+
 					return jid
 				})
 			)


### PR DESCRIPTION
This remove all the wireJid from messages-send and let libsignal.ts handle it, fixing the addressing in binary attrs.