### PR TITLE
fix: Handle undefined results in USync query parser

### DIFF
--- a/src/WAUSync/USyncQuery.ts
+++ b/src/WAUSync/USyncQuery.ts
@@ -45,8 +45,8 @@ export class USyncQuery {
 		return this
 	}
 
-	parseUSyncQueryResult(result: BinaryNode): USyncQueryResult | undefined {
-		if (result.attrs.type !== 'result') {
+	parseUSyncQueryResult(result: BinaryNode | undefined): USyncQueryResult | undefined {
+		if (!result || result.attrs.type !== 'result') {
 			return
 		}
 
@@ -68,27 +68,32 @@ export class USyncQuery {
 		//TODO: see if there are any errors in the result node
 		//const resultNode = getBinaryNodeChild(usyncNode, 'result')
 
-		const listNode = getBinaryNodeChild(usyncNode, 'list')
-		if (Array.isArray(listNode?.content) && typeof listNode !== 'undefined') {
-			queryResult.list = listNode.content.map(node => {
-				const id = node?.attrs.jid!
-				const data = Array.isArray(node?.content)
-					? Object.fromEntries(
-							node.content
-								.map(content => {
-									const protocol = content.tag
-									const parser = protocolMap[protocol]
-									if (parser) {
-										return [protocol, parser(content)]
-									} else {
-										return [protocol, null]
-									}
-								})
-								.filter(([, b]) => b !== null) as [string, unknown][]
-						)
-					: {}
-				return { ...data, id }
-			})
+		const listNode = usyncNode ? getBinaryNodeChild(usyncNode, 'list') : undefined
+
+		if (listNode?.content && Array.isArray(listNode.content)) {
+			queryResult.list = listNode.content.reduce((acc: USyncQueryResultList[], node) => {
+				const id = node?.attrs.jid
+				if (id) {
+					const data = Array.isArray(node?.content)
+						? Object.fromEntries(
+								node.content
+									.map(content => {
+										const protocol = content.tag
+										const parser = protocolMap[protocol]
+										if (parser) {
+											return [protocol, parser(content)]
+										} else {
+											return [protocol, null]
+										}
+									})
+									.filter(([, b]) => b !== null) as [string, unknown][]
+							)
+						: {}
+					acc.push({ ...data, id })
+				}
+
+				return acc
+			}, [])
 		}
 
 		//TODO: implement side list


### PR DESCRIPTION
This patch addresses the issue by:

- Adding a check to ensure `result` is not `undefined` before processing.
- Updating the function signature to correctly type the `result` parameter as `BinaryNode | undefined`.
- Removing a risky non-null assertion (`!`) on `node.attrs.jid` and replacing it with a safe check, improving overall type safety.


Evict some errors like:
```
Error on sendMediaMessage: TypeError: Cannot read properties of undefined (reading 'attrs')
    at USyncQuery.parseUSyncQueryResult (file:///usr/app/node_modules/baileys/lib/WAUSync/USyncQuery.js:26:20)
    at Object.executeUSyncQuery (file:///usr/app/node_modules/baileys/lib/Socket/socket.js:179:27)
    at async getUSyncDevices (file:///usr/app/node_modules/baileys/lib/Socket/messages-send.js:185:24)
    at async file:///usr/app/node_modules/baileys/lib/Socket/messages-send.js:493:47
    at async file:///usr/app/node_modules/baileys/lib/Utils/auth-utils.js:222:36
```