### PR TITLE
fix: gracefully handle unavailable view-once messages and improve log error

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1143,11 +1143,21 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 
 		const encNode = getBinaryNodeChild(node, 'enc')
+		const unavailableNode = getBinaryNodeChild(node, 'unavailable')
 
 		// TODO: temporary fix for crashes and issues resulting of failed msmsg decryption
 		if (encNode && encNode.attrs.type === 'msmsg') {
 			logger.debug({ key: node.attrs.key }, 'ignored msmsg')
 			await sendMessageAck(node, NACK_REASONS.MissingMessageSecret)
+			return
+		}
+
+		if (unavailableNode) {
+			logger.warn(
+				{ id: node.attrs.id, from: node.attrs.from, type: unavailableNode.attrs?.type },
+				'received unavailable message, sending positive ack'
+			)
+			await sendMessageAck(node)
 			return
 		}
 

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -38,6 +38,7 @@ import {
 	type BinaryNode,
 	binaryNodeToString,
 	encodeBinaryNode,
+	getAllBinaryNodeChildren,
 	getBinaryNodeChild,
 	getBinaryNodeChildren,
 	isLidUser,
@@ -908,11 +909,12 @@ export const makeSocket = (config: SocketConfig) => {
 	})
 
 	ws.on('CB:stream:error', (node: BinaryNode) => {
-		logger.error({ node }, 'stream errored out')
+		const [reasonNode] = getAllBinaryNodeChildren(node)
+		logger.error({ reasonNode, fullErrorNode: node }, 'stream errored out')
 
 		const { reason, statusCode } = getErrorCodeFromStreamError(node)
 
-		end(new Boom(`Stream Errored (${reason})`, { statusCode, data: node }))
+		end(new Boom(`Stream Errored (${reason})`, { statusCode, data: reasonNode || node }))
 	})
 	// stream fail, possible logout
 	ws.on('CB:failure', (node: BinaryNode) => {


### PR DESCRIPTION
It turns out the disconnections were caused by our client getting stuck in a loop. When we'd receive a "view-once" message where the media was missing (marked as `unavailable`), we treated it as a decryption error and kept asking the server to send it again. This rapid-fire retry loop was making the connection unstable, and eventually, the server would kick us off.

I've observed the whatsapp web behaviour and replicate to baileys.

Bonus: improve error detail logs