### PR TITLE
fix: replace console statements with logger for consistency

### DIFF
--- a/src/Socket/communities.ts
+++ b/src/Socket/communities.ts
@@ -86,7 +86,7 @@ export const makeCommunitiesSocket = (config: SocketConfig) => {
 				const metadata = await sock.groupMetadata(`${groupNode.attrs.id}@g.us`)
 				return metadata ? metadata : Optional.empty()
 			} catch (error) {
-				console.error('Error parsing group metadata:', error)
+				logger.error({ error }, 'Error parsing group metadata')
 				return Optional.empty()
 			}
 		}

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -80,8 +80,8 @@ export const makeSocket = (config: SocketConfig) => {
 	const generateMessageTag = () => `${uqTagId}${epoch++}`
 
 	if (printQRInTerminal) {
-		console.warn(
-			'⚠️ The printQRInTerminal option has been deprecated. You will no longer receive QR codes in the terminal automatically. Please listen to the connection.update event yourself and handle the QR your way. You can remove this message by removing this opttion. This message will be removed in a future version.'
+		logger.warn(
+			'The printQRInTerminal option has been deprecated. You will no longer receive QR codes in the terminal automatically. Please listen to the connection.update event yourself and handle the QR your way. You can remove this message by removing this option. This message will be removed in a future version.'
 		)
 	}
 

--- a/src/Utils/business.ts
+++ b/src/Utils/business.ts
@@ -261,7 +261,7 @@ export const uploadingNecessaryImages = async (
 				timeoutMs
 			})
 
-			await fs.unlink(filePath).catch(err => console.log('Error deleting temp file ', err))
+			await fs.unlink(filePath).catch(() => {})
 
 			return { url: getUrlFromDirectPath(directPath) }
 		})


### PR DESCRIPTION
## Summary

Replace scattered `console.log/error/warn` statements with the project's logger infrastructure for consistent logging behavior.

## Changes

- **business.ts**: Silently ignore temp file deletion errors (non-critical operation, follows existing pattern in codebase)
- **communities.ts**: Use `logger.error` instead of `console.error` for group metadata parsing errors
- **socket.ts**: Use `logger.warn` instead of `console.warn` for deprecation notice

## Additional Fix

Fixed a typo in the deprecation message: "opttion" → "option"

## Motivation

- Ensures consistent logging behavior across the codebase
- Respects user's log level configuration (console statements bypass log level settings)
- Follows existing patterns established in other files