### PR TITLE
Increased message reliability

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -151,7 +151,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 
 		await delay(5000)
 
-		if (!await placeholderResendCache.get(messageKey?.id!)) {
+		if (!(await placeholderResendCache.get(messageKey?.id!))) {
 			logger.debug({ messageKey }, 'message received while resend requested')
 			return 'RESOLVED'
 		}

--- a/src/Utils/event-buffer.ts
+++ b/src/Utils/event-buffer.ts
@@ -163,6 +163,28 @@ export const makeEventBuffer = (logger: ILogger): BaileysBufferableEventEmitter 
 			}
 		},
 		emit<T extends BaileysEvent>(event: BaileysEvent, evData: BaileysEventMap[T]) {
+			// Check if this is a messages.upsert with a different type than what's buffered
+			// If so, flush the buffered messages first to avoid type overshadowing
+			if (event === 'messages.upsert') {
+				const { type } = evData as BaileysEventMap['messages.upsert']
+				const existingUpserts = Object.values(data.messageUpserts)
+				if (existingUpserts.length > 0) {
+					const bufferedType = existingUpserts[0]!.type
+					if (bufferedType !== type) {
+						logger.debug({ bufferedType, newType: type }, 'messages.upsert type mismatch, emitting buffered messages')
+						// Emit the buffered messages with their correct type
+						ev.emit('event', {
+							'messages.upsert': {
+								messages: existingUpserts.map(m => m.message),
+								type: bufferedType
+							}
+						})
+						// Clear the message upserts from the buffer
+						data.messageUpserts = {}
+					}
+				}
+			}
+
 			if (isBuffering && BUFFERABLE_EVENT_SET.has(event)) {
 				append(data, historyCache, event as BufferableEvent, evData, logger)
 				return true


### PR DESCRIPTION
Motivation: We (@jlucaso1 and I) were running some large scale tests on message send/recv (simple ping/pong test) and found that when ran fast enough (around 150 messages a second) around 4% of messages were lost. This caused me to dig deeper.

Problem: The problem lies in the ping/pong. Baileys is emitting "append" messages as soon as the pong is sent. This append then gets buffered in the event buffer. When a new message arrives, the type "notify" of this message is lost due to it being added to the array of messages rather than being emitted on its own. 

Solution: Simply emit the event and flush the buffer if the type is different.

Impact: This has a really wide impact, for people who have a lot of notifications, and for people who are getting messages from channels and newsletters, this causes many lost messages. To the server, the message was received, but to the user of Baileys, this is not the case.

Side note: I hate the event buffer, its the worst thing mankind has seen, Adi please commit seppuku for this sin /s. All jokes aside, I think I will likely either rewrite the entire event buffer next or remove it for potentially higher speed (depends what event library we use next).

**NOTE:** I just finished this investigation at 6:28 AM. We are doing a lot for this project. If you are a business and would like to give back to our work, I suggest you sponsor me at https://purpshell.dev/sponsor or book a meeting with me https://purpshell.dev/book to help fund the project. The highest sponsor tier has a free meeting every 2 months so check that out too. If you can contribute in bona fide / contribution hours as as company, we would also appreciate that.

Thank you to everyone who supports me, we are 55 sponsors growing strong ❤️
