### PR TITLE
 Per user mutex

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -28,7 +28,7 @@ import type {
 import { ALL_WA_PATCH_NAMES } from '../Types'
 import type { QuickReplyAction } from '../Types/Bussines.js'
 import type { LabelActionBody } from '../Types/Label'
-import { SyncState } from '../Types/State'
+import { SyncState } from '../Types'
 import {
 	chatModificationToAppPatch,
 	type ChatMutationMap,
@@ -41,7 +41,7 @@ import {
 	newLTHashState,
 	processSyncAction
 } from '../Utils'
-import { makeMutex } from '../Utils/make-mutex'
+import { makeMutex , makeKeyedMutex} from '../Utils/make-mutex'
 import processMessage from '../Utils/process-message'
 import {
 	type BinaryNode,
@@ -74,16 +74,16 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	let syncState: SyncState = SyncState.Connecting
 
 	/** this mutex ensures that messages are processed in order */
-	const messageMutex = makeMutex()
+	const messageMutex = makeKeyedMutex()
 
 	/** this mutex ensures that receipts are processed in order */
-	const receiptMutex = makeMutex()
+	const receiptMutex = makeKeyedMutex()
 
 	/** this mutex ensures that app state patches are processed in order */
 	const appStatePatchMutex = makeMutex()
 
 	/** this mutex ensures that notifications are processed in order */
-	const notificationMutex = makeMutex()
+	const notificationMutex = makeKeyedMutex()
 
 	// Timeout for AwaitingInitialSync state
 	let awaitingSyncTimeout: NodeJS.Timeout | undefined

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -142,7 +142,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			throw new Boom('Not authenticated')
 		}
 
-		if (placeholderResendCache.get(messageKey?.id!)) {
+		if (await placeholderResendCache.get(messageKey?.id!)) {
 			logger.debug({ messageKey }, 'already requested resend')
 			return
 		} else {
@@ -151,7 +151,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 
 		await delay(5000)
 
-		if (!placeholderResendCache.get(messageKey?.id!)) {
+		if (!(await placeholderResendCache.get(messageKey?.id!))) {
 			logger.debug({ messageKey }, 'message received while resend requested')
 			return 'RESOLVED'
 		}
@@ -166,7 +166,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 
 		setTimeout(async () => {
-			if (placeholderResendCache.get(messageKey?.id!)) {
+			if (await placeholderResendCache.get(messageKey?.id!)) {
 				logger.debug({ messageKey }, 'PDO message without response after 15 seconds. Phone possibly offline')
 				await placeholderResendCache.del(messageKey?.id!)
 			}

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -2,7 +2,7 @@ import NodeCache from '@cacheable/node-cache'
 import { Boom } from '@hapi/boom'
 import { randomBytes } from 'crypto'
 import Long from 'long'
-import { proto } from '../../WAProto/index.js'
+import { proto } from '../../WAProto'
 import { DEFAULT_CACHE_TTLS, KEY_BUNDLE_TYPE, MIN_PREKEY_COUNT } from '../Defaults'
 import type {
 	GroupParticipant,
@@ -41,7 +41,7 @@ import {
 	xmppPreKey,
 	xmppSignedPreKey
 } from '../Utils'
-import { makeKeyedMutex, makeMutex } from '../Utils/make-mutex'
+import { makeKeyedMutex } from '../Utils/make-mutex'
 import {
 	areJidsSameUser,
 	type BinaryNode,

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -1199,7 +1199,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				})
 				if (config.emitOwnEvents) {
 					process.nextTick(async () => {
-						await messageMutex.mutex(() => upsertMessage(fullMsg, 'append'))
+						await messageMutex.mutex(jid,() => upsertMessage(fullMsg, 'append'))
 					})
 				}
 


### PR DESCRIPTION
Right now, message locking was global, which slowed things down a lot for accounts with many groups and chats. This PR changes it so that each user (remoteJid) has its own lock.

Files updated: chats.ts, messages-recv.ts, messages-send.ts

Performance improvement is huge up to 100x faster in heavy accounts

⚠️ Needs testing to ensure no race conditions are introduced.