### PR TITLE
calls: Decrypt call key and include node in call event + offer receipt

### DIFF
--- a/Example/example.ts
+++ b/Example/example.ts
@@ -200,6 +200,10 @@ const startSock = async() => {
 				logger.debug(events['chats.update'])
 			}
 
+			if (events['call']) {
+				logger.debug(events['call'], 'call received')
+			}
+
 			if(events['contacts.update']) {
 				for(const contact of events['contacts.update']) {
 					if(typeof contact.imgUrl !== 'undefined') {

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1347,6 +1347,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		const from = infoChild.attrs.from! || infoChild.attrs['call-creator']!
 
 		const call: WACallEvent = {
+			node,
 			chatId: attrs.from!,
 			from,
 			callerPn: infoChild.attrs['caller_pn'],
@@ -1361,6 +1362,76 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			call.isGroup = infoChild.attrs.type === 'group' || !!infoChild.attrs['group-jid']
 			call.groupJid = infoChild.attrs['group-jid']
 			await callOfferCache.set(call.id, call)
+			// Decrypt call enc
+			const { fullMessage: msg, decrypt } = decryptMessageNode(
+				node,
+				authState.creds.me!.id,
+				authState.creds.me!.lid || '',
+				signalRepository,
+				logger
+			)
+
+			await decrypt()
+
+			// call key enc failed to decrypt
+			if (msg.messageStubType === proto.WebMessageInfo.StubType.CIPHERTEXT && msg.category !== 'peer') {
+				if (msg?.messageStubParameters?.[0] === MISSING_KEYS_ERROR_TEXT) {
+					return sendMessageAck(node, NACK_REASONS.ParsingError)
+				}
+
+				const errorMessage = msg?.messageStubParameters?.[0] || ''
+				const isPreKeyError = errorMessage.includes('PreKey')
+
+				logger.debug(`[handleCall] Attempting retry request for failed decryption`)
+
+				// Handle both pre-key and normal retries in single mutex
+				await retryMutex.mutex(async () => {
+					try {
+						if (!ws.isOpen) {
+							logger.debug({ node }, 'Connection closed, skipping retry')
+							return
+						}
+
+						// Handle pre-key errors with upload and delay
+						if (isPreKeyError) {
+							logger.info({ error: errorMessage }, 'PreKey error detected, uploading and retrying')
+
+							try {
+								logger.debug('Uploading pre-keys for error recovery')
+								await uploadPreKeys(5)
+								logger.debug('Waiting for server to process new pre-keys')
+								await delay(1000)
+							} catch (uploadErr) {
+								logger.error({ uploadErr }, 'Pre-key upload failed, proceeding with retry anyway')
+							}
+						}
+
+						const encNode = getBinaryNodeChild(node, 'enc')
+						await sendRetryRequest(node, !encNode)
+						if (retryRequestDelayMs) {
+							await delay(retryRequestDelayMs)
+						}
+					} catch (err) {
+						logger.error({ err, isPreKeyError }, 'Failed to handle retry, attempting basic retry')
+						// Still attempt retry even if pre-key upload failed
+						try {
+							const encNode = getBinaryNodeChild(node, 'enc')
+							await sendRetryRequest(node, !encNode)
+						} catch (retryErr) {
+							logger.error({ retryErr }, 'Failed to send retry after error handling')
+						}
+					}
+
+					await sendMessageAck(node, NACK_REASONS.UnhandledError)
+				})
+			} else {
+				// call key enc decrypted
+				if (messageRetryManager && msg.key.id) {
+					messageRetryManager.cancelPendingPhoneRequest(msg.key.id)
+				}
+
+				call.callKey = msg.message?.call?.callKey
+			}
 		}
 
 		const existingCall = await callOfferCache.get<WACallEvent>(call.id)

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -367,6 +367,10 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			stanza.attrs.from = authState.creds.me!.id
 		}
 
+		if (tag === 'call') {
+			stanza.attrs.type = (content?.[0] as BinaryNode)?.tag
+		}
+
 		logger.debug({ recv: { tag, attrs }, sent: stanza.attrs }, 'sent ack')
 		await sendNode(stanza)
 	}

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -30,6 +30,7 @@ import {
 	encodeSignedDeviceIdentity,
 	extractAddressingContext,
 	getCallStatusFromNode,
+	getDecryptionJid,
 	getHistoryMsg,
 	getNextPreKeys,
 	getStatusFromReceiptType,
@@ -40,6 +41,7 @@ import {
 	NO_MESSAGE_FOUND_ERROR_TEXT,
 	toNumber,
 	unixTimestampSeconds,
+	unpadRandomMax16,
 	xmppPreKey,
 	xmppSignedPreKey
 } from '../Utils'
@@ -85,6 +87,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		sendNode,
 		relayMessage,
 		sendReceipt,
+		sendCallReceipt,
 		uploadPreKeys,
 		sendPeerDataOperationMessage,
 		messageRetryManager
@@ -1344,12 +1347,12 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 
 		const callId = infoChild.attrs['call-id']!
-		const from = infoChild.attrs.from! || infoChild.attrs['call-creator']!
+		const caller = infoChild.attrs['call-creator']! || infoChild.attrs['caller_pn'] || infoChild.attrs.from!
 
 		const call: WACallEvent = {
 			node,
 			chatId: attrs.from!,
-			from,
+			caller,
 			callerPn: infoChild.attrs['caller_pn'],
 			id: callId,
 			date: new Date(+attrs.t! * 1000),
@@ -1363,75 +1366,126 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			call.groupJid = infoChild.attrs['group-jid']
 			await callOfferCache.set(call.id, call)
 			// Decrypt call enc
-			const { fullMessage: msg, decrypt } = decryptMessageNode(
-				node,
-				authState.creds.me!.id,
-				authState.creds.me!.lid || '',
-				signalRepository,
-				logger
-			)
+			if (Array.isArray(infoChild.content)) {
+				for (const encNode of infoChild.content) {
+					if (encNode.tag !== 'enc') {
+						continue
+					}
 
-			await decrypt()
+					if (!(encNode.content instanceof Uint8Array)) {
+						continue
+					}
 
-			// call key enc failed to decrypt
-			if (msg.messageStubType === proto.WebMessageInfo.StubType.CIPHERTEXT && msg.category !== 'peer') {
-				if (msg?.messageStubParameters?.[0] === MISSING_KEYS_ERROR_TEXT) {
-					return sendMessageAck(node, NACK_REASONS.ParsingError)
-				}
+					let msgBuffer: Uint8Array
 
-				const errorMessage = msg?.messageStubParameters?.[0] || ''
-				const isPreKeyError = errorMessage.includes('PreKey')
+					const decryptionJid = await getDecryptionJid(caller, signalRepository)
 
-				logger.debug(`[handleCall] Attempting retry request for failed decryption`)
+					if (
+						infoChild.attrs['call-creator'] &&
+						infoChild.attrs['caller_pn'] &&
+						isLidUser(infoChild.attrs['call-creator'])
+					) {
+						// TODO: How does HOSTED enc work here?
+						await signalRepository.lidMapping.storeLIDPNMappings([
+							{ lid: infoChild.attrs['call-creator'], pn: infoChild.attrs['caller_pn'] }
+						])
+						await signalRepository.migrateSession(infoChild.attrs['caller_pn'], infoChild.attrs['call-creator'])
+					}
 
-				// Handle both pre-key and normal retries in single mutex
-				await retryMutex.mutex(async () => {
 					try {
-						if (!ws.isOpen) {
-							logger.debug({ node }, 'Connection closed, skipping retry')
-							return
+						//eslint-disable-next-line max-depth
+						switch (encNode.attrs.type) {
+							case 'skmsg':
+								// TODO: investigate group calls
+								msgBuffer = await signalRepository.decryptGroupMessage({
+									group: attrs.from!,
+									authorJid: caller,
+									msg: encNode.content
+								})
+								break
+							case 'pkmsg':
+							case 'msg':
+								msgBuffer = await signalRepository.decryptMessage({
+									jid: decryptionJid,
+									type: encNode.attrs.type,
+									ciphertext: encNode.content
+								})
+								break
+							default:
+								throw new Error(`Unknown e2e type: ${encNode.attrs.type}`)
 						}
 
-						// Handle pre-key errors with upload and delay
-						if (isPreKeyError) {
-							logger.info({ error: errorMessage }, 'PreKey error detected, uploading and retrying')
-
+						let msg: proto.IMessage = proto.Message.decode(unpadRandomMax16(msgBuffer))
+						msg = msg.deviceSentMessage?.message || msg
+						//eslint-disable-next-line max-depth
+						if (msg.senderKeyDistributionMessage) {
+							//eslint-disable-next-line max-depth
 							try {
-								logger.debug('Uploading pre-keys for error recovery')
-								await uploadPreKeys(5)
-								logger.debug('Waiting for server to process new pre-keys')
-								await delay(1000)
-							} catch (uploadErr) {
-								logger.error({ uploadErr }, 'Pre-key upload failed, proceeding with retry anyway')
+								await signalRepository.processSenderKeyDistributionMessage({
+									authorJid: caller,
+									item: msg.senderKeyDistributionMessage
+								})
+							} catch (err) {
+								logger.error({ caller, callId, err }, 'failed to process sender key distribution message from call')
 							}
 						}
 
-						const encNode = getBinaryNodeChild(node, 'enc')
-						await sendRetryRequest(node, !encNode)
-						if (retryRequestDelayMs) {
-							await delay(retryRequestDelayMs)
-						}
-					} catch (err) {
-						logger.error({ err, isPreKeyError }, 'Failed to handle retry, attempting basic retry')
-						// Still attempt retry even if pre-key upload failed
-						try {
-							const encNode = getBinaryNodeChild(node, 'enc')
-							await sendRetryRequest(node, !encNode)
-						} catch (retryErr) {
-							logger.error({ retryErr }, 'Failed to send retry after error handling')
-						}
+						//eslint-disable-next-line max-depth
+						if (!msg.call) logger.error({ caller, callId, msg }, 'missing call message from call enc')
+
+						call.callKey = msg.call?.callKey
+					} catch (err: any) {
+						const errorMessage = err.message.toString()
+						const isPreKeyError = errorMessage.includes('PreKey')
+						logger.error({ err, caller, callId, isPreKeyError }, 'failed to decrypt call enc')
+
+						logger.debug({}, `[handleCall] Attempting retry request for failed decryption`)
+
+						// Handle both pre-key and normal retries in single mutex
+						await retryMutex.mutex(async () => {
+							try {
+								if (!ws.isOpen) {
+									logger.debug({ node }, 'Connection closed, skipping retry')
+									return
+								}
+
+								// Handle pre-key errors with upload and delay
+								if (isPreKeyError) {
+									logger.info({ error: errorMessage }, 'PreKey error detected, uploading and retrying')
+
+									try {
+										logger.debug('Uploading pre-keys for error recovery')
+										await uploadPreKeys(5)
+										logger.debug('Waiting for server to process new pre-keys')
+										await delay(1000)
+									} catch (uploadErr) {
+										logger.error({ uploadErr }, 'Pre-key upload failed, proceeding with retry anyway')
+									}
+								}
+
+								// TODO: Implement voip_1x1_retry
+								//const encNode = getBinaryNodeChild(infoChild, 'enc')
+								//await sendRetryRequest(node, !encNode)
+								if (retryRequestDelayMs) {
+									await delay(retryRequestDelayMs)
+								}
+							} catch (err) {
+								logger.error({ err, isPreKeyError }, 'Failed to handle retry, attempting basic retry')
+								// Still attempt retry even if pre-key upload failed
+								try {
+									//const encNode = getBinaryNodeChild(infoChild, 'enc')
+									//await sendRetryRequest(node, !encNode)
+								} catch (retryErr) {
+									logger.error({ retryErr }, 'Failed to send retry after error handling')
+								}
+							}
+						})
 					}
-
-					await sendMessageAck(node, NACK_REASONS.UnhandledError)
-				})
-			} else {
-				// call key enc decrypted
-				if (messageRetryManager && msg.key.id) {
-					messageRetryManager.cancelPendingPhoneRequest(msg.key.id)
 				}
-
-				call.callKey = msg.message?.call?.callKey
 			}
+			await sendCallReceipt(node)
+		} else {
+			await sendMessageAck(node)
 		}
 
 		const existingCall = await callOfferCache.get<WACallEvent>(call.id)
@@ -1449,8 +1503,6 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 
 		ev.emit('call', [call])
-
-		await sendMessageAck(node)
 	}
 
 	const handleBadAck = async ({ attrs }: BinaryNode) => {
@@ -1618,38 +1670,6 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	})
 	ws.on('CB:ack,class:message', (node: BinaryNode) => {
 		handleBadAck(node).catch(error => onUnexpectedError(error, 'handling bad ack'))
-	})
-
-	ev.on('call', async ([call]) => {
-		if (!call) {
-			return
-		}
-
-		// missed call + group call notification message generation
-		if (call.status === 'timeout' || (call.status === 'offer' && call.isGroup)) {
-			const msg: WAMessage = {
-				key: {
-					remoteJid: call.chatId,
-					id: call.id,
-					fromMe: false
-				},
-				messageTimestamp: unixTimestampSeconds(call.date)
-			}
-			if (call.status === 'timeout') {
-				if (call.isGroup) {
-					msg.messageStubType = call.isVideo
-						? WAMessageStubType.CALL_MISSED_GROUP_VIDEO
-						: WAMessageStubType.CALL_MISSED_GROUP_VOICE
-				} else {
-					msg.messageStubType = call.isVideo ? WAMessageStubType.CALL_MISSED_VIDEO : WAMessageStubType.CALL_MISSED_VOICE
-				}
-			} else {
-				msg.message = { call: { callKey: Buffer.from(call.id) } }
-			}
-
-			const protoMsg = proto.WebMessageInfo.fromObject(msg) as WAMessage
-			await upsertMessage(protoMsg, call.offline ? 'append' : 'notify')
-		}
 	})
 
 	ev.on('connection.update', ({ isOnline }) => {

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -25,6 +25,7 @@ import {
 	generateMessageIDV2,
 	generateParticipantHashV2,
 	generateWAMessage,
+	getCallStatusFromNode,
 	getStatusCodeForMediaRetry,
 	getUrlFromDirectPath,
 	getWAUploadToServer,
@@ -41,6 +42,7 @@ import {
 	type BinaryNode,
 	type BinaryNodeAttributes,
 	type FullJid,
+	getAllBinaryNodeChildren,
 	getBinaryNodeChild,
 	getBinaryNodeChildren,
 	isHostedLidUser,
@@ -131,6 +133,40 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		}
 
 		return mediaConn
+	}
+
+	/**
+	 * Call receipt
+	 */
+	const sendCallReceipt = async (node: BinaryNode) => {
+		if (!authState.creds.me) throw new Boom('Client must be logged in')
+
+		if (node.tag !== 'call') {
+			logger.error({ node }, 'sendCallReceipt called on a node that isnt a <call/>')
+			return
+		}
+
+		const [infoNode] = getAllBinaryNodeChildren(node)
+		if (!infoNode) {
+			logger.error({ node }, '[sendCallReceipt] call node is missing an info child')
+			return
+		}
+
+		const { tag: type, attrs: callAttrs } = infoNode
+
+		const receipt: BinaryNode = {
+			tag: 'receipt',
+			attrs: {
+				id: node.attrs.id!,
+				to: node.attrs.from!,
+				from: authState.creds.me.id
+			},
+			content: [
+				{ tag: type, attrs: { 'call-creator': callAttrs['call-creator'] || '', 'call-id': callAttrs['call-id'] || '' } }
+			]
+		}
+
+		await sendNode(receipt)
 	}
 
 	/**
@@ -1155,6 +1191,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		getUSyncDevices,
 		messageRetryManager,
 		updateMemberLabel,
+		sendCallReceipt,
 		updateMediaMessage: async (message: WAMessage) => {
 			const content = assertMediaContent(message.message)
 			const mediaKey = content.mediaKey!

--- a/src/Types/Call.ts
+++ b/src/Types/Call.ts
@@ -1,6 +1,9 @@
+import type { BinaryNode } from '../WABinary'
+
 export type WACallUpdateType = 'offer' | 'ringing' | 'timeout' | 'reject' | 'accept' | 'terminate'
 
 export type WACallEvent = {
+	node: BinaryNode
 	chatId: string
 	from: string
 	callerPn?: string
@@ -12,4 +15,5 @@ export type WACallEvent = {
 	status: WACallUpdateType
 	offline: boolean
 	latencyMs?: number
+	callKey?: Uint8Array | null
 }

--- a/src/Types/Call.ts
+++ b/src/Types/Call.ts
@@ -5,7 +5,7 @@ export type WACallUpdateType = 'offer' | 'ringing' | 'timeout' | 'reject' | 'acc
 export type WACallEvent = {
 	node: BinaryNode
 	chatId: string
-	from: string
+	caller: string
 	callerPn?: string
 	isGroup?: boolean
 	groupJid?: string


### PR DESCRIPTION
# Call Key Decryption

This PR allows you to get the call key needed to do call encryption directly through baileys. It also includes the node to be able to configure call settings according to the values.

----

Support development progress by contributing with PRs and issues or with a sponsorship at https://purpshell.dev/sponsor.

Thank you for everyone who makes my work possible.