### PR TITLE
fix: skip retry for expired status messages over 24 hours old

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -22,6 +22,9 @@ export const WA_ADV_HOSTED_DEVICE_SIG_PREFIX = Buffer.from([6, 6])
 
 export const WA_DEFAULT_EPHEMERAL = 7 * 24 * 60 * 60
 
+/** Status messages older than 24 hours are considered expired */
+export const STATUS_EXPIRY_SECONDS = 24 * 60 * 60
+
 export const NOISE_MODE = 'Noise_XX_25519_AESGCM_SHA256\0\0\0\0'
 export const DICT_VERSION = 3
 export const KEY_BUNDLE_TYPE = Buffer.from([5])

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -3,7 +3,7 @@ import { Boom } from '@hapi/boom'
 import { randomBytes } from 'crypto'
 import Long from 'long'
 import { proto } from '../../WAProto/index.js'
-import { DEFAULT_CACHE_TTLS, KEY_BUNDLE_TYPE, MIN_PREKEY_COUNT } from '../Defaults'
+import { DEFAULT_CACHE_TTLS, KEY_BUNDLE_TYPE, MIN_PREKEY_COUNT, STATUS_EXPIRY_SECONDS } from '../Defaults'
 import type {
 	GroupParticipant,
 	MessageReceiptType,
@@ -1230,6 +1230,18 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 						msg.messageStubParameters?.[0] === NO_MESSAGE_FOUND_ERROR_TEXT
 					) {
 						return sendMessageAck(node)
+					}
+
+					// Skip retry for expired status messages (>24h old)
+					if (isJidStatusBroadcast(msg.key.remoteJid!)) {
+						const messageAge = unixTimestampSeconds() - toNumber(msg.messageTimestamp)
+						if (messageAge > STATUS_EXPIRY_SECONDS) {
+							logger.debug(
+								{ msgId: msg.key.id, messageAge, remoteJid: msg.key.remoteJid },
+								'skipping retry for expired status message'
+							)
+							return sendMessageAck(node)
+						}
 					}
 
 					const errorMessage = msg?.messageStubParameters?.[0] || ''

--- a/src/__tests__/Utils/sync-action-utils.test.ts
+++ b/src/__tests__/Utils/sync-action-utils.test.ts
@@ -2,7 +2,6 @@ import { jest } from '@jest/globals'
 import type { ILogger } from '../../Utils/logger'
 import { processContactAction } from '../../Utils/sync-action-utils'
 
-
 describe('processContactAction', () => {
 	const mockLogger: ILogger = {
 		warn: jest.fn(),


### PR DESCRIPTION
This matches whatsapp web implementation and evict some errors or unecessary retries:

```ts
// WhatsApp Web skips retrying EXPIRED status messages (>24h old)                                                                                        
if (l.isStatus()) {                                                                                                                                      
  var u = unixTime() - (timestamp + DAY_SECONDS);                                                                                                        
  var isExpired = u > 0;  // More than 24h old                                                                                                           
                                                                                                                                                         
  if (isExpired && getABProp("web_skip_expired_status_error")) {                                                                                         
    return { result: SUCCESS };  // Silent success, no retry                                                                                             
  }                                                                                                                                                      
}
  ```