### PR TITLE
fix: extract LID-PN mappings from history sync phoneNumberToLidMappings

### DIFF
--- a/src/Types/Events.ts
+++ b/src/Types/Events.ts
@@ -1,6 +1,6 @@
 import type { Boom } from '@hapi/boom'
 import { proto } from '../../WAProto/index.js'
-import type { AuthenticationCreds } from './Auth'
+import type { AuthenticationCreds, LIDMapping } from './Auth'
 import type { WACallEvent } from './Call'
 import type { Chat, ChatUpdate, PresenceData } from './Chat'
 import type { Contact } from './Contact'
@@ -36,7 +36,7 @@ export type BaileysEventMap = {
 	'chats.upsert': Chat[]
 	/** update the given chats */
 	'chats.update': ChatUpdate[]
-	'lid-mapping.update': { lid: string; pn: string }
+	'lid-mapping.update': LIDMapping
 	/** delete chats with given ID */
 	'chats.delete': string[]
 	/** presence of contact in a chat updated */

--- a/src/Utils/history.ts
+++ b/src/Utils/history.ts
@@ -1,7 +1,7 @@
 import { promisify } from 'util'
 import { inflate } from 'zlib'
 import { proto } from '../../WAProto/index.js'
-import type { Chat, Contact, WAMessage } from '../Types'
+import type { Chat, Contact, LIDMapping, WAMessage } from '../Types'
 import { WAMessageStubType } from '../Types'
 import { toNumber } from './generics'
 import { normalizeMessageContent } from './messages'
@@ -29,6 +29,13 @@ export const processHistoryMessage = (item: proto.IHistorySync) => {
 	const messages: WAMessage[] = []
 	const contacts: Contact[] = []
 	const chats: Chat[] = []
+	// Extract LID-PN mappings for all sync types
+	const lidPnMappings: LIDMapping[] = []
+	for (const m of item.phoneNumberToLidMappings || []) {
+		if (m.lidJid && m.pnJid) {
+			lidPnMappings.push({ lid: m.lidJid, pn: m.pnJid })
+		}
+	}
 
 	switch (item.syncType) {
 		case proto.HistorySync.HistorySyncType.INITIAL_BOOTSTRAP:
@@ -87,6 +94,7 @@ export const processHistoryMessage = (item: proto.IHistorySync) => {
 		chats,
 		contacts,
 		messages,
+		lidPnMappings,
 		syncType: item.syncType,
 		progress: item.progress
 	}

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -287,6 +287,16 @@ const processMessage = async (
 
 					const data = await downloadAndProcessHistorySyncNotification(histNotification, options)
 
+					// Emit LID-PN mappings from history sync
+					// This is how WhatsApp Web learns mappings for chats with non-contacts
+					if (data.lidPnMappings?.length) {
+						logger?.debug({ count: data.lidPnMappings.length }, 'processing LID-PN mappings from history sync')
+						// eslint-disable-next-line max-depth
+						for (const mapping of data.lidPnMappings) {
+							ev.emit('lid-mapping.update', mapping)
+						}
+					}
+
 					ev.emit('messaging-history.set', {
 						...data,
 						isLatest: histNotification.syncType !== proto.HistorySync.HistorySyncType.ON_DEMAND ? isLatest : undefined,

--- a/src/__tests__/Utils/history.test.ts
+++ b/src/__tests__/Utils/history.test.ts
@@ -1,0 +1,94 @@
+import { proto } from '../../../WAProto/index.js'
+import { processHistoryMessage } from '../../Utils/history'
+
+describe('processHistoryMessage', () => {
+	describe('phoneNumberToLidMappings extraction', () => {
+		it('should extract LID-PN mappings from history sync payload', () => {
+			const historySync: proto.IHistorySync = {
+				syncType: proto.HistorySync.HistorySyncType.INITIAL_BOOTSTRAP,
+				conversations: [],
+				phoneNumberToLidMappings: [
+					{ lidJid: '11111111111111@lid', pnJid: '1234567890123@s.whatsapp.net' },
+					{ lidJid: '22222222222222@lid', pnJid: '9876543210987@s.whatsapp.net' }
+				]
+			}
+
+			const result = processHistoryMessage(historySync)
+
+			expect(result.lidPnMappings).toEqual([
+				{ lid: '11111111111111@lid', pn: '1234567890123@s.whatsapp.net' },
+				{ lid: '22222222222222@lid', pn: '9876543210987@s.whatsapp.net' }
+			])
+		})
+
+		it('should skip mappings with missing lidJid or pnJid', () => {
+			const historySync: proto.IHistorySync = {
+				syncType: proto.HistorySync.HistorySyncType.RECENT,
+				conversations: [],
+				phoneNumberToLidMappings: [
+					{ lidJid: undefined, pnJid: '1234567890123@s.whatsapp.net' },
+					{ lidJid: '11111111111111@lid', pnJid: undefined },
+					{ lidJid: '22222222222222@lid', pnJid: '9876543210987@s.whatsapp.net' }
+				]
+			}
+
+			const result = processHistoryMessage(historySync)
+
+			expect(result.lidPnMappings).toEqual([{ lid: '22222222222222@lid', pn: '9876543210987@s.whatsapp.net' }])
+		})
+
+		it('should return empty array when no mappings exist', () => {
+			const historySync: proto.IHistorySync = {
+				syncType: proto.HistorySync.HistorySyncType.INITIAL_BOOTSTRAP,
+				conversations: []
+			}
+
+			const result = processHistoryMessage(historySync)
+
+			expect(result.lidPnMappings).toEqual([])
+		})
+
+		it('should process mappings regardless of sync type', () => {
+			const syncTypes = [proto.HistorySync.HistorySyncType.PUSH_NAME, proto.HistorySync.HistorySyncType.ON_DEMAND]
+
+			for (const syncType of syncTypes) {
+				const historySync: proto.IHistorySync = {
+					syncType,
+					conversations: [],
+					pushnames: [],
+					phoneNumberToLidMappings: [{ lidJid: '11111111111111@lid', pnJid: '1234567890123@s.whatsapp.net' }]
+				}
+
+				const result = processHistoryMessage(historySync)
+
+				expect(result.lidPnMappings).toEqual([{ lid: '11111111111111@lid', pn: '1234567890123@s.whatsapp.net' }])
+			}
+		})
+	})
+
+	describe('conversations processing', () => {
+		it('should extract contacts with LID and PN from conversations', () => {
+			const historySync: proto.IHistorySync = {
+				syncType: proto.HistorySync.HistorySyncType.INITIAL_BOOTSTRAP,
+				conversations: [
+					{
+						id: '1234567890123@s.whatsapp.net',
+						name: 'Test User',
+						lidJid: '11111111111111@lid',
+						pnJid: '1234567890123@s.whatsapp.net'
+					}
+				]
+			}
+
+			const result = processHistoryMessage(historySync)
+
+			expect(result.contacts).toHaveLength(1)
+			expect(result.contacts[0]).toEqual({
+				id: '1234567890123@s.whatsapp.net',
+				name: 'Test User',
+				lid: '11111111111111@lid',
+				phoneNumber: '1234567890123@s.whatsapp.net'
+			})
+		})
+	})
+})


### PR DESCRIPTION
Chats with non-contact users show only LID (no phone number) in Baileys, while WhatsApp Web shows the phone number correctly.

- Extract `phoneNumberToLidMappings` from history sync payloads in `processHistoryMessage()`
- Emit `lid-mapping.update` events for each mapping found during history sync processing
- Add comprehensive unit tests for the new functionality