### PR TITLE
fix(messages-recv): cancel pending phone requests for message retries

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1275,6 +1275,10 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 						await sendMessageAck(node, NACK_REASONS.UnhandledError)
 					})
 				} else {
+					if (messageRetryManager && msg.key.id) {
+						messageRetryManager.cancelPendingPhoneRequest(msg.key.id)
+					}
+
 					const isNewsletter = isJidNewsletter(msg.key.remoteJid!)
 					if (!isNewsletter) {
 						// no type in the receipt => message delivered


### PR DESCRIPTION
When a user leaves a group and rejoins via link, then sends a message (like "ping"), the bot responds twice (two "pong" messages).

The issue occurs due to the Signal Protocol session being invalidated when a participant rejoins a group. Here's the sequence:

  1. When the rejoined user sends a message, decryption initially fails because the sender key session is stale
  2. A retry request is sent to the sender asking them to resend with fresh keys
  3. Simultaneously, a phone request (PDO - Peer Data Operation) is scheduled to ask the primary phone for the message content
  4. The retry succeeds - the message is decrypted and messages.upsert is emitted → Bot sends "pong"
  5. The PDO response arrives later with the same message content, triggering another messages.upsert → Bot sends "pong"
  
  I just added code to cancel any pending phone request when decryption succeeds
  
  Thanks @Salientekill for reproduction of the issue