### PR TITLE
Add button and interactive message support

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,72 @@ await sock.sendMessage(
 )
 ```
 
+#### Buttons Message
+```ts
+await sock.sendMessage(jid, {
+    text: 'Choose an option:',
+    footer: 'Baileys',
+    buttons: [
+        { buttonId: 'opt1', buttonText: { displayText: 'Option 1' } },
+        { buttonId: 'opt2', buttonText: { displayText: 'Option 2' } }
+    ]
+})
+```
+
+#### Template Buttons Message
+```ts
+await sock.sendMessage(jid, {
+    text: 'Select:',
+    footer: 'Baileys',
+    templateButtons: [
+        { index: 0, quickReplyButton: { displayText: 'Yes', id: 'yes' } },
+        { index: 1, quickReplyButton: { displayText: 'No', id: 'no' } }
+    ]
+})
+```
+
+#### List Message
+```ts
+await sock.sendMessage(jid, {
+    text: 'Select an item:',
+    footer: 'Baileys',
+    title: 'Products',
+    buttonText: 'Open',
+    sections: [
+        {
+            title: 'Category A',
+            rows: [
+                { id: 'a1', title: 'Item A1', description: 'Desc A1' },
+                { id: 'a2', title: 'Item A2', description: 'Desc A2' }
+            ]
+        }
+    ]
+})
+```
+
+#### Interactive Message (Native Flow)
+```ts
+await sock.sendMessage(jid, {
+    interactiveMessage: {
+        header: { title: 'Menu' },
+        body: { text: 'Choose:' },
+        footer: { text: 'Baileys' },
+        nativeFlowMessage: {
+            buttons: [
+                {
+                    name: 'quick_reply',
+                    buttonParamsJson: JSON.stringify({ display_text: 'Option 1', id: 'opt1' })
+                },
+                {
+                    name: 'quick_reply',
+                    buttonParamsJson: JSON.stringify({ display_text: 'Option 2', id: 'opt2' })
+                }
+            ]
+        }
+    }
+})
+```
+
 ### Sending Messages with Link Previews
 
 1. By default, wa does not have link generation when sent from the web

--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -122,6 +122,26 @@ type ViewOnce = {
 	viewOnce?: boolean
 }
 
+type Buttonable = {
+	/** add buttons to the message */
+	buttons?: proto.Message.ButtonsMessage.IButton[]
+}
+type Templatable = {
+	/** add buttons to the message (conflicts with normal buttons) */
+	templateButtons?: proto.IHydratedTemplateButton[]
+	footer?: string
+}
+type Listable = {
+	/** Sections of the List */
+	sections?: proto.Message.ListMessage.ISection[]
+
+	/** Title of a List Message only */
+	title?: string
+
+	/** Text of the button on the list (required) */
+	buttonText?: string
+}
+
 type Editable = {
 	edit?: WAMessageKey
 }
@@ -160,6 +180,10 @@ type RequestPhoneNumber = {
 	requestPhoneNumber: boolean
 }
 
+export type InteractiveMessageContent = {
+	interactiveMessage: proto.Message.IInteractiveMessage
+}
+
 export type AnyMediaMessageContent = (
 	| ({
 			image: WAMediaUpload
@@ -167,6 +191,8 @@ export type AnyMediaMessageContent = (
 			jpegThumbnail?: string
 	  } & Mentionable &
 			Contextable &
+			Buttonable &
+			Templatable &
 			WithDimensions)
 	| ({
 			video: WAMediaUpload
@@ -177,6 +203,8 @@ export type AnyMediaMessageContent = (
 			ptv?: boolean
 	  } & Mentionable &
 			Contextable &
+			Buttonable &
+			Templatable &
 			WithDimensions)
 	| {
 			audio: WAMediaUpload
@@ -194,7 +222,9 @@ export type AnyMediaMessageContent = (
 			mimetype: string
 			fileName?: string
 			caption?: string
-	  } & Contextable)
+	  } & Contextable &
+			Buttonable &
+			Templatable)
 ) & { mimetype?: string } & Editable
 
 export type ButtonReplyInfo = {
@@ -221,6 +251,9 @@ export type AnyRegularMessageContent = (
 			linkPreview?: WAUrlInfo | null
 	  } & Mentionable &
 			Contextable &
+			Buttonable &
+			Templatable &
+			Listable &
 			Editable)
 	| AnyMediaMessageContent
 	| { event: EventMessageOptions }
@@ -263,6 +296,7 @@ export type AnyRegularMessageContent = (
 			body?: string
 			footer?: string
 	  }
+	| InteractiveMessageContent
 	| SharePhoneNumber
 	| RequestPhoneNumber
 ) &


### PR DESCRIPTION
## What changed
- Added support for buttons messages (plain buttons).
- Added support for template buttons.
- Added support for list messages (sections/title/buttonText/footer).
- Added support for interactiveMessage (native flow) payloads.
- Added MD patch + biz node for correct WhatsApp Web rendering.

## Examples (README)
**Buttons message**
`	s
await sock.sendMessage(jid, {
    text: 'Choose an option:',
    footer: 'Baileys',
    buttons: [
        { buttonId: 'opt1', buttonText: { displayText: 'Option 1' } },
        { buttonId: 'opt2', buttonText: { displayText: 'Option 2' } }
    ]
})
`

**Template buttons**
`	s
await sock.sendMessage(jid, {
    text: 'Select:',
    footer: 'Baileys',
    templateButtons: [
        { index: 0, quickReplyButton: { displayText: 'Yes', id: 'yes' } },
        { index: 1, quickReplyButton: { displayText: 'No', id: 'no' } }
    ]
})
`

**List message**
`	s
await sock.sendMessage(jid, {
    text: 'Select an item:',
    footer: 'Baileys',
    title: 'Products',
    buttonText: 'Open',
    sections: [
        {
            title: 'Category A',
            rows: [
                { id: 'a1', title: 'Item A1', description: 'Desc A1' },
                { id: 'a2', title: 'Item A2', description: 'Desc A2' }
            ]
        }
    ]
})
`

**Interactive message (native flow)**
`	s
await sock.sendMessage(jid, {
    interactiveMessage: {
        header: { title: 'Menu' },
        body: { text: 'Choose:' },
        footer: { text: 'Baileys' },
        nativeFlowMessage: {
            buttons: [
                {
                    name: 'quick_reply',
                    buttonParamsJson: JSON.stringify({ display_text: 'Option 1', id: 'opt1' })
                },
                {
                    name: 'quick_reply',
                    buttonParamsJson: JSON.stringify({ display_text: 'Option 2', id: 'opt2' })
                }
            ]
        }
    }
})
`
