### PR TITLE
Added missing attribute to community participant removal

### DIFF
--- a/src/Socket/communities.ts
+++ b/src/Socket/communities.ts
@@ -288,7 +288,7 @@ export const makeCommunitiesSocket = (config: SocketConfig) => {
 			const result = await communityQuery(jid, 'set', [
 				{
 					tag: action,
-					attrs: {},
+					attrs: action === 'remove' ? { linked_groups: 'true' } : {},
 					content: participants.map(jid => ({
 						tag: 'participant',
 						attrs: { jid }


### PR DESCRIPTION
To properly kick a member from a community, the attribute `linked_groups` must be set to `"true"` so that the member is removed from all community groups. Otherwise, the community member removal will fail.