### PR TITLE
refactor(retry): improve message encryption and retry logic

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1189,7 +1189,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			await processingMutex.mutex(async () => {
 				await decrypt()
 				// message failed to decrypt
-				if (msg.messageStubType === proto.WebMessageInfo.StubType.CIPHERTEXT) {
+				if (msg.messageStubType === proto.WebMessageInfo.StubType.CIPHERTEXT && msg.category !== 'peer') {
 					if (msg?.messageStubParameters?.[0] === MISSING_KEYS_ERROR_TEXT) {
 						return sendMessageAck(node, NACK_REASONS.ParsingError)
 					}

--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -8,7 +8,12 @@ import type { CacheStore } from './Socket'
 
 // export the WAMessage Prototypes
 export { proto as WAProto }
-export type WAMessage = proto.IWebMessageInfo & { key: WAMessageKey; messageStubParameters?: any }
+export type WAMessage = proto.IWebMessageInfo & {
+	key: WAMessageKey
+	messageStubParameters?: any
+	category?: string
+	retryCount?: number
+}
 export type WAMessageContent = proto.IMessage
 export type WAContactMessage = proto.Message.IContactMessage
 export type WAContactsArrayMessage = proto.Message.IContactsArrayMessage

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -206,6 +206,7 @@ export function decodeMessageNode(stanza: BinaryNode, meId: string, meLid: strin
 
 	const fullMessage: WAMessage = {
 		key,
+		category: stanza.attrs.category,
 		messageTimestamp: +stanza.attrs.t!,
 		pushName: pushname,
 		broadcast: isJidBroadcast(from)
@@ -246,6 +247,10 @@ export const decryptMessageNode = (
 
 					if (tag === 'unavailable' && attrs.type === 'view_once') {
 						fullMessage.key.isViewOnce = true // TODO: remove from here and add a STUB TYPE
+					}
+
+					if (attrs.count && tag === 'enc') {
+						fullMessage.retryCount = Number(attrs.count)
 					}
 
 					if (tag !== 'enc' && tag !== 'plaintext') {
@@ -333,7 +338,7 @@ export const decryptMessageNode = (
 			}
 
 			// if nothing was found to decrypt
-			if (!decryptables) {
+			if (!decryptables && !fullMessage.key?.isViewOnce) {
 				fullMessage.messageStubType = proto.WebMessageInfo.StubType.CIPHERTEXT
 				fullMessage.messageStubParameters = [NO_MESSAGE_FOUND_ERROR_TEXT]
 			}


### PR DESCRIPTION
Based on: https://github.com/canove/whaileys/compare/v6.3.0...v6.3.3

**Fix message retry:** Correct payload on resend
**Improve view-once handling:** Skip retries on failed view-once messages
**Skip peer retries:** Avoid retrying peer messages
**Support own devices:** Use deviceSentMessage for same-user devices
**Category and retryCount:** Add category and retryCount params to MessageKey