### PR TITLE
fix: add missing await for mutationKeys in decodeSyncdMutations

### DIFF
--- a/src/Utils/chat-utils.ts
+++ b/src/Utils/chat-utils.ts
@@ -264,7 +264,7 @@ export const decodeSyncdMutations = async (
 			})
 		}
 
-		return mutationKeys(keyEnc.keyData!)
+		return await mutationKeys(keyEnc.keyData!)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds missing `await` for the async `mutationKeys()` function call in the `getKey` helper inside `decodeSyncdMutations`.

## Problem

When `hkdf` was made async, the `mutationKeys` function was also made async. However, the `getKey` helper function inside `decodeSyncdMutations` was not updated to `await` the result:

```typescript
// Before (bug)
return mutationKeys(keyEnc.keyData!)

// After (fix)  
return await mutationKeys(keyEnc.keyData!)
```

This causes the function to return a Promise instead of the actual keys object, leading to failures when trying to use the key properties for decryption.

## Impact

This bug prevents `contacts.upsert` events from being emitted when contacts are renamed on the mobile device. Users reported that contact name changes no longer propagate from WhatsApp to their applications after upgrading to v7.0.0-rc.x.

## Related Issues

Fixes #1900 

## Test Plan

1. Connect to WhatsApp
2. On a mobile device, rename a contact
3. Verify the `contacts.upsert` event is now emitted with the updated contact name