### PR TITLE
Fix fetchLatestWaWebVersion to bypass WhatsApp anti-bot detection with minimal headers

### DIFF
--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -66,6 +66,7 @@ export const makeGroupsSocket = (config: SocketConfig) => {
 				data[meta.id] = meta
 			}
 		}
+
 		// TODO: properly parse LID / PN DATA
 		sock.ev.emit('groups.update', Object.values(data))
 

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -699,7 +699,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				for (const device of devices) {
 					const deviceJid = device.jid
 					const hasKey = !!senderKeyMap[deviceJid]
-					if ((!hasKey || !!participant ) && !isJidHostedLidUser(deviceJid) && !isJidHostedPnUser(deviceJid)) {
+					if ((!hasKey || !!participant) && !isJidHostedLidUser(deviceJid) && !isJidHostedPnUser(deviceJid)) {
 						//todo: revamp all this logic
 						// the goal is to follow with what I said above for each group, and instead of a true false map of ids, we can set an array full of those the app has already sent pkmsgs
 						senderKeyRecipients.push(deviceJid)

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -272,29 +272,28 @@ export const fetchLatestBaileysVersion = async (options: RequestInit = {}) => {
  * A utility that fetches the latest web version of whatsapp.
  * Use to ensure your WA connection is always on the latest version
  */
-export const fetchLatestWaWebVersion = async () => {
+export const fetchLatestWaWebVersion = async (options: RequestInit = {}) => {
 	try {
-		let data: string
-
-		try {
-			const { execSync } = await import('child_process')
-			data = execSync('curl -s https://web.whatsapp.com/sw.js', {
-				encoding: 'utf8',
-				timeout: 10000
-			})
-		} catch (error: any) {
-			const errorMsg =
-				error?.code === 'ENOENT'
-					? 'curl command not found, please install curl'
-					: error?.killed
-						? 'Request timeout while fetching sw.js'
-						: `Failed to fetch sw.js: ${error?.message || 'Unknown error'}`
-
-			throw new Boom(errorMsg, {
-				statusCode: error?.code === 'ENOENT' ? 501 : 500,
-				data: { originalError: error }
-			})
+		// Absolute minimal headers required to bypass anti-bot detection
+		const defaultHeaders = {
+			'sec-fetch-site': 'none',
+			'user-agent':
+				'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
 		}
+
+		const headers = { ...defaultHeaders, ...options.headers }
+
+		const response = await fetch('https://web.whatsapp.com/sw.js', {
+			...options,
+			method: 'GET',
+			headers
+		})
+
+		if (!response.ok) {
+			throw new Boom(`Failed to fetch sw.js: ${response.statusText}`, { statusCode: response.status })
+		}
+
+		const data = await response.text()
 
 		const regex = /\\?"client_revision\\?":\s*(\d+)/
 		const match = data.match(regex)

--- a/src/__tests__/e2e/fetch-wa-web-version.test-e2e.ts
+++ b/src/__tests__/e2e/fetch-wa-web-version.test-e2e.ts
@@ -1,0 +1,60 @@
+import { jest } from '@jest/globals'
+import { fetchLatestWaWebVersion } from '../../Utils/generics'
+
+describe('fetchLatestWaWebVersion Integration Tests', () => {
+	jest.setTimeout(10000)
+
+	it('should successfully fetch the latest WhatsApp Web version from real API', async () => {
+		const result = await fetchLatestWaWebVersion()
+
+		expect(Array.isArray(result.version)).toBe(true)
+		expect(result.version).toHaveLength(3)
+		expect(typeof result.version[0]).toBe('number')
+		expect(typeof result.version[1]).toBe('number')
+		expect(typeof result.version[2]).toBe('number')
+
+		expect(typeof result.isLatest).toBe('boolean')
+
+		if (!result.isLatest) {
+			expect(result.error).toBeDefined()
+		}
+	})
+
+	it('should handle custom headers correctly', async () => {
+		const customHeaders = {
+			accept:
+				'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+			'accept-language': 'en-US,en;q=0.9',
+			'cache-control': 'max-age=0',
+			'sec-ch-prefers-color-scheme': 'dark',
+			'sec-fetch-dest': 'document',
+			'sec-fetch-mode': 'navigate',
+			'sec-fetch-site': 'none',
+			'upgrade-insecure-requests': '1'
+		}
+
+		const result = await fetchLatestWaWebVersion({
+			headers: customHeaders
+		})
+
+		expect(Array.isArray(result.version)).toBe(true)
+		expect(result.version).toHaveLength(3)
+		expect(result.isLatest).toBe(true)
+	})
+
+	it('should fallback gracefully when client_revision is not found', async () => {
+		const result = await fetchLatestWaWebVersion()
+
+		expect(result).toHaveProperty('version')
+		expect(result).toHaveProperty('isLatest')
+		expect(Array.isArray(result.version)).toBe(true)
+	})
+
+	it('should handle network timeouts gracefully', async () => {
+		const result = await fetchLatestWaWebVersion()
+
+		expect(result).toHaveProperty('version')
+		expect(result).toHaveProperty('isLatest')
+		expect(Array.isArray(result.version)).toBe(true)
+	})
+})


### PR DESCRIPTION
```
WA Version:  [ 2, 3000, 1023223821 ] isLatest: false error: Error: Failed to fetch sw.js: Bad Request
    at fetchLatestWaWebVersion (file:///app/node_modules/@whiskeysockets/baileys/lib/Utils/generics.js:223:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /app/dist/libs/wbot.js:164:54 {
  data: null,
  isBoom: true,
  isServer: false,
  output: {
    statusCode: 400,
    payload: {
      statusCode: 400,
      error: 'Bad Request',
      message: 'Failed to fetch sw.js: Bad Request'
    },
    headers: {}
  }
}
```

The fetchLatestWaWebVersion function was failing with "Bad Request" errors due to WhatsApp's anti-bot detection mechanisms. This occurred because the original implementation used minimal headers that made the request appear programmatic.