### PR TITLE
fix: improve error handling and safe checking

### DIFF
--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -1,3 +1,4 @@
+import { Boom } from '@hapi/boom'
 import { proto } from '../../WAProto/index.js'
 import type { GroupMetadata, GroupParticipant, ParticipantAction, SocketConfig, WAMessageKey } from '../Types'
 import { WAMessageAddressingMode, WAMessageStubType } from '../Types'
@@ -301,7 +302,23 @@ export const makeGroupsSocket = (config: SocketConfig) => {
 }
 
 export const extractGroupMetadata = (result: BinaryNode) => {
-	const group = getBinaryNodeChild(result, 'group')!
+	const group = getBinaryNodeChild(result, 'group')
+	if (!group) {
+		// Mirror WAWeb: surface server/client errors with their code+text instead of crashing.
+		const errorNode = getBinaryNodeChild(result, 'error')
+		if (errorNode) {
+			const code = errorNode.attrs.code ? +errorNode.attrs.code : 500
+			const text = errorNode.attrs.text || 'group metadata query failed'
+			throw new Boom(text, { statusCode: code, data: errorNode })
+		}
+
+		throw new Boom('Invalid group metadata response: missing <group> node', { data: result })
+	}
+
+	if (!group.attrs.id) {
+		throw new Boom('Invalid group metadata response: missing group id', { data: group })
+	}
+
 	const descChild = getBinaryNodeChild(group, 'description')
 	let desc: string | undefined
 	let descId: string | undefined
@@ -318,11 +335,11 @@ export const extractGroupMetadata = (result: BinaryNode) => {
 		descId = descChild.attrs.id
 	}
 
-	const groupId = group.attrs.id!.includes('@') ? group.attrs.id : jidEncode(group.attrs.id!, 'g.us')
+	const groupId = group.attrs.id.includes('@') ? group.attrs.id : jidEncode(group.attrs.id, 'g.us')
 	const eph = getBinaryNodeChild(group, 'ephemeral')?.attrs.expiration
 	const memberAddMode = getBinaryNodeChildString(group, 'member_add_mode') === 'all_member_add'
 	const metadata: GroupMetadata = {
-		id: groupId!,
+		id: groupId,
 		notify: group.attrs.notify,
 		addressingMode: group.attrs.addressing_mode === 'lid' ? WAMessageAddressingMode.LID : WAMessageAddressingMode.PN,
 		subject: group.attrs.subject!,

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -15,6 +15,7 @@ import type {
 import {
 	aggregateMessageKeysNotFromMe,
 	assertMediaContent,
+	assertMeId,
 	bindWaitForEvent,
 	decryptMediaRetryData,
 	encodeNewsletterMessage,
@@ -633,7 +634,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 			statusJidList
 		}: MessageRelayOptions
 	) => {
-		const meId = authState.creds.me!.id
+		const meId = assertMeId(authState.creds)
 		const meLid = authState.creds.me?.lid
 		const isRetryResend = Boolean(participant?.jid)
 		let shouldIncludeDeviceIdentity = isRetryResend

--- a/src/Utils/auth-utils.ts
+++ b/src/Utils/auth-utils.ts
@@ -1,4 +1,5 @@
 import NodeCache from '@cacheable/node-cache'
+import { Boom } from '@hapi/boom'
 import { AsyncLocalStorage } from 'async_hooks'
 import { Mutex } from 'async-mutex'
 import { randomBytes } from 'crypto'
@@ -341,6 +342,19 @@ export const addTransactionCapability = (
 			}
 		}
 	}
+}
+
+/**
+ * Returns the authenticated user's JID, or throws a Boom-401 if creds are not yet authenticated.
+ * Use this anywhere we'd otherwise reach for `creds.me!.id` to fail fast with a descriptive error.
+ */
+export const assertMeId = (creds: AuthenticationCreds): string => {
+	const id = creds.me?.id
+	if (!id) {
+		throw new Boom('Cannot proceed: socket is not authenticated yet (creds.me.id is missing)', { statusCode: 401 })
+	}
+
+	return id
 }
 
 export const initAuthCreds = (): AuthenticationCreds => {

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -143,6 +143,14 @@ export function decodeMessageNode(stanza: BinaryNode, meId: string, meLid: strin
 	const participant: string | undefined = stanza.attrs.participant
 	const recipient: string | undefined = stanza.attrs.recipient
 
+	if (!msgId) {
+		throw new Boom('Invalid message stanza: missing id attribute', { data: stanza })
+	}
+
+	if (!from) {
+		throw new Boom('Invalid message stanza: missing from attribute', { data: stanza })
+	}
+
 	const addressingContext = extractAddressingContext(stanza)
 
 	const isMe = (jid: string) => areJidsSameUser(jid, meId)
@@ -150,21 +158,21 @@ export function decodeMessageNode(stanza: BinaryNode, meId: string, meLid: strin
 
 	if (isPnUser(from) || isLidUser(from) || isHostedLidUser(from) || isHostedPnUser(from)) {
 		if (recipient && !isJidMetaAI(recipient)) {
-			if (!isMe(from!) && !isMeLid(from!)) {
+			if (!isMe(from) && !isMeLid(from)) {
 				throw new Boom('receipient present, but msg not from me', { data: stanza })
 			}
 
-			if (isMe(from!) || isMeLid(from!)) {
+			if (isMe(from) || isMeLid(from)) {
 				fromMe = true
 			}
 
 			chatId = recipient
 		} else {
-			chatId = from!
+			chatId = from
 		}
 
 		msgType = 'chat'
-		author = from!
+		author = from
 	} else if (isJidGroup(from)) {
 		if (!participant) {
 			throw new Boom('No participant in group message')
@@ -176,28 +184,28 @@ export function decodeMessageNode(stanza: BinaryNode, meId: string, meLid: strin
 
 		msgType = 'group'
 		author = participant
-		chatId = from!
+		chatId = from
 	} else if (isJidBroadcast(from)) {
 		if (!participant) {
 			throw new Boom('No participant in group message')
 		}
 
 		const isParticipantMe = isMe(participant)
-		if (isJidStatusBroadcast(from!)) {
+		if (isJidStatusBroadcast(from)) {
 			msgType = isParticipantMe ? 'direct_peer_status' : 'other_status'
 		} else {
 			msgType = isParticipantMe ? 'peer_broadcast' : 'other_broadcast'
 		}
 
 		fromMe = isParticipantMe
-		chatId = from!
+		chatId = from
 		author = participant
 	} else if (isJidNewsletter(from)) {
 		msgType = 'newsletter'
-		chatId = from!
-		author = from!
+		chatId = from
+		author = from
 
-		if (isMe(from!) || isMeLid(from!)) {
+		if (isMe(from) || isMeLid(from)) {
 			fromMe = true
 		}
 	} else {

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -1,3 +1,4 @@
+import { Boom } from '@hapi/boom'
 import { proto } from '../../WAProto/index.js'
 import type {
 	AuthenticationCreds,
@@ -187,12 +188,24 @@ export const shouldIncrementChatUnread = (message: WAMessage) => !message.key.fr
  * Get the ID of the chat from the given key.
  * Typically -- that'll be the remoteJid, but for broadcasts, it'll be the participant
  */
-export const getChatId = ({ remoteJid, participant, fromMe }: WAMessageKey) => {
-	if (isJidBroadcast(remoteJid!) && !isJidStatusBroadcast(remoteJid!) && !fromMe) {
-		return participant!
+export const getChatId = ({ remoteJid, participant, fromMe }: WAMessageKey): string => {
+	if (!remoteJid) {
+		throw new Boom('Cannot derive chat id: message key is missing remoteJid', {
+			data: { remoteJid, participant, fromMe }
+		})
 	}
 
-	return remoteJid!
+	if (isJidBroadcast(remoteJid) && !isJidStatusBroadcast(remoteJid) && !fromMe) {
+		if (!participant) {
+			throw new Boom('Cannot derive chat id: broadcast message key is missing participant', {
+				data: { remoteJid, fromMe }
+			})
+		}
+
+		return participant
+	}
+
+	return remoteJid
 }
 
 type PollContext = {

--- a/src/__tests__/Socket/groups.test.ts
+++ b/src/__tests__/Socket/groups.test.ts
@@ -1,0 +1,93 @@
+import { Boom } from '@hapi/boom'
+import { extractGroupMetadata } from '../../Socket/groups'
+import type { BinaryNode } from '../../WABinary'
+
+const minimalGroupNode = (overrides: Partial<BinaryNode['attrs']> = {}): BinaryNode => ({
+	tag: 'group',
+	attrs: {
+		id: '120363000000000000',
+		creation: '1700000000',
+		s_t: '1700000000',
+		subject: 'Test Group',
+		...overrides
+	},
+	content: []
+})
+
+describe('extractGroupMetadata', () => {
+	it('parses a valid <group> node', () => {
+		const result: BinaryNode = {
+			tag: 'iq',
+			attrs: { type: 'result' },
+			content: [minimalGroupNode()]
+		}
+
+		const meta = extractGroupMetadata(result)
+
+		expect(meta.id).toBe('120363000000000000@g.us')
+		expect(meta.subject).toBe('Test Group')
+	})
+
+	it('keeps the @-suffix when group id already contains it', () => {
+		const result: BinaryNode = {
+			tag: 'iq',
+			attrs: { type: 'result' },
+			content: [minimalGroupNode({ id: '120363000000000000@g.us' })]
+		}
+
+		expect(extractGroupMetadata(result).id).toBe('120363000000000000@g.us')
+	})
+
+	it('throws Boom with the server <error> code+text when no <group> is present', () => {
+		const result: BinaryNode = {
+			tag: 'iq',
+			attrs: { type: 'error' },
+			content: [
+				{
+					tag: 'error',
+					attrs: { code: '403', text: 'forbidden' }
+				}
+			]
+		}
+
+		const captured = captureThrow(() => extractGroupMetadata(result))
+		expect(captured).toBeInstanceOf(Boom)
+		expect((captured as Boom).output.statusCode).toBe(403)
+		expect((captured as Error).message).toBe('forbidden')
+	})
+
+	it('falls back to a generic Boom when neither <group> nor <error> is present', () => {
+		const result: BinaryNode = { tag: 'iq', attrs: { type: 'result' }, content: [] }
+
+		expect(() => extractGroupMetadata(result)).toThrow(/missing <group>/)
+	})
+
+	it('throws when the <group> node lacks an id', () => {
+		const group = minimalGroupNode()
+		delete (group.attrs as Record<string, string>).id
+		const result: BinaryNode = { tag: 'iq', attrs: { type: 'result' }, content: [group] }
+
+		expect(() => extractGroupMetadata(result)).toThrow(/missing group id/)
+	})
+
+	it('uses default code 500 when <error> has no code attribute', () => {
+		const result: BinaryNode = {
+			tag: 'iq',
+			attrs: { type: 'error' },
+			content: [{ tag: 'error', attrs: {} }]
+		}
+
+		const captured = captureThrow(() => extractGroupMetadata(result))
+		expect((captured as Boom).output.statusCode).toBe(500)
+	})
+})
+
+const captureThrow = (fn: () => unknown): unknown => {
+	try {
+		fn()
+	} catch (err) {
+		return err
+	}
+
+	throw new Error('expected function to throw')
+}

--- a/src/__tests__/Utils/auth-utils.test.ts
+++ b/src/__tests__/Utils/auth-utils.test.ts
@@ -1,0 +1,37 @@
+import { Boom } from '@hapi/boom'
+import type { AuthenticationCreds, Contact } from '../../Types'
+import { assertMeId, initAuthCreds } from '../../Utils/auth-utils'
+
+const credsWithMe = (me?: Partial<Contact>): AuthenticationCreds => ({
+	...initAuthCreds(),
+	me: me as Contact | undefined
+})
+
+describe('assertMeId', () => {
+	it('returns me.id when authenticated', () => {
+		const creds = credsWithMe({ id: '5511999999999@s.whatsapp.net' })
+		expect(assertMeId(creds)).toBe('5511999999999@s.whatsapp.net')
+	})
+
+	it('throws Boom 401 when creds.me is undefined', () => {
+		const creds = credsWithMe(undefined)
+		try {
+			assertMeId(creds)
+			throw new Error('expected throw')
+		} catch (err) {
+			expect(err).toBeInstanceOf(Boom)
+			expect((err as Boom).output.statusCode).toBe(401)
+			expect((err as Error).message).toMatch(/not authenticated/)
+		}
+	})
+
+	it('throws Boom 401 when me has no id', () => {
+		const creds = credsWithMe({})
+		expect(() => assertMeId(creds)).toThrow(/not authenticated/)
+	})
+
+	it('throws Boom 401 when me.id is empty string', () => {
+		const creds = credsWithMe({ id: '' })
+		expect(() => assertMeId(creds)).toThrow(/not authenticated/)
+	})
+})

--- a/src/__tests__/Utils/decode-wa-message.test.ts
+++ b/src/__tests__/Utils/decode-wa-message.test.ts
@@ -1,0 +1,86 @@
+import { Boom } from '@hapi/boom'
+import { decodeMessageNode } from '../../Utils/decode-wa-message'
+import type { BinaryNode } from '../../WABinary'
+
+const ME_ID = '5511999999999@s.whatsapp.net'
+const ME_LID = '111111111111111@lid'
+const PEER_ID = '5511888888888@s.whatsapp.net'
+const GROUP_ID = '120363000000000000@g.us'
+
+const message = (attrs: Record<string, string>): BinaryNode => ({
+	tag: 'message',
+	attrs: { t: '1700000000', ...attrs },
+	content: []
+})
+
+const captureThrow = (fn: () => unknown): unknown => {
+	try {
+		fn()
+	} catch (err) {
+		return err
+	}
+
+	throw new Error('expected function to throw')
+}
+
+describe('decodeMessageNode', () => {
+	describe('validation', () => {
+		it('throws Boom when stanza has no id attribute', () => {
+			const stanza = message({ from: PEER_ID })
+			const err = captureThrow(() => decodeMessageNode(stanza, ME_ID, ME_LID))
+			expect(err).toBeInstanceOf(Boom)
+			expect((err as Error).message).toMatch(/missing id/)
+		})
+
+		it('throws Boom when stanza has no from attribute', () => {
+			const stanza = message({ id: 'MSG_1' })
+			const err = captureThrow(() => decodeMessageNode(stanza, ME_ID, ME_LID))
+			expect(err).toBeInstanceOf(Boom)
+			expect((err as Error).message).toMatch(/missing from/)
+		})
+
+		it('throws Boom for an unknown jid type', () => {
+			const stanza = message({ id: 'MSG_1', from: 'unknown@server' })
+			expect(() => decodeMessageNode(stanza, ME_ID, ME_LID)).toThrow(/Unknown message type/)
+		})
+
+		it('throws Boom for group message without participant', () => {
+			const stanza = message({ id: 'MSG_1', from: GROUP_ID })
+			expect(() => decodeMessageNode(stanza, ME_ID, ME_LID)).toThrow(/No participant/)
+		})
+	})
+
+	describe('happy paths', () => {
+		it('decodes a 1:1 incoming chat message', () => {
+			const stanza = message({ id: 'MSG_1', from: PEER_ID })
+			const result = decodeMessageNode(stanza, ME_ID, ME_LID)
+
+			expect(result.fullMessage.key.id).toBe('MSG_1')
+			expect(result.fullMessage.key.remoteJid).toBe(PEER_ID)
+			expect(result.fullMessage.key.fromMe).toBeFalsy()
+			expect(result.author).toBe(PEER_ID)
+		})
+
+		it('decodes an outgoing chat message (recipient set, from = me)', () => {
+			const stanza = message({ id: 'MSG_2', from: ME_ID, recipient: PEER_ID })
+			const result = decodeMessageNode(stanza, ME_ID, ME_LID)
+
+			expect(result.fullMessage.key.fromMe).toBe(true)
+			expect(result.fullMessage.key.remoteJid).toBe(PEER_ID)
+		})
+
+		it('rejects a recipient-tagged message that is not from me', () => {
+			const stanza = message({ id: 'MSG_3', from: PEER_ID, recipient: ME_ID })
+			expect(() => decodeMessageNode(stanza, ME_ID, ME_LID)).toThrow(/not from me/)
+		})
+
+		it('decodes a group message', () => {
+			const stanza = message({ id: 'MSG_G', from: GROUP_ID, participant: PEER_ID })
+			const result = decodeMessageNode(stanza, ME_ID, ME_LID)
+
+			expect(result.fullMessage.key.remoteJid).toBe(GROUP_ID)
+			expect(result.fullMessage.key.participant).toBe(PEER_ID)
+			expect(result.author).toBe(PEER_ID)
+		})
+	})
+})

--- a/src/__tests__/Utils/process-message.test.ts
+++ b/src/__tests__/Utils/process-message.test.ts
@@ -1,5 +1,5 @@
 import type { WAMessage } from '../../Types'
-import { cleanMessage } from '../../Utils/process-message'
+import { cleanMessage, getChatId } from '../../Utils/process-message'
 
 const createBaseMessage = (key: Partial<WAMessage['key']>, message?: Partial<WAMessage['message']>): WAMessage => {
 	return {
@@ -134,5 +134,56 @@ describe('cleanMessage', () => {
 			const message = createBaseMessage({}, {})
 			expect(() => cleanMessage(message, meId, meLid)).not.toThrow()
 		})
+	})
+})
+
+describe('getChatId', () => {
+	it('returns remoteJid for a regular 1:1 chat', () => {
+		expect(getChatId({ remoteJid: 'peer@s.whatsapp.net', fromMe: false, id: 'X' })).toBe('peer@s.whatsapp.net')
+	})
+
+	it('returns remoteJid for a group chat (broadcast check is false)', () => {
+		expect(getChatId({ remoteJid: '120363@g.us', fromMe: false, id: 'X' })).toBe('120363@g.us')
+	})
+
+	it('returns remoteJid for status broadcast (status is special-cased to remoteJid)', () => {
+		expect(
+			getChatId({
+				remoteJid: 'status@broadcast',
+				participant: 'someone@s.whatsapp.net',
+				fromMe: false,
+				id: 'X'
+			})
+		).toBe('status@broadcast')
+	})
+
+	it('returns participant for non-status broadcast received from peer', () => {
+		expect(
+			getChatId({
+				remoteJid: '12345@broadcast',
+				participant: 'sender@s.whatsapp.net',
+				fromMe: false,
+				id: 'X'
+			})
+		).toBe('sender@s.whatsapp.net')
+	})
+
+	it('returns remoteJid for non-status broadcast sent by me', () => {
+		expect(
+			getChatId({
+				remoteJid: '12345@broadcast',
+				participant: 'me@s.whatsapp.net',
+				fromMe: true,
+				id: 'X'
+			})
+		).toBe('12345@broadcast')
+	})
+
+	it('throws when remoteJid is missing', () => {
+		expect(() => getChatId({ fromMe: false, id: 'X' })).toThrow(/missing remoteJid/)
+	})
+
+	it('throws when broadcast key has no participant', () => {
+		expect(() => getChatId({ remoteJid: '12345@broadcast', fromMe: false, id: 'X' })).toThrow(/missing participant/)
 	})
 })


### PR DESCRIPTION
Closes the gaps in #1891 by hardening four spots that previously crashed on malformed/early data, with focused unit tests for each. Scope was rebuilt against current `master` since the original `withAck` refactor became redundant — `handleReceipt`/`handleNotification` already use `try { ... } finally { sendMessageAck(...).catch(...) }` inline, and `handleMessage` now does granular `NACK_REASONS` acks that a single wrapper would flatten.

## Changes

- **`extractGroupMetadata` (`src/Socket/groups.ts`)** — when the IQ result has no `<group>`, detect `<error>` and throw a `Boom` carrying `code` (statusCode) and `text` (message). Also validates `group.attrs.id`. Mirrors WhatsApp Web's `BatchGetGroupInfoResponseClientError/ServerError → ServerStatusCodeError(code, text)` pattern from `Group/QueryJob.js`.
- **`decodeMessageNode` (`src/Utils/decode-wa-message.ts`)** — validate `stanza.attrs.id` and `stanza.attrs.from` up-front; redundant `from!` removed. Aligns with WhatsApp Web's `WADeprecatedWapParser.attrString(...)` mandatory-attribute model.
- **`getChatId` (`src/Utils/process-message.ts`)** — replace `!` with explicit guards; throws a descriptive `Boom` for missing `remoteJid` or for non-status broadcasts missing `participant`. Return type tightened from implicit `string | undefined` to `string`.
- **`assertMeId(creds)` (`src/Utils/auth-utils.ts`)** — new pure helper that throws `Boom 401` when `creds.me?.id` is missing. Used by `relayMessage` to fail fast before authentication completes.

## Tests

- `src/__tests__/Socket/groups.test.ts` — 6 cases (happy path, `<error>` with/without code, missing `<group>`, missing id).
- `src/__tests__/Utils/decode-wa-message.test.ts` — 8 cases (missing id/from, unknown jid, group without participant, 1:1, outgoing, recipient mismatch, group).
- `src/__tests__/Utils/process-message.test.ts` — 7 cases added for `getChatId` (1:1, group, status, broadcast received, broadcast sent, missing remoteJid, missing participant).
- `src/__tests__/Utils/auth-utils.test.ts` — 4 cases for `assertMeId` (authenticated, no `me`, no `id`, empty `id`).

All 392 tests pass. No changes to `messages-recv.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing or invalid authentication data with clearer error messages
  * Enhanced validation of message and group data to prevent silent failures
  * Strengthened null safety checks across core messaging and group operations

* **Tests**
  * Added comprehensive test coverage for authentication, message decoding, and group metadata handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->