### PR TITLE
feat: add android browser (can receive viewonce)

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -98,6 +98,12 @@ export const makeSocket = (config: SocketConfig) => {
 		)
 	}
 
+	if (browser[1].toLocaleLowerCase().includes('android')) {
+		logger.warn(
+			'⚠️ Using the Android browser is experimental and may lead to unexpected behavior. Use at your own risk.'
+		)
+	}
+
 	const syncDisabled =
 		PROCESSABLE_HISTORY_TYPES.map(syncType => config.shouldSyncHistoryMessage({ syncType })).filter(x => x === false)
 			.length === PROCESSABLE_HISTORY_TYPES.length

--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -21,6 +21,7 @@ export type BrowsersMap = {
 	macOS(browser: string): [string, string, string]
 	baileys(browser: string): [string, string, string]
 	windows(browser: string): [string, string, string]
+	android(browser: string): [string, string, string]
 	appropriate(browser: string): [string, string, string]
 }
 

--- a/src/Utils/browser-utils.ts
+++ b/src/Utils/browser-utils.ts
@@ -21,6 +21,7 @@ export const Browsers: BrowsersMap = {
 	macOS: browser => ['Mac OS', browser, '14.4.1'],
 	baileys: browser => ['Baileys', browser, '6.5.0'],
 	windows: browser => ['Windows', browser, '10.0.22631'],
+	android: browser => [browser, 'Android', ''],
 	/** The appropriate browser based on your OS & release */
 	appropriate: browser => [PLATFORM_MAP[platform()] || 'Ubuntu', browser, release()]
 }

--- a/src/Utils/validate-connection.ts
+++ b/src/Utils/validate-connection.ts
@@ -20,7 +20,9 @@ const getUserAgent = (config: SocketConfig): proto.ClientPayload.IUserAgent => {
 			secondary: config.version[1],
 			tertiary: config.version[2]
 		},
-		platform: proto.ClientPayload.UserAgent.Platform.WEB,
+		platform: config.browser[1].toLocaleLowerCase().includes('android')
+			? proto.ClientPayload.UserAgent.Platform.ANDROID
+			: proto.ClientPayload.UserAgent.Platform.WEB,
 		releaseChannel: proto.ClientPayload.UserAgent.ReleaseChannel.RELEASE,
 		osVersion: '0.1',
 		device: 'Desktop',
@@ -58,7 +60,9 @@ const getClientPayload = (config: SocketConfig) => {
 		userAgent: getUserAgent(config)
 	}
 
-	payload.webInfo = getWebInfo(config)
+	if (!config.browser[1].toLocaleLowerCase().includes('android')) {
+		payload.webInfo = getWebInfo(config)
+	}
 
 	if (config.pushName) {
 		payload.pushName = config.pushName
@@ -83,6 +87,10 @@ export const generateLoginNode = (userJid: string, config: SocketConfig): proto.
 
 const getPlatformType = (platform: string): proto.DeviceProps.PlatformType => {
 	const platformType = platform.toUpperCase()
+	if (platformType === 'ANDROID') {
+		return proto.DeviceProps.PlatformType.ANDROID_PHONE
+	}
+
 	return (
 		proto.DeviceProps.PlatformType[platformType as keyof typeof proto.DeviceProps.PlatformType] ||
 		proto.DeviceProps.PlatformType.CHROME


### PR DESCRIPTION
how to use

```ts
	const sock = makeWASocket({
		version,
		logger,
		auth: {
			creds: state.creds,
			/** caching makes the store faster to send/recv messages */
			keys: makeCacheableSignalKeyStore(state.keys, logger),
		},
		browser: Browsers.android('13'), // here
		msgRetryCounterCache,
		generateHighQualityLinkPreview: true,
		// ignore all broadcast messages -- to receive the same
		// comment the line below out
		// shouldIgnoreJid: jid => isJidBroadcast(jid),
		// implement to handle retries & poll updates
		getMessage
	})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental Android browser support enabling connections from Android devices.
  * Android browser users will receive warnings indicating the feature is in experimental status.
  * Improved platform detection and device identification for Android device connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->