### PR TITLE
perf: reduce DB calls during sync with caching and batching

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -478,8 +478,8 @@ export const makeChatsSocket = (config: SocketConfig) => {
 
 	const resyncAppState = ev.createBufferedFunction(
 		async (collections: readonly WAPatchName[], isInitialSync: boolean) => {
-			// Sync-scoped cache for app state sync keys (cleared when sync completes)
 			const appStateSyncKeyCache = new Map<string, proto.Message.IAppStateSyncKeyData | null>()
+
 			const getCachedAppStateSyncKey = async (
 				keyId: string
 			): Promise<proto.Message.IAppStateSyncKeyData | null | undefined> => {

--- a/src/Types/Events.ts
+++ b/src/Types/Events.ts
@@ -27,6 +27,7 @@ export type BaileysEventMap = {
 		chats: Chat[]
 		contacts: Contact[]
 		messages: WAMessage[]
+		lidPnMappings?: LIDMapping[]
 		isLatest?: boolean
 		progress?: number | null
 		syncType?: proto.HistorySync.HistorySyncType | null

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -287,14 +287,11 @@ const processMessage = async (
 
 					const data = await downloadAndProcessHistorySyncNotification(histNotification, options, logger)
 
-					// Emit LID-PN mappings from history sync
-					// This is how WhatsApp Web learns mappings for chats with non-contacts
 					if (data.lidPnMappings?.length) {
 						logger?.debug({ count: data.lidPnMappings.length }, 'processing LID-PN mappings from history sync')
-						// eslint-disable-next-line max-depth
-						for (const mapping of data.lidPnMappings) {
-							ev.emit('lid-mapping.update', mapping)
-						}
+						await signalRepository.lidMapping
+							.storeLIDPNMappings(data.lidPnMappings)
+							.catch(err => logger?.warn({ err }, 'failed to store LID-PN mappings from history sync'))
 					}
 
 					ev.emit('messaging-history.set', {


### PR DESCRIPTION
- Add sync-scoped cache for `getAppStateSyncKey` to avoid redundant key lookups during sync
- Batch `storeLIDPNMappings` DB reads to reduce N individual queries to 1 batch query
- Add request coalescing for `getLIDsForPNs`/`getPNsForLIDs` to prevent duplicate concurrent DB calls