### PR TITLE
Add senderPn and senderLid to message types

### DIFF
--- a/WAProto/index.d.ts
+++ b/WAProto/index.d.ts
@@ -3131,6 +3131,8 @@ export namespace proto {
         participant?: (string|null);
         quotedMessage?: (proto.IMessage|null);
         remoteJid?: (string|null);
+        senderPn?: (string|null);
+        senderLid?: (string|null);
         mentionedJid?: (string[]|null);
         conversionSource?: (string|null);
         conversionData?: (Uint8Array|null);
@@ -3190,6 +3192,8 @@ export namespace proto {
         public participant?: (string|null);
         public quotedMessage?: (proto.IMessage|null);
         public remoteJid?: (string|null);
+        public senderPn?: (string|null);
+        public senderLid?: (string|null);
         public mentionedJid: string[];
         public conversionSource?: (string|null);
         public conversionData?: (Uint8Array|null);
@@ -9566,6 +9570,8 @@ export namespace proto {
 
     interface IMessageKey {
         remoteJid?: (string|null);
+        senderPn?: (string|null);
+        senderLid?: (string|null);
         fromMe?: (boolean|null);
         id?: (string|null);
         participant?: (string|null);
@@ -9574,6 +9580,8 @@ export namespace proto {
     class MessageKey implements IMessageKey {
         constructor(p?: proto.IMessageKey);
         public remoteJid?: (string|null);
+        public senderPn?: (string|null);
+        public senderLid?: (string|null);
         public fromMe?: (boolean|null);
         public id?: (string|null);
         public participant?: (string|null);


### PR DESCRIPTION
Added optional fields `senderPn` and `senderLid` to WAProto message structures (`ContextInfo` and `MessageKey`) to support retrieving the real sender identifier in multi-device WhatsApp environments.

These fields are exposed as part of both the interface definitions and their corresponding class implementations, allowing message handlers to access phone-number JIDs and linked-device JIDs without requiring changes in the consuming application.

This update ensures compatibility with messages where WhatsApp delivers sender information through PN (phone number) or LID (linked device), improving identification accuracy across different message routing scenarios.