### PR TITLE
fix: set duplex property when uploading media to server

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -674,6 +674,7 @@ export const getWAUploadToServer = (
 						'Content-Type': 'application/octet-stream',
 						Origin: DEFAULT_ORIGIN
 					},
+					duplex: 'half',
 					// Note: custom agents/proxy require undici Agent; omitted here.
 					signal: timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined
 				})


### PR DESCRIPTION
As of Node v18+, [`duplex` is required to be set if the body is a `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#duplex). Uploading media to WhatsApp gives this error if `duplex` is not set:
```
TypeError: RequestInit: duplex option is required when sending a body
```