### PR TITLE
fix: getmessagetype to ensure stanza consistency with whatsapp

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -1001,7 +1001,40 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	}
 
 	const getMessageType = (message: proto.IMessage) => {
-		if (message.pollCreationMessage || message.pollCreationMessageV2 || message.pollCreationMessageV3) {
+		if (message.viewOnceMessage?.message) {
+			return getMessageType(message.viewOnceMessage.message)
+		}
+
+		if (message.viewOnceMessageV2?.message) {
+			return getMessageType(message.viewOnceMessageV2.message)
+		}
+
+		if (message.viewOnceMessageV2Extension?.message) {
+			return getMessageType(message.viewOnceMessageV2Extension.message)
+		}
+
+		if (message.lottieStickerMessage?.message) {
+			return getMessageType(message.lottieStickerMessage.message)
+		}
+
+		if (message.ephemeralMessage?.message) {
+			return getMessageType(message.ephemeralMessage.message)
+		}
+
+		if (message.documentWithCaptionMessage?.message) {
+			return getMessageType(message.documentWithCaptionMessage.message)
+		}
+
+		if (message.reactionMessage || message.encReactionMessage) {
+			return 'reaction'
+		}
+
+		if (
+			message.pollCreationMessage ||
+			message.pollCreationMessageV2 ||
+			message.pollCreationMessageV3 ||
+			message.pollUpdateMessage
+		) {
 			return 'poll'
 		}
 


### PR DESCRIPTION
Some types of messages were missing, for example reactions were sent as 'text'.