### PR TITLE
perf: optimize history sync memory and CPU usage

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -597,7 +597,7 @@ export const downloadEncryptedContent = async (
 
 	const output = new Transform({
 		transform(chunk, _, callback) {
-			let data = Buffer.concat([remainingBytes, chunk])
+			let data = remainingBytes.length ? Buffer.concat([remainingBytes, chunk]) : chunk
 
 			const decryptLength = toSmallestChunkSize(data.length)
 			remainingBytes = data.slice(decryptLength)

--- a/src/__tests__/bigint-validation.test.ts
+++ b/src/__tests__/bigint-validation.test.ts
@@ -1,0 +1,186 @@
+import Long from 'long'
+import $protobuf from 'protobufjs/minimal.js'
+
+const $util = $protobuf.util
+
+// proto implementation
+function longToStringOld(value: any, unsigned?: boolean): string {
+	if (typeof value === 'string') return value
+	if (typeof value === 'number') return String(value)
+	if (!$util.Long) return String(value)
+	const normalized = ($util.Long as any).fromValue(value)
+	const prepared =
+		unsigned && normalized && typeof normalized.toUnsigned === 'function' ? normalized.toUnsigned() : normalized
+	return prepared.toString()
+}
+
+// bigint implementation
+function longToStringNew(value: any, unsigned?: boolean): string {
+	if (typeof value === 'string') return value
+	if (typeof value === 'number') return String(value)
+	if (value && typeof value.low === 'number' && typeof value.high === 'number') {
+		const lo = BigInt(value.low >>> 0)
+		const hi = BigInt(value.high >>> 0)
+		const combined = (hi << 32n) | lo
+		if (!unsigned && value.high < 0) {
+			return (combined - (1n << 64n)).toString()
+		}
+
+		return combined.toString()
+	}
+
+	return String(value)
+}
+
+function longToNumberOld(value: any, unsigned?: boolean): number {
+	if (typeof value === 'number') return value
+	if (typeof value === 'string') return Number(value)
+	if (!$util.Long) return Number(value)
+	const normalized = ($util.Long as any).fromValue(value)
+	const prepared =
+		unsigned && normalized && typeof normalized.toUnsigned === 'function'
+			? normalized.toUnsigned()
+			: typeof normalized.toSigned === 'function'
+				? normalized.toSigned()
+				: normalized
+	return prepared.toNumber()
+}
+
+function longToNumberNew(value: any, unsigned?: boolean): number {
+	if (typeof value === 'number') return value
+	if (typeof value === 'string') return Number(value)
+	if (value && typeof value.low === 'number' && typeof value.high === 'number') {
+		const lo = BigInt(value.low >>> 0)
+		const hi = BigInt(value.high >>> 0)
+		const combined = (hi << 32n) | lo
+		if (!unsigned && value.high < 0) {
+			return Number(combined - (1n << 64n))
+		}
+
+		return Number(combined)
+	}
+
+	return Number(value)
+}
+
+describe('BigInt vs Long equivalence validation', () => {
+	// Test cases: [description, Long value, unsigned flag]
+	const testCases: [string, Long, boolean][] = [
+		// Basic values
+		['zero unsigned', Long.fromNumber(0, true), true],
+		['zero signed', Long.fromNumber(0, false), false],
+		['one unsigned', Long.fromNumber(1, true), true],
+		['one signed', Long.fromNumber(1, false), false],
+
+		// Typical WhatsApp timestamps (seconds since epoch)
+		['timestamp 2023', Long.fromNumber(1700000000, true), true],
+		['timestamp 2025', Long.fromNumber(1750000000, true), true],
+		['timestamp as signed', Long.fromNumber(1700000000, false), false],
+
+		// File sizes
+		['small file', Long.fromNumber(1024, true), true],
+		['medium file 10MB', Long.fromNumber(10485760, true), true],
+		['large file 2GB', Long.fromNumber(2147483648, true), true],
+
+		// Boundary values - 32-bit
+		['max int32', Long.fromNumber(2147483647, false), false],
+		['min int32', Long.fromNumber(-2147483648, false), false],
+		['max uint32', Long.fromNumber(4294967295, true), true],
+
+		// Around MAX_SAFE_INTEGER
+		['MAX_SAFE_INTEGER', Long.fromString('9007199254740991', false), false],
+		['MAX_SAFE_INTEGER + 1', Long.fromString('9007199254740992', false), false],
+		['MAX_SAFE_INTEGER unsigned', Long.fromString('9007199254740991', true), true],
+
+		// Large unsigned values
+		['large unsigned', Long.fromString('9999999999999999999', true), true],
+		['max uint64', Long.fromString('18446744073709551615', true), true],
+		['max uint64 - 1', Long.fromString('18446744073709551614', true), true],
+
+		// Signed negative values
+		['negative one', Long.fromNumber(-1, false), false],
+		['negative small', Long.fromNumber(-100, false), false],
+		['negative large', Long.fromNumber(-2147483648, false), false],
+		['min int64', Long.fromString('-9223372036854775808', false), false],
+		['max int64', Long.fromString('9223372036854775807', false), false],
+		['-1 as signed Long', Long.fromBits(-1, -1, false), false],
+
+		// Tricky bit patterns
+		['high=1, low=0', Long.fromBits(0, 1, true), true],
+		['high=0, low=-1 (0xFFFFFFFF)', Long.fromBits(-1, 0, true), true],
+		['high=-1, low=-1 unsigned (max uint64)', Long.fromBits(-1, -1, true), true],
+		['high=0x7FFFFFFF, low=0xFFFFFFFF (max int64)', Long.fromBits(-1, 0x7fffffff, false), false],
+		['high=0x80000000, low=0 (min int64)', Long.fromBits(0, -2147483648, false), false],
+
+		// Powers of 2
+		['2^32', Long.fromString('4294967296', true), true],
+		['2^32 signed', Long.fromString('4294967296', false), false],
+		['2^48', Long.fromString('281474976710656', true), true],
+		['2^63', Long.fromString('9223372036854775808', true), true]
+	]
+
+	describe('longToString equivalence', () => {
+		for (const [desc, longVal, unsigned] of testCases) {
+			it(`${desc}: Long(${longVal.low}, ${longVal.high}, ${unsigned})`, () => {
+				const oldResult = longToStringOld(longVal, unsigned)
+				const newResult = longToStringNew(longVal, unsigned)
+				expect(newResult).toBe(oldResult)
+			})
+		}
+	})
+
+	describe('longToNumber equivalence', () => {
+		for (const [desc, longVal, unsigned] of testCases) {
+			it(`${desc}: Long(${longVal.low}, ${longVal.high}, ${unsigned})`, () => {
+				const oldResult = longToNumberOld(longVal, unsigned)
+				const newResult = longToNumberNew(longVal, unsigned)
+				// For large values, both may lose precision equally (Number limitation)
+				// So we compare string representations
+				expect(newResult.toString()).toBe(oldResult.toString())
+			})
+		}
+	})
+
+	describe('non-Long inputs (fallback paths)', () => {
+		it('string passthrough', () => {
+			expect(longToStringNew('12345')).toBe('12345')
+			expect(longToStringNew('0')).toBe('0')
+		})
+		it('number passthrough', () => {
+			expect(longToStringNew(42)).toBe('42')
+			expect(longToStringNew(0)).toBe('0')
+			expect(longToStringNew(-1)).toBe('-1')
+		})
+		it('null/undefined fallback', () => {
+			expect(longToStringNew(null)).toBe('null')
+			expect(longToStringNew(undefined)).toBe('undefined')
+		})
+		it('object without low/high', () => {
+			expect(longToStringNew({ foo: 'bar' })).toBe('[object Object]')
+		})
+	})
+
+	describe('fuzz: random Long values', () => {
+		it('100 random unsigned values match', () => {
+			for (let i = 0; i < 100; i++) {
+				const low = (Math.random() * 0xffffffff) | 0
+				const high = (Math.random() * 0xffffffff) | 0
+				const longVal = Long.fromBits(low, high, true)
+				const oldResult = longToStringOld(longVal, true)
+				const newResult = longToStringNew(longVal, true)
+				expect(newResult).toBe(oldResult)
+			}
+		})
+
+		it('100 random signed values match', () => {
+			for (let i = 0; i < 100; i++) {
+				const low = (Math.random() * 0xffffffff) | 0
+				const high = (Math.random() * 0xffffffff) | 0
+				const longVal = Long.fromBits(low, high, false)
+				const oldResult = longToStringOld(longVal, false)
+				const newResult = longToStringNew(longVal, false)
+				expect(newResult).toBe(oldResult)
+			}
+		})
+	})
+})

--- a/src/__tests__/proto-tojson-long.test.ts
+++ b/src/__tests__/proto-tojson-long.test.ts
@@ -1,3 +1,4 @@
+import Long from 'long'
 import '../index.js'
 import { proto } from '../../WAProto/index.js'
 
@@ -27,5 +28,88 @@ describe('proto serialization', () => {
 		expect(() => JSON.stringify(message)).not.toThrow()
 		const json = message.toJSON()
 		expect(json.message?.imageMessage?.fileLength).toBe('1234567890123456789')
+	})
+
+	it('converts Long objects to strings correctly via BigInt fast path', () => {
+		const message = proto.WebMessageInfo.fromObject({
+			key: {
+				remoteJid: '123@s.whatsapp.net',
+				id: 'ABC123',
+				fromMe: false
+			},
+			messageTimestamp: Long.fromNumber(1700000000, true),
+			message: {
+				imageMessage: {
+					fileLength: Long.fromString('9876543210', true)
+				}
+			}
+		})
+
+		const json = message.toJSON()
+		expect(json.messageTimestamp).toBe('1700000000')
+		expect(json.message?.imageMessage?.fileLength).toBe('9876543210')
+	})
+
+	it('handles large unsigned Long values (> MAX_SAFE_INTEGER)', () => {
+		const message = proto.WebMessageInfo.fromObject({
+			key: {
+				remoteJid: '123@s.whatsapp.net',
+				id: 'ABC123',
+				fromMe: false
+			},
+			messageTimestamp: Long.fromString('18446744073709551615', true), // max uint64
+			message: {
+				imageMessage: {
+					fileLength: Long.fromString('9999999999999999999', true)
+				}
+			}
+		})
+
+		const json = message.toJSON()
+		expect(json.messageTimestamp).toBe('18446744073709551615')
+		expect(json.message?.imageMessage?.fileLength).toBe('9999999999999999999')
+	})
+
+	it('handles zero and small Long values', () => {
+		const message = proto.WebMessageInfo.fromObject({
+			key: {
+				remoteJid: '123@s.whatsapp.net',
+				id: 'ABC123',
+				fromMe: false
+			},
+			messageTimestamp: Long.fromNumber(0, true),
+			message: {
+				imageMessage: {
+					fileLength: Long.fromNumber(1, true)
+				}
+			}
+		})
+
+		const json = message.toJSON()
+		expect(json.messageTimestamp).toBe('0')
+		expect(json.message?.imageMessage?.fileLength).toBe('1')
+	})
+
+	it('roundtrips encode/decode with Long fields preserving values', () => {
+		const original = proto.WebMessageInfo.fromObject({
+			key: {
+				remoteJid: '123@s.whatsapp.net',
+				id: 'ABC123',
+				fromMe: false
+			},
+			messageTimestamp: 1700000000,
+			message: {
+				imageMessage: {
+					fileLength: 123456789
+				}
+			}
+		})
+
+		const encoded = proto.WebMessageInfo.encode(original).finish()
+		const decoded = proto.WebMessageInfo.decode(encoded)
+		const json = decoded.toJSON()
+
+		expect(json.messageTimestamp).toBe('1700000000')
+		expect(json.message?.imageMessage?.fileLength).toBe('123456789')
 	})
 })


### PR DESCRIPTION
reduce memory allocations and CPU time during history sync, especially for accounts with large chat histories that cause memory spikes after scanning.

profiling a production instance (6h window, node 20) showed memory peaks up to ~8GB during history sync. the main bottlenecks were protobuf Long-to-string conversion (7.6% CPU), unnecessary buffer copies during media decryption, and redundant object allocations in history processing.

### changes

**1. replace Long library with native BigInt for protobuf conversion**

`longToString`/`longToNumber` in WAProto previously used the `long` library's pure JS division loops for base-10 conversion. replaced with direct BigInt bitwise conversion (`(BigInt(high >>> 0) << 32n) | BigInt(low >>> 0)`), which delegates to V8's native C++ `toString()`.

**2. stream-pipe zlib in `downloadHistory`**

instead of collecting all encrypted+decrypted chunks into an array, concatenating them, then inflating — pipe the decrypted stream directly through `createInflate()`. avoids allocating the full compressed buffer as an intermediate step.

**3. remove unnecessary `{ ...chat }` spread in `processHistoryMessage`**

each chat from the protobuf decode was being shallow-copied via spread before pushing to the result array. the original object is already mutated in-place and not referenced elsewhere after the function returns.

**4. skip `Buffer.concat` in media decryption when no remainder**

in `downloadEncryptedContent`, the transform was always calling `Buffer.concat([remainingBytes, chunk])` even when `remainingBytes` was empty (which is most of the time since chunks arrive AES-aligned). now skips the concat and uses the chunk directly.

### benchmarks

| change | before | after | improvement |
|--------|--------|-------|-------------|
| `longToString` (Long object -> string) | 237 ns/call | 52 ns/call | **4.6x faster** |
| `Buffer.concat` in media decrypt (per chunk) | 78ms / 25k chunks | 4ms / 25k chunks | **~19x faster** |
| chat object push (per chat) | 3.3 us/chat | 1.1 us/chat | **2.9x faster** |
| `downloadHistory` inflate (50MB payload) | ~111MB RSS peak | ~56MB RSS peak | **~50% less memory** |

### how this impacts history sync

during a full history sync (e.g. 200 chats, 10k messages), every message goes through protobuf decode -> `toJSON()` which calls `longToString` on every Long field (timestamps, file lengths, etc). the BigInt optimization directly reduces CPU time for this hot path.

the streaming inflate and concat skip reduce memory pressure during the download+decompress+decrypt pipeline, which is where the large memory spikes originate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate handling of large 64-bit integer conversions in protocol buffer serialization, preserving signed/unsigned semantics and preventing precision loss.

* **Performance**
  * Faster history downloads via streaming decompression.
  * Reduced memory allocations during encrypted message decryption.

* **Tests**
  * Added comprehensive tests validating large-integer conversions, serialization roundtrips, and fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->