### PR TITLE
fix: use MACOS platform to resolve 405 Connection Failure

### DIFF
--- a/src/Utils/validate-connection.ts
+++ b/src/Utils/validate-connection.ts
@@ -20,7 +20,7 @@ const getUserAgent = (config: SocketConfig): proto.ClientPayload.IUserAgent => {
 			secondary: config.version[1],
 			tertiary: config.version[2]
 		},
-		platform: proto.ClientPayload.UserAgent.Platform.WEB,
+		platform: proto.ClientPayload.UserAgent.Platform.MACOS,
 		releaseChannel: proto.ClientPayload.UserAgent.ReleaseChannel.RELEASE,
 		osVersion: '0.1',
 		device: 'Desktop',


### PR DESCRIPTION
## Fix for 405 Connection Failure (Issue #2364)

This PR resolves the 405 Connection Failure affecting ALL new Baileys connections globally as of 2026-02-24.

### Root Cause
WhatsApp servers have started rejecting the UserAgent.Platform.WEB (value 14) and now require MACOS (value 24) for new device pairing. The noise handshake succeeds, but WhatsApp then sends `<failure reason='405' location='xxx'/>` due to client payload validation failure.

### Solution
Changed `platform: proto.ClientPayload.UserAgent.Platform.WEB` to `platform: proto.ClientPayload.UserAgent.Platform.MACOS` in `src/Utils/validate-connection.ts`.

This aligns with WhatsApp Web's current behavior, which now identifies itself as MACOS platform rather than WEB.

### Impact
- ✅ Fixes QR code generation for new device pairing
- ✅ Does not affect existing authenticated sessions
- ✅ Minimal code change with maximum compatibility

### Testing
Confirmed that QR codes generate successfully after this change, resolving the global connection issues reported in issue #2364.

Closes #2364