### PR TITLE
fix: request placeholder resend for messages without encryption (CTWAads)

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -25,6 +25,9 @@ export const WA_DEFAULT_EPHEMERAL = 7 * 24 * 60 * 60
 /** Status messages older than 24 hours are considered expired */
 export const STATUS_EXPIRY_SECONDS = 24 * 60 * 60
 
+/** WA Web enforces a 14-day maximum age for placeholder resend requests */
+export const PLACEHOLDER_MAX_AGE_SECONDS = 14 * 24 * 60 * 60
+
 export const NOISE_MODE = 'Noise_XX_25519_AESGCM_SHA256\0\0\0\0'
 export const DICT_VERSION = 3
 export const KEY_BUNDLE_TYPE = Buffer.from([5])

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -3,7 +3,13 @@ import { Boom } from '@hapi/boom'
 import { randomBytes } from 'crypto'
 import Long from 'long'
 import { proto } from '../../WAProto/index.js'
-import { DEFAULT_CACHE_TTLS, KEY_BUNDLE_TYPE, MIN_PREKEY_COUNT, STATUS_EXPIRY_SECONDS } from '../Defaults'
+import {
+	DEFAULT_CACHE_TTLS,
+	KEY_BUNDLE_TYPE,
+	MIN_PREKEY_COUNT,
+	PLACEHOLDER_MAX_AGE_SECONDS,
+	STATUS_EXPIRY_SECONDS
+} from '../Defaults'
 import type {
 	GroupParticipant,
 	MessageReceiptType,
@@ -141,7 +147,10 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		return sendPeerDataOperationMessage(pdoMessage)
 	}
 
-	const requestPlaceholderResend = async (messageKey: WAMessageKey): Promise<string | undefined> => {
+	const requestPlaceholderResend = async (
+		messageKey: WAMessageKey,
+		msgData?: Partial<WAMessage>
+	): Promise<string | undefined> => {
 		if (!authState.creds.me?.id) {
 			throw new Boom('Not authenticated')
 		}
@@ -150,7 +159,9 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			logger.debug({ messageKey }, 'already requested resend')
 			return
 		} else {
-			await placeholderResendCache.set(messageKey?.id!, true)
+			// Store original message data so PDO response handler can preserve
+			// metadata (LID details, timestamps, etc.) that the phone may omit
+			await placeholderResendCache.set(messageKey?.id!, msgData || true)
 		}
 
 		await delay(2000)
@@ -1231,7 +1242,11 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 						// Check if this is eligible for placeholder resend (matching WA Web filters).
 						const unavailableNode = getBinaryNodeChild(node, 'unavailable')
 						const unavailableType = unavailableNode?.attrs?.type
-						if (unavailableType === 'bot_unavailable_fanout' || unavailableType === 'hosted_unavailable_fanout') {
+						if (
+							unavailableType === 'bot_unavailable_fanout' ||
+							unavailableType === 'hosted_unavailable_fanout' ||
+							unavailableType === 'view_once_unavailable_fanout'
+						) {
 							logger.debug(
 								{ msgId: msg.key.id, unavailableType },
 								'skipping placeholder resend for excluded unavailable type'
@@ -1239,8 +1254,6 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 							return sendMessageAck(node)
 						}
 
-						// WA Web enforces a 14-day maximum age for placeholder resend requests
-						const PLACEHOLDER_MAX_AGE_SECONDS = 14 * 24 * 60 * 60
 						const messageAge = unixTimestampSeconds() - toNumber(msg.messageTimestamp)
 						if (messageAge > PLACEHOLDER_MAX_AGE_SECONDS) {
 							logger.debug({ msgId: msg.key.id, messageAge }, 'skipping placeholder resend for old message')
@@ -1248,81 +1261,100 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 						}
 
 						// Request the real content from the phone via placeholder resend PDO.
+						// Upsert the CIPHERTEXT stub as a placeholder (like WA Web's processPlaceholderMsg),
+						// and store the requestId in stubParameters[1] so users can correlate
+						// with the incoming PDO response event.
 						const cleanKey: proto.IMessageKey = {
 							remoteJid: msg.key.remoteJid,
 							fromMe: msg.key.fromMe,
 							id: msg.key.id,
 							participant: msg.key.participant
 						}
-						requestPlaceholderResend(cleanKey)
+						// Cache the original message metadata so the PDO response handler
+						// can preserve key fields (LID details etc.) that the phone may omit
+						const msgData: Partial<WAMessage> = {
+							key: msg.key,
+							messageTimestamp: msg.messageTimestamp,
+							pushName: msg.pushName,
+							participant: msg.participant,
+							verifiedBizName: msg.verifiedBizName
+						}
+						requestPlaceholderResend(cleanKey, msgData)
 							.then(requestId => {
-								if (requestId) {
+								if (requestId && requestId !== 'RESOLVED') {
 									logger.debug({ msgId: msg.key.id, requestId }, 'requested placeholder resend for unavailable message')
+									ev.emit('messages.update', [
+										{
+											key: msg.key,
+											update: { messageStubParameters: [NO_MESSAGE_FOUND_ERROR_TEXT, requestId] }
+										}
+									])
 								}
 							})
 							.catch(err => {
 								logger.warn({ err, msgId: msg.key.id }, 'failed to request placeholder resend for unavailable message')
 							})
-						return sendMessageAck(node)
-					}
-
-					// Skip retry for expired status messages (>24h old)
-					if (isJidStatusBroadcast(msg.key.remoteJid!)) {
-						const messageAge = unixTimestampSeconds() - toNumber(msg.messageTimestamp)
-						if (messageAge > STATUS_EXPIRY_SECONDS) {
-							logger.debug(
-								{ msgId: msg.key.id, messageAge, remoteJid: msg.key.remoteJid },
-								'skipping retry for expired status message'
-							)
-							return sendMessageAck(node)
-						}
-					}
-
-					const errorMessage = msg?.messageStubParameters?.[0] || ''
-					const isPreKeyError = errorMessage.includes('PreKey')
-
-					logger.debug(`[handleMessage] Attempting retry request for failed decryption`)
-
-					// Handle both pre-key and normal retries in single mutex
-					await retryMutex.mutex(async () => {
-						try {
-							if (!ws.isOpen) {
-								logger.debug({ node }, 'Connection closed, skipping retry')
-								return
+						await sendMessageAck(node)
+						// Don't return — fall through to upsertMessage so the stub is emitted
+					} else {
+						// Skip retry for expired status messages (>24h old)
+						if (isJidStatusBroadcast(msg.key.remoteJid!)) {
+							const messageAge = unixTimestampSeconds() - toNumber(msg.messageTimestamp)
+							if (messageAge > STATUS_EXPIRY_SECONDS) {
+								logger.debug(
+									{ msgId: msg.key.id, messageAge, remoteJid: msg.key.remoteJid },
+									'skipping retry for expired status message'
+								)
+								return sendMessageAck(node)
 							}
+						}
 
-							// Handle pre-key errors with upload and delay
-							if (isPreKeyError) {
-								logger.info({ error: errorMessage }, 'PreKey error detected, uploading and retrying')
+						const errorMessage = msg?.messageStubParameters?.[0] || ''
+						const isPreKeyError = errorMessage.includes('PreKey')
 
+						logger.debug(`[handleMessage] Attempting retry request for failed decryption`)
+
+						// Handle both pre-key and normal retries in single mutex
+						await retryMutex.mutex(async () => {
+							try {
+								if (!ws.isOpen) {
+									logger.debug({ node }, 'Connection closed, skipping retry')
+									return
+								}
+
+								// Handle pre-key errors with upload and delay
+								if (isPreKeyError) {
+									logger.info({ error: errorMessage }, 'PreKey error detected, uploading and retrying')
+
+									try {
+										logger.debug('Uploading pre-keys for error recovery')
+										await uploadPreKeys(5)
+										logger.debug('Waiting for server to process new pre-keys')
+										await delay(1000)
+									} catch (uploadErr) {
+										logger.error({ uploadErr }, 'Pre-key upload failed, proceeding with retry anyway')
+									}
+								}
+
+								const encNode = getBinaryNodeChild(node, 'enc')
+								await sendRetryRequest(node, !encNode)
+								if (retryRequestDelayMs) {
+									await delay(retryRequestDelayMs)
+								}
+							} catch (err) {
+								logger.error({ err, isPreKeyError }, 'Failed to handle retry, attempting basic retry')
+								// Still attempt retry even if pre-key upload failed
 								try {
-									logger.debug('Uploading pre-keys for error recovery')
-									await uploadPreKeys(5)
-									logger.debug('Waiting for server to process new pre-keys')
-									await delay(1000)
-								} catch (uploadErr) {
-									logger.error({ uploadErr }, 'Pre-key upload failed, proceeding with retry anyway')
+									const encNode = getBinaryNodeChild(node, 'enc')
+									await sendRetryRequest(node, !encNode)
+								} catch (retryErr) {
+									logger.error({ retryErr }, 'Failed to send retry after error handling')
 								}
 							}
 
-							const encNode = getBinaryNodeChild(node, 'enc')
-							await sendRetryRequest(node, !encNode)
-							if (retryRequestDelayMs) {
-								await delay(retryRequestDelayMs)
-							}
-						} catch (err) {
-							logger.error({ err, isPreKeyError }, 'Failed to handle retry, attempting basic retry')
-							// Still attempt retry even if pre-key upload failed
-							try {
-								const encNode = getBinaryNodeChild(node, 'enc')
-								await sendRetryRequest(node, !encNode)
-							} catch (retryErr) {
-								logger.error({ retryErr }, 'Failed to send retry after error handling')
-							}
-						}
-
-						await sendMessageAck(node, NACK_REASONS.UnhandledError)
-					})
+							await sendMessageAck(node, NACK_REASONS.UnhandledError)
+						})
+					}
 				} else {
 					if (messageRetryManager && msg.key.id) {
 						messageRetryManager.cancelPendingPhoneRequest(msg.key.id)

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -358,15 +358,34 @@ const processMessage = async (
 						//eslint-disable-next-line max-depth
 						try {
 							const webMessageInfo = proto.WebMessageInfo.decode(retryResponse.webMessageInfoBytes)
-							// Clean up placeholder resend cache using the original message ID
+							const msgId = webMessageInfo.key?.id
+							// Retrieve cached original message data (preserves LID details,
+							// timestamps, etc. that the phone may omit in its PDO response)
+							const cachedData = msgId ? await placeholderResendCache?.get<Partial<WAMessage> | true>(msgId) : undefined
 							//eslint-disable-next-line max-depth
-							if (webMessageInfo.key?.id) {
-								await placeholderResendCache?.del(webMessageInfo.key.id)
+							if (msgId) {
+								await placeholderResendCache?.del(msgId)
 							}
 
-							// TODO: parse through proper message handling utilities (to add relevant key fields)
+							let finalMsg: WAMessage
+							//eslint-disable-next-line max-depth
+							if (cachedData && typeof cachedData === 'object') {
+								// Apply decoded message content onto cached metadata (preserves LID etc.)
+								cachedData.message = webMessageInfo.message
+								//eslint-disable-next-line max-depth
+								if (webMessageInfo.messageTimestamp) {
+									cachedData.messageTimestamp = webMessageInfo.messageTimestamp
+								}
+
+								finalMsg = cachedData as WAMessage
+							} else {
+								finalMsg = webMessageInfo as WAMessage
+							}
+
+							logger?.debug({ msgId, requestId: response.stanzaId }, 'received placeholder resend')
+
 							ev.emit('messages.upsert', {
-								messages: [webMessageInfo as WAMessage],
+								messages: [finalMsg],
 								type: 'notify',
 								requestId: response.stanzaId!
 							})


### PR DESCRIPTION
fixes #1723

messages from Facebook/Instagram Click-to-WhatsApp ads arrive at companion devices without an `enc` node — Meta's ads endpoint doesn't encrypt for linked devices. previously Baileys just ACKed and silently dropped these, so `messages.upsert` was never fired.

the phone has the real message. WhatsApp Web and whatsmeow both request a **placeholder resend** via PDO (Peer Data Operation) to get it. Baileys already had the `requestPlaceholderResend` infrastructure but never called it for this case.

### how it works end-to-end (just for reference)

1. ads message arrives without `enc` node → `decryptables === 0` → CIPHERTEXT stub
2. handler ACKs the stanza and upserts the CIPHERTEXT stub as a placeholder (like WA Web's `processPlaceholderMsg`)
3. `requestPlaceholderResend(cleanKey, msgData)` fires in the background, caching the original message metadata (key w/ LID, pushName, etc.)
4. `messages.update` emits with the `requestId` in `stubParameters[1]` so consumers can correlate
5. after 2s dedup window, PDO request is sent to phone
6. phone responds with `PEER_DATA_OPERATION_REQUEST_RESPONSE_MESSAGE`
7. `processMessage` decodes `webMessageInfoBytes`, merges with cached metadata (preserves LID details the phone may omit)
8. `messages.upsert` fires with the real decoded message

also fixes null safety / cache key bugs in the existing PDO response handler and adds WA Web's filters (excludes `bot_unavailable_fanout`, `hosted_unavailable_fanout`, `view_once_unavailable_fanout`, and messages older than 14 days).