### PR TITLE
feat: album message sending

### DIFF
--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -154,6 +154,13 @@ export type EventMessageOptions = {
 	messageSecret?: Uint8Array<ArrayBufferLike>
 }
 
+export type AlbumMessageOptions = {
+	/** Number of images expected in the album */
+	expectedImageCount?: number
+	/** Number of videos expected in the album */
+	expectedVideoCount?: number
+}
+
 type SharePhoneNumber = {
 	sharePhoneNumber: boolean
 }
@@ -197,7 +204,10 @@ export type AnyMediaMessageContent = (
 			fileName?: string
 			caption?: string
 	  } & Contextable)
-) & { mimetype?: string } & Editable
+) & { mimetype?: string } & Editable & {
+		/** key of the parent albumMessage to associate this media with */
+		albumParentKey?: WAMessageKey
+	}
 
 export type ButtonReplyInfo = {
 	displayText: string
@@ -231,6 +241,10 @@ export type AnyRegularMessageContent = (
 	  } & Mentionable &
 			Contextable &
 			Editable)
+	| ({
+			album: AlbumMessageOptions
+	  } & Contextable &
+			Mentionable)
 	| {
 			contacts: {
 				displayName?: string

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -586,6 +586,11 @@ export const generateWAMessageContent = async (
 				m.pollCreationMessage = pollCreationMessage
 			}
 		}
+	} else if (hasNonNullishProperty(message, 'album')) {
+		m.albumMessage = {
+			expectedImageCount: message.album.expectedImageCount,
+			expectedVideoCount: message.album.expectedVideoCount
+		}
 	} else if (hasNonNullishProperty(message, 'sharePhoneNumber')) {
 		m.protocolMessage = {
 			type: proto.Message.ProtocolMessage.Type.SHARE_PHONE_NUMBER
@@ -651,6 +656,16 @@ export const generateWAMessageContent = async (
 			key.contextInfo = { ...key.contextInfo, ...message.contextInfo }
 		} else if (key!) {
 			key.contextInfo = message.contextInfo
+		}
+	}
+
+	if (hasOptionalProperty(message, 'albumParentKey') && !!message.albumParentKey) {
+		m.messageContextInfo = {
+			...m.messageContextInfo,
+			messageAssociation: {
+				associationType: WAProto.MessageAssociation.AssociationType.MEDIA_ALBUM,
+				parentMessageKey: message.albumParentKey
+			}
 		}
 	}
 


### PR DESCRIPTION
example

```ts
const {key: albumKey} = await sock.sendMessage(msg.key.remoteJid!, {
	album: {
	    expectedImageCount: 1,
	}
})
await sock.sendMessage(msg.key.remoteJid!, {
  image: {
    url: 'test.png'	
  },   
  albumKey
})

```
<img width="452" height="467" alt="image" src="https://github.com/user-attachments/assets/9b66988a-c428-4c75-b762-1c0f2fac1dbd" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Album messaging: Send grouped media messages with expected image and video counts.
  * Media association: Link individual media items to parent album messages for organized galleries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->