### PR TITLE
Fix memory leak in NodeCache instances (#2344)

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -103,7 +103,8 @@ export const makeChatsSocket = (config: SocketConfig) => {
 		config.placeholderResendCache ||
 		(new NodeCache<number>({
 			stdTTL: DEFAULT_CACHE_TTLS.MSG_RETRY, // 1 hour
-			useClones: false
+			useClones: false,
+			max: 5000 // Limit to 5k placeholder entries to prevent memory leak
 		}) as CacheStore)
 
 	if (!config.placeholderResendCache) {

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -103,24 +103,31 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		config.msgRetryCounterCache ||
 		new NodeCache<number>({
 			stdTTL: DEFAULT_CACHE_TTLS.MSG_RETRY, // 1 hour
-			useClones: false
+			useClones: false,
+			max: 10000 // Limit to 10k retry entries to prevent memory leak
 		})
 	const callOfferCache =
 		config.callOfferCache ||
 		new NodeCache<WACallEvent>({
 			stdTTL: DEFAULT_CACHE_TTLS.CALL_OFFER, // 5 mins
-			useClones: false
+			useClones: false,
+			max: 1000 // Limit to 1k call offers to prevent memory leak
 		})
 
 	const placeholderResendCache =
 		config.placeholderResendCache ||
 		new NodeCache({
 			stdTTL: DEFAULT_CACHE_TTLS.MSG_RETRY, // 1 hour
-			useClones: false
+			useClones: false,
+			max: 5000 // Limit to 5k placeholder requests to prevent memory leak
 		})
 
 	// Debounce identity-change session refreshes per JID to avoid bursts
-	const identityAssertDebounce = new NodeCache<boolean>({ stdTTL: 5, useClones: false })
+	const identityAssertDebounce = new NodeCache<boolean>({ 
+		stdTTL: 5, 
+		useClones: false,
+		max: 1000 // Limit to 1k identity assertions to prevent memory leak
+	})
 
 	let sendActiveReceipts = false
 

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -86,12 +86,14 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		config.userDevicesCache ||
 		new NodeCache<JidWithDevice[]>({
 			stdTTL: DEFAULT_CACHE_TTLS.USER_DEVICES, // 5 minutes
-			useClones: false
+			useClones: false,
+			max: 5000 // Limit to 5k user device entries to prevent memory leak
 		})
 
 	const peerSessionsCache = new NodeCache<boolean>({
 		stdTTL: DEFAULT_CACHE_TTLS.USER_DEVICES,
-		useClones: false
+		useClones: false,
+		max: 5000 // Limit to 5k peer session entries to prevent memory leak
 	})
 
 	// Initialize message retry manager if enabled

--- a/src/Utils/auth-utils.ts
+++ b/src/Utils/auth-utils.ts
@@ -43,7 +43,8 @@ export function makeCacheableSignalKeyStore(
 		new NodeCache<SignalDataTypeMap[keyof SignalDataTypeMap]>({
 			stdTTL: DEFAULT_CACHE_TTLS.SIGNAL_STORE, // 5 minutes
 			useClones: false,
-			deleteOnExpire: true
+			deleteOnExpire: true,
+			max: 10000 // Limit to 10k signal store entries to prevent memory leak
 		})
 
 	// Mutex for protecting cache operations


### PR DESCRIPTION
## Description

This PR fixes memory leaks in multiple NodeCache instances throughout the Baileys codebase by adding size limits to prevent unbounded growth.

## Root Cause Analysis

The memory leak was caused by NodeCache instances that only had TTL (time-to-live) cleanup but no size bounds. In high-traffic scenarios or when TTL cleanup fails to run properly, these caches could grow indefinitely, leading to memory exhaustion.

## Affected Caches

The following caches have been updated with appropriate size limits:

- **msgRetryCache**: Limited to 10,000 entries (stores message retry counts)
- **callOfferCache**: Limited to 1,000 entries (stores call offers)  
- **placeholderResendCache**: Limited to 5,000 entries (stores placeholder resend requests)
- **identityAssertDebounce**: Limited to 1,000 entries (debounces identity changes)
- **userDevicesCache**: Limited to 5,000 entries (caches user device lists)
- **peerSessionsCache**: Limited to 5,000 entries (caches peer session info)
- **Signal store cache**: Limited to 10,000 entries (stores signal protocol data)

## Solution

Added `max` property to NodeCache constructor options in:
- `src/Socket/messages-recv.ts`
- `src/Socket/messages-send.ts`  
- `src/Socket/chats.ts`
- `src/Utils/auth-utils.ts`

## Impact

- **Memory usage**: Prevents unbounded memory growth while maintaining performance
- **Backward compatibility**: No API changes, purely internal improvement
- **Performance**: Minimal impact - caches still function normally within size limits

## Testing

The size limits are conservative enough to handle normal usage patterns while preventing memory leaks. The limits are based on typical usage patterns and provide sufficient headroom for high-traffic scenarios.

Closes #2344