### PR TITLE
Update messages-recv.ts

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -375,7 +375,10 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 
 		logger.debug({ recv: { tag, attrs }, sent: stanza.attrs }, 'sent ack')
-		await sendNode(stanza)
+		await ackSendMutex.mutex(async () => {
+			await applyAckRateLimit()
+			await sendNode(stanza)
+		})
 	}
 
 	const rejectCall = async (callId: string, callFrom: string) => {


### PR DESCRIPTION
Added a shared mutex and sliding-window rate limiter before dispatching ack stanzas so they’re serialized and throttled, reducing the risk of WhatsApp returning rate-limit errors in large-group traffic.