### PR TITLE
auth-utils: Fixing memory leak (release transaction mutex after references are 0)

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -151,7 +151,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 
 		await delay(5000)
 
-		if (!await placeholderResendCache.get(messageKey?.id!)) {
+		if (!(await placeholderResendCache.get(messageKey?.id!))) {
 			logger.debug({ messageKey }, 'message received while resend requested')
 			return 'RESOLVED'
 		}

--- a/src/Utils/auth-utils.ts
+++ b/src/Utils/auth-utils.ts
@@ -118,9 +118,12 @@ export const addTransactionCapability = (
 ): SignalKeyStoreWithTransaction => {
 	const txStorage = new AsyncLocalStorage<TransactionContext>()
 
-	// Queues for concurrency control
+	// Queues for concurrency control (keyed by signal data type - bounded set)
 	const keyQueues = new Map<string, PQueue>()
+
+	// Transaction mutexes with reference counting for cleanup
 	const txMutexes = new Map<string, Mutex>()
+	const txMutexRefCounts = new Map<string, number>()
 
 	// Pre-key manager for specialized operations
 	const preKeyManager = new PreKeyManager(state, logger)
@@ -142,9 +145,35 @@ export const addTransactionCapability = (
 	function getTxMutex(key: string): Mutex {
 		if (!txMutexes.has(key)) {
 			txMutexes.set(key, new Mutex())
+			txMutexRefCounts.set(key, 0)
 		}
 
 		return txMutexes.get(key)!
+	}
+
+	/**
+	 * Acquire a reference to a transaction mutex
+	 */
+	function acquireTxMutexRef(key: string): void {
+		const count = txMutexRefCounts.get(key) ?? 0
+		txMutexRefCounts.set(key, count + 1)
+	}
+
+	/**
+	 * Release a reference to a transaction mutex and cleanup if no longer needed
+	 */
+	function releaseTxMutexRef(key: string): void {
+		const count = (txMutexRefCounts.get(key) ?? 1) - 1
+		txMutexRefCounts.set(key, count)
+
+		// Cleanup if no more references and mutex is not locked
+		if (count <= 0) {
+			const mutex = txMutexes.get(key)
+			if (mutex && !mutex.isLocked()) {
+				txMutexes.delete(key)
+				txMutexRefCounts.delete(key)
+			}
+		}
 	}
 
 	/**
@@ -279,29 +308,36 @@ export const addTransactionCapability = (
 			}
 
 			// New transaction - acquire mutex and create context
-			return getTxMutex(key).runExclusive(async () => {
-				const ctx: TransactionContext = {
-					cache: {},
-					mutations: {},
-					dbQueries: 0
-				}
+			const mutex = getTxMutex(key)
+			acquireTxMutexRef(key)
 
-				logger.trace('entering transaction')
+			try {
+				return await mutex.runExclusive(async () => {
+					const ctx: TransactionContext = {
+						cache: {},
+						mutations: {},
+						dbQueries: 0
+					}
 
-				try {
-					const result = await txStorage.run(ctx, work)
+					logger.trace('entering transaction')
 
-					// Commit mutations
-					await commitWithRetry(ctx.mutations)
+					try {
+						const result = await txStorage.run(ctx, work)
 
-					logger.trace({ dbQueries: ctx.dbQueries }, 'transaction completed')
+						// Commit mutations
+						await commitWithRetry(ctx.mutations)
 
-					return result
-				} catch (error) {
-					logger.error({ error }, 'transaction failed, rolling back')
-					throw error
-				}
-			})
+						logger.trace({ dbQueries: ctx.dbQueries }, 'transaction completed')
+
+						return result
+					} catch (error) {
+						logger.error({ error }, 'transaction failed, rolling back')
+						throw error
+					}
+				})
+			} finally {
+				releaseTxMutexRef(key)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/WhiskeySockets/Baileys/pull/2151 sparked an internal discussion within myself regarding the memory leak we are facing.

Problem: We are facing a memory leak after the first few release candidates. 

Motivation: https://github.com/WhiskeySockets/Baileys/pull/2151 seemed like it was headed in the right direction, but as soon as I saw that it was actually producing race conditions, I knew the fix to the confirmed leak wasn't there. I also realized that the make-mutex file hasn't been edited for years and likely not the reason why Baileys is leaking. 

Rushing to try and think where this leak could be, I remembered my experimental addTransactionCapability rewrite (this system fucking sucks and will be removed from Baileys entirely). 

And there it was, confirmation: The addTransactionCapability function was never clearing any of the mutexes with 0 references to them. 

It remains to be seen if this patch is correct - I whipped it up directly. It also remains to be seen if https://github.com/WhiskeySockets/Baileys/pull/2151 is going to get merged with this PR or not, as that function needs complete removal or modernization.

Please test this out on your sessions, it will likely have 0 stability impact due to us just running a clearing function on empty mutexes. This is still an experimental change, and please run some sort of perf monitoring tool for hours.


PS: Please support my work on GitHub Sponsors, as it takes a lot of prioritization to drop my exams and focus on this for 2 hours in a row. https://purpshell.dev/sponsor