### PR TITLE
fix: streamline JID handling by removing redundant checks and acknowledgments

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1573,7 +1573,17 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	) => {
 		// Fast path: ack and drop ignored JIDs before entering the buffer/queue
 		const from = node.attrs.from
-		if (from && from !== S_WHATSAPP_NET && shouldIgnoreJid(from)) {
+		let ignoreJid = from
+		if (type === 'receipt' && from) {
+			const attrs = node.attrs
+			const isLid = attrs.from!.includes('lid')
+			const isNodeFromMe = areJidsSameUser(
+				attrs.participant || attrs.from,
+				isLid ? authState.creds.me?.lid : authState.creds.me?.id
+			)
+			ignoreJid = !isNodeFromMe || isJidGroup(attrs.from) ? attrs.from : attrs.recipient
+		}
+		if (ignoreJid && ignoreJid !== S_WHATSAPP_NET && shouldIgnoreJid(ignoreJid)) {
 			await sendMessageAck(node, type === 'message' ? NACK_REASONS.UnhandledError : undefined)
 			return
 		}

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1572,12 +1572,10 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		exec: (node: BinaryNode) => Promise<void>
 	) => {
 		// Fast path: ack and drop ignored JIDs before entering the buffer/queue
-		if (type !== 'call') {
-			const from = node.attrs.from
-			if (from && from !== S_WHATSAPP_NET && shouldIgnoreJid(from)) {
-				await sendMessageAck(node, type === 'message' ? NACK_REASONS.UnhandledError : undefined)
-				return
-			}
+		const from = node.attrs.from
+		if (from && from !== S_WHATSAPP_NET && shouldIgnoreJid(from)) {
+			await sendMessageAck(node, type === 'message' ? NACK_REASONS.UnhandledError : undefined)
+			return
 		}
 
 		const isOffline = !!node.attrs.offline

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1064,12 +1064,6 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			participant: attrs.participant
 		}
 
-		if (shouldIgnoreJid(remoteJid!) && remoteJid !== S_WHATSAPP_NET) {
-			logger.debug({ remoteJid }, 'ignoring receipt from jid')
-			await sendMessageAck(node)
-			return
-		}
-
 		const ids = [attrs.id!]
 		if (Array.isArray(content)) {
 			const items = getBinaryNodeChildren(content[0], 'item')
@@ -1144,11 +1138,6 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 
 	const handleNotification = async (node: BinaryNode) => {
 		const remoteJid = node.attrs.from
-		if (shouldIgnoreJid(remoteJid!) && remoteJid !== S_WHATSAPP_NET) {
-			logger.debug({ remoteJid, id: node.attrs.id }, 'ignored notification')
-			await sendMessageAck(node)
-			return
-		}
 
 		try {
 			await Promise.all([
@@ -1180,12 +1169,6 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	}
 
 	const handleMessage = async (node: BinaryNode) => {
-		if (shouldIgnoreJid(node.attrs.from!) && node.attrs.from !== S_WHATSAPP_NET) {
-			logger.debug({ key: node.attrs.key }, 'ignored message')
-			await sendMessageAck(node, NACK_REASONS.UnhandledError)
-			return
-		}
-
 		const encNode = getBinaryNodeChild(node, 'enc')
 		// TODO: temporary fix for crashes and issues resulting of failed msmsg decryption
 		if (encNode?.attrs.type === 'msmsg') {
@@ -1588,6 +1571,15 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		identifier: string,
 		exec: (node: BinaryNode) => Promise<void>
 	) => {
+		// Fast path: ack and drop ignored JIDs before entering the buffer/queue
+		if (type !== 'call') {
+			const from = node.attrs.from
+			if (from && from !== S_WHATSAPP_NET && shouldIgnoreJid(from)) {
+				await sendMessageAck(node, type === 'message' ? NACK_REASONS.UnhandledError : undefined)
+				return
+			}
+		}
+
 		const isOffline = !!node.attrs.offline
 
 		if (isOffline) {


### PR DESCRIPTION
Moves the shouldIgnoreJid check from inside each handler (handleMessage, handleReceipt, handleNotification) up into processNode so ignored JIDs are acked and dropped before entering the event buffer or offline queue.

Previously every ignored message still went through the full ev.buffer()/ev.flush() cycle and handler invocation just to be discarded. In setups with many sessions in a single process this added thousands of unnecessary buffer cycles for group/broadcast messages during history sync.

Messages still get a proper ack (error 500 for messages, clean ack for receipts/notifications) matching the original behavior. Calls are excluded since they don't use shouldIgnoreJid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized handling for messages from ignored contacts to streamline processing and reduce unnecessary work
  * Dropped inbound items from ignored senders earlier to improve responsiveness and offline buffering decisions
  * Refined acknowledgment behavior for ignored inbound items to ensure clearer signal handling and consistent responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->