### PR TITLE
fix: detect identity key changes and reset sessions (align with WA Web)

### DIFF
--- a/src/Types/Auth.ts
+++ b/src/Types/Auth.ts
@@ -81,11 +81,6 @@ export type SignalDataTypeMap = {
 	'lid-mapping': string
 	'device-list': string[]
 	tctoken: { token: Buffer; timestamp?: string }
-	/**
-	 * Remote identity keys - used to detect identity changes.
-	 * When an identity key changes, sessions should be invalidated.
-	 * Reference: WhatsApp Web's saveIdentity (GysEGRAXCvh.js:49388-49403)
-	 */
 	'identity-key': Uint8Array
 }
 

--- a/src/Utils/message-retry-manager.ts
+++ b/src/Utils/message-retry-manager.ts
@@ -39,11 +39,7 @@ export interface RetryStatistics {
 	phoneRequests: number
 }
 
-/**
- * Retry reason codes matching WhatsApp Web's Signal error codes.
- * These are sent in retry receipts to help the sender make informed decisions.
- * Reference: MpTzv7av1aW.js lines 27267-27282
- */
+// Retry reason codes matching WhatsApp Web's Signal error codes.
 export enum RetryReason {
 	UnknownError = 0,
 	SignalErrorNoSession = 1,
@@ -136,11 +132,6 @@ export class MessageRetryManager {
 	/**
 	 * Check if a session should be recreated based on retry count, history, and error code.
 	 * MAC errors (codes 4 and 7) trigger immediate session recreation regardless of timeout.
-	 * Reference: WhatsApp Web's handleNewIdentity flow (GysEGRAXCvh.js:43790-43809)
-	 *
-	 * @param jid The JID of the remote party
-	 * @param hasSession Whether we currently have a session with them
-	 * @param errorCode Optional error code from retry receipt (RetryReason enum)
 	 */
 	shouldRecreateSession(
 		jid: string,
@@ -158,7 +149,6 @@ export class MessageRetryManager {
 		}
 
 		// IMMEDIATE recreation for MAC errors - session is definitely out of sync
-		// This matches WhatsApp Web behavior (MpTzv7av1aW.js:27436-27439)
 		if (errorCode !== undefined && MAC_ERROR_CODES.has(errorCode)) {
 			this.sessionRecreateHistory.set(jid, Date.now())
 			this.statistics.sessionRecreations++


### PR DESCRIPTION
Fixes decryption failures (MAC errors) that occur when a contact changes their identity key (e.g., reinstall). Previously, Baileys silently updated the identity key but kept the stale session, causing immediate MAC verification failures.

**Changes**
1. **Identity Change Detection**: proper implementation of `saveIdentity` in `libsignal.ts` that checks if the identity key has changed.
2. **Session Reset**: If identity changes, the existing session is now deleted, forcing a fresh session establishment.
3. **Pkmsg Handling**: Added `extractIdentityFromPkmsg` to inspect identity keys *before* decryption attempts.

**References**
- Matches WhatsApp Web's `handleNewIdentity` behavior.
- Fixes issues where re-registered contacts resulted in permanent decryption failures.

**Verification**
Verified with a Rust client re-registration test:
1. Linked Rust client (Identity A) → Baileys (Identity A)
2. Deleted Rust client info & re-registered (Identity B)
3. Sent message from Rust (Identity B) → Baileys
4. **Result**: Baileys detected change (`identity key changed...`), reset session, and successfully decrypted the message.


## Sequence Diagrams

### Before Fix (MAC Failure)

```mermaid
sequenceDiagram
    participant Sender (Rust)
    participant Receiver (Baileys)
    participant Store
    
    Note over Sender: Re-installs App\n(New Identity Key)
    Sender->>Receiver: pkmsg (New Identity)
    Receiver->>Store: saveIdentity(New Key)
    Note over Store: Updates Identity Key\nKEEPS Old Session
    Receiver->>Receiver: session.decrypt(pkmsg)
    Note right of Receiver: MAC Mismatch!\n(Session uses Old Key)
    Receiver--xSender: Decryption Error (Bad MAC)
```

### After Fix (Auto-Recovery)

```mermaid
sequenceDiagram
    participant Sender (Rust)
    participant Receiver (Baileys)
    participant Store
    
    Note over Sender: Re-installs App\n(New Identity Key)
    Sender->>Receiver: pkmsg (New Identity)
    Receiver->>Store: saveIdentity(New Key)
    Note over Store: DETECTS CHANGE
    Store->>Store: 1. Delete Old Session\n2. Save New Identity
    Note over Store: Session Reset
    Receiver->>Receiver: session.decrypt(pkmsg)
    Note right of Receiver: Success!\n(New Session Created)
    Receiver-->>Sender: Receipt (Sender)
```