### PR TITLE
Fix jimp type check from 'object' to 'function'

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -199,7 +199,7 @@ export const generateProfilePicture = async (
 				quality: 50
 			})
 			.toBuffer()
-	} else if ('jimp' in lib && typeof lib.jimp?.Jimp === 'object') {
+	} else if ('jimp' in lib && typeof lib.jimp?.Jimp === 'function') {
 		const jimp = await (lib.jimp.Jimp as any).read(buffer)
 		const min = Math.min(jimp.width, jimp.height)
 		const cropped = jimp.crop({ x: 0, y: 0, w: min, h: min })


### PR DESCRIPTION
Fixes the error “No image processing library is available.” even when Jimp is installed.

In recent versions of Jimp, Jimp is now defined as a class instead of an object, which breaks the existing type check.



*Idk if this is useless/useful