### PR TITLE
fix: resolve Bad MAC, No Session, Invalid PreKey errors (#1769)

### DIFF
--- a/src/Signal/libsignal.ts
+++ b/src/Signal/libsignal.ts
@@ -68,14 +68,14 @@ export function makeLibSignalRepository(
 	 * acquire different mutex locks, allowing concurrent session modifications.
 	 * See: https://github.com/WhiskeySockets/Baileys/issues/1769
 	 */
-	const resolveCanonicalJid = async(jid: string): Promise<string> => {
-		if(isLidUser(jid) || isHostedLidUser(jid)) {
+	const resolveCanonicalJid = async (jid: string): Promise<string> => {
+		if (isLidUser(jid) || isHostedLidUser(jid)) {
 			return jid
 		}
 
-		if(isPnUser(jid) || isHostedPnUser(jid)) {
+		if (isPnUser(jid) || isHostedPnUser(jid)) {
 			const lid = await lidMapping.getLIDForPN(jid)
-			if(lid) {
+			if (lid) {
 				return lid
 			}
 		}
@@ -431,32 +431,32 @@ const jidToSignalSenderKeyName = (group: string, user: string): SenderKeyName =>
  */
 const PREKEY_GRACE_PERIOD_MS = 5 * 60 * 1000 // 5 minutes
 const PREKEY_CLEANUP_INTERVAL_MS = 60_000 // 1 minute
-const pendingPreKeyDeletions = new Map<string, { id: number, expiry: number, keys: SignalAuthState['keys'] }>()
+const pendingPreKeyDeletions = new Map<string, { id: number; expiry: number; keys: SignalAuthState['keys'] }>()
 
 let preKeyCleanupTimer: ReturnType<typeof setInterval> | undefined
 
 function ensurePreKeyCleanup() {
-	if(preKeyCleanupTimer) {
+	if (preKeyCleanupTimer) {
 		return
 	}
 
 	preKeyCleanupTimer = setInterval(() => {
 		const now = Date.now()
-		for(const [key, entry] of pendingPreKeyDeletions) {
-			if(now >= entry.expiry) {
-				entry.keys.set({ 'pre-key': { [entry.id]: null } })
+		for (const [key, entry] of pendingPreKeyDeletions) {
+			if (now >= entry.expiry) {
+				void entry.keys.set({ 'pre-key': { [entry.id]: null } })
 				pendingPreKeyDeletions.delete(key)
 			}
 		}
 
-		if(pendingPreKeyDeletions.size === 0 && preKeyCleanupTimer) {
+		if (pendingPreKeyDeletions.size === 0 && preKeyCleanupTimer) {
 			clearInterval(preKeyCleanupTimer)
 			preKeyCleanupTimer = undefined
 		}
 	}, PREKEY_CLEANUP_INTERVAL_MS)
 
 	// Don't block process exit
-	if(preKeyCleanupTimer && typeof preKeyCleanupTimer === 'object' && 'unref' in preKeyCleanupTimer) {
+	if (preKeyCleanupTimer && typeof preKeyCleanupTimer === 'object' && 'unref' in preKeyCleanupTimer) {
 		preKeyCleanupTimer.unref()
 	}
 }

--- a/src/Signal/libsignal.ts
+++ b/src/Signal/libsignal.ts
@@ -62,6 +62,27 @@ export function makeLibSignalRepository(
 		updateAgeOnGet: true
 	})
 
+	/**
+	 * Resolve a JID to its canonical (LID-preferred) form for use as transaction lock key.
+	 * This prevents race conditions where PN and LID JIDs for the same contact
+	 * acquire different mutex locks, allowing concurrent session modifications.
+	 * See: https://github.com/WhiskeySockets/Baileys/issues/1769
+	 */
+	const resolveCanonicalJid = async(jid: string): Promise<string> => {
+		if(isLidUser(jid) || isHostedLidUser(jid)) {
+			return jid
+		}
+
+		if(isPnUser(jid) || isHostedPnUser(jid)) {
+			const lid = await lidMapping.getLIDForPN(jid)
+			if(lid) {
+				return lid
+			}
+		}
+
+		return jid
+	}
+
 	const repository: SignalRepositoryWithLIDStore = {
 		decryptGroupMessage({ group, authorJid, msg }) {
 			const senderName = jidToSignalSenderKeyName(group, authorJid)
@@ -132,23 +153,27 @@ export function makeLibSignalRepository(
 				return result
 			}
 
-			// If it's not a sync message, we need to ensure atomicity
-			// For regular messages, we use a transaction to ensure atomicity
+			// Resolve to canonical (LID-preferred) JID for transaction lock key
+			// to prevent PN/LID race conditions on the same logical session
+			const canonicalJid = await resolveCanonicalJid(jid)
+
 			return parsedKeys.transaction(async () => {
 				return await doDecrypt()
-			}, jid)
+			}, canonicalJid)
 		},
 
 		async encryptMessage({ jid, data }) {
 			const addr = jidToSignalProtocolAddress(jid)
 			const cipher = new libsignal.SessionCipher(storage, addr)
 
-			// Use transaction to ensure atomicity
+			// Resolve to canonical (LID-preferred) JID for transaction lock key
+			const canonicalJid = await resolveCanonicalJid(jid)
+
 			return parsedKeys.transaction(async () => {
 				const { type: sigType, body } = await cipher.encrypt(data)
 				const type = sigType === 3 ? 'pkmsg' : 'msg'
 				return { type, ciphertext: Buffer.from(body, 'binary') }
-			}, jid)
+			}, canonicalJid)
 		},
 
 		async encryptGroupMessage({ group, meId, data }) {
@@ -337,9 +362,13 @@ export function makeLibSignalRepository(
 							// Session exists (guaranteed from device discovery)
 							const fromSession = libsignal.SessionRecord.deserialize(pnSession)
 							if (fromSession.haveOpenSession()) {
-								// Queue for bulk update: copy to LID, delete from PN
+								// Copy session to LID address but retain PN session.
+								// PN session must stay alive so in-flight messages
+								// addressed to the PN JID can still be decrypted.
+								// The PN session will naturally expire as new messages
+								// arrive under the LID address.
+								// See: https://github.com/WhiskeySockets/Baileys/issues/1769
 								sessionUpdates[lidAddrStr] = fromSession.serialize()
-								sessionUpdates[pnAddrStr] = null
 
 								migratedCount++
 							}
@@ -393,6 +422,43 @@ const jidToSignalProtocolAddress = (jid: string): libsignal.ProtocolAddress => {
 
 const jidToSignalSenderKeyName = (group: string, user: string): SenderKeyName => {
 	return new SenderKeyName(group, jidToSignalProtocolAddress(user))
+}
+
+/**
+ * Grace period before actually deleting used pre-keys.
+ * Retransmissions reusing the same pre-key ID will succeed during this window.
+ * See: https://github.com/WhiskeySockets/Baileys/issues/1769
+ */
+const PREKEY_GRACE_PERIOD_MS = 5 * 60 * 1000 // 5 minutes
+const PREKEY_CLEANUP_INTERVAL_MS = 60_000 // 1 minute
+const pendingPreKeyDeletions = new Map<string, { id: number, expiry: number, keys: SignalAuthState['keys'] }>()
+
+let preKeyCleanupTimer: ReturnType<typeof setInterval> | undefined
+
+function ensurePreKeyCleanup() {
+	if(preKeyCleanupTimer) {
+		return
+	}
+
+	preKeyCleanupTimer = setInterval(() => {
+		const now = Date.now()
+		for(const [key, entry] of pendingPreKeyDeletions) {
+			if(now >= entry.expiry) {
+				entry.keys.set({ 'pre-key': { [entry.id]: null } })
+				pendingPreKeyDeletions.delete(key)
+			}
+		}
+
+		if(pendingPreKeyDeletions.size === 0 && preKeyCleanupTimer) {
+			clearInterval(preKeyCleanupTimer)
+			preKeyCleanupTimer = undefined
+		}
+	}, PREKEY_CLEANUP_INTERVAL_MS)
+
+	// Don't block process exit
+	if(preKeyCleanupTimer && typeof preKeyCleanupTimer === 'object' && 'unref' in preKeyCleanupTimer) {
+		preKeyCleanupTimer.unref()
+	}
 }
 
 function signalStorage(
@@ -487,7 +553,13 @@ function signalStorage(
 				}
 			}
 		},
-		removePreKey: (id: number) => keys.set({ 'pre-key': { [id]: null } }),
+		removePreKey: (id: number) => {
+			// Delay pre-key deletion so retransmissions using the same
+			// pre-key ID can still decrypt during the grace period.
+			const key = `${id}`
+			pendingPreKeyDeletions.set(key, { id, expiry: Date.now() + PREKEY_GRACE_PERIOD_MS, keys })
+			ensurePreKeyCleanup()
+		},
 		loadSignedPreKey: () => {
 			const key = creds.signedPreKey
 			return {

--- a/src/Signal/libsignal.ts
+++ b/src/Signal/libsignal.ts
@@ -431,35 +431,6 @@ const jidToSignalSenderKeyName = (group: string, user: string): SenderKeyName =>
  */
 const PREKEY_GRACE_PERIOD_MS = 5 * 60 * 1000 // 5 minutes
 const PREKEY_CLEANUP_INTERVAL_MS = 60_000 // 1 minute
-const pendingPreKeyDeletions = new Map<string, { id: number; expiry: number; keys: SignalAuthState['keys'] }>()
-
-let preKeyCleanupTimer: ReturnType<typeof setInterval> | undefined
-
-function ensurePreKeyCleanup() {
-	if (preKeyCleanupTimer) {
-		return
-	}
-
-	preKeyCleanupTimer = setInterval(() => {
-		const now = Date.now()
-		for (const [key, entry] of pendingPreKeyDeletions) {
-			if (now >= entry.expiry) {
-				void entry.keys.set({ 'pre-key': { [entry.id]: null } })
-				pendingPreKeyDeletions.delete(key)
-			}
-		}
-
-		if (pendingPreKeyDeletions.size === 0 && preKeyCleanupTimer) {
-			clearInterval(preKeyCleanupTimer)
-			preKeyCleanupTimer = undefined
-		}
-	}, PREKEY_CLEANUP_INTERVAL_MS)
-
-	// Don't block process exit
-	if (preKeyCleanupTimer && typeof preKeyCleanupTimer === 'object' && 'unref' in preKeyCleanupTimer) {
-		preKeyCleanupTimer.unref()
-	}
-}
 
 function signalStorage(
 	{ creds, keys }: SignalAuthState,
@@ -469,6 +440,35 @@ function signalStorage(
 		loadIdentityKey(id: string): Promise<Uint8Array | undefined>
 		saveIdentity(id: string, identityKey: Uint8Array): Promise<boolean>
 	} {
+	// Scoped per-instance to prevent multi-account collisions
+	const pendingPreKeyDeletions = new Map<number, number>() // preKeyId → expiry timestamp
+	let preKeyCleanupTimer: ReturnType<typeof setInterval> | undefined
+
+	function ensurePreKeyCleanup() {
+		if (preKeyCleanupTimer) {
+			return
+		}
+
+		preKeyCleanupTimer = setInterval(() => {
+			const now = Date.now()
+			for (const [id, expiry] of pendingPreKeyDeletions) {
+				if (now >= expiry) {
+					void keys.set({ 'pre-key': { [id]: null } })
+					pendingPreKeyDeletions.delete(id)
+				}
+			}
+
+			if (pendingPreKeyDeletions.size === 0 && preKeyCleanupTimer) {
+				clearInterval(preKeyCleanupTimer)
+				preKeyCleanupTimer = undefined
+			}
+		}, PREKEY_CLEANUP_INTERVAL_MS)
+
+		// Don't block process exit
+		if (preKeyCleanupTimer && typeof preKeyCleanupTimer === 'object' && 'unref' in preKeyCleanupTimer) {
+			preKeyCleanupTimer.unref()
+		}
+	}
 	// Shared function to resolve PN signal address to LID if mapping exists
 	const resolveLIDSignalAddress = async (id: string): Promise<string> => {
 		if (id.includes('.')) {
@@ -556,8 +556,7 @@ function signalStorage(
 		removePreKey: (id: number) => {
 			// Delay pre-key deletion so retransmissions using the same
 			// pre-key ID can still decrypt during the grace period.
-			const key = `${id}`
-			pendingPreKeyDeletions.set(key, { id, expiry: Date.now() + PREKEY_GRACE_PERIOD_MS, keys })
+			pendingPreKeyDeletions.set(id, Date.now() + PREKEY_GRACE_PERIOD_MS)
 			ensurePreKeyCleanup()
 		},
 		loadSignedPreKey: () => {

--- a/src/Signal/libsignal.ts
+++ b/src/Signal/libsignal.ts
@@ -469,6 +469,7 @@ function signalStorage(
 			preKeyCleanupTimer.unref()
 		}
 	}
+
 	// Shared function to resolve PN signal address to LID if mapping exists
 	const resolveLIDSignalAddress = async (id: string): Promise<string> => {
 		if (id.includes('.')) {
@@ -522,9 +523,7 @@ function signalStorage(
 			const { [wireJid]: existingKey } = await keys.get('identity-key', [wireJid])
 
 			const keysMatch =
-				existingKey &&
-				existingKey.length === identityKey.length &&
-				existingKey.every((byte, i) => byte === identityKey[i])
+				existingKey?.length === identityKey.length && existingKey.every((byte, i) => byte === identityKey[i])
 
 			if (existingKey && !keysMatch) {
 				// Identity changed - clear session and update key

--- a/src/WAUSync/USyncQuery.ts
+++ b/src/WAUSync/USyncQuery.ts
@@ -46,7 +46,7 @@ export class USyncQuery {
 	}
 
 	parseUSyncQueryResult(result: BinaryNode | undefined): USyncQueryResult | undefined {
-		if (!result || result.attrs.type !== 'result') {
+		if (result?.attrs.type !== 'result') {
 			return
 		}
 


### PR DESCRIPTION
## Problem

Users experience persistent decryption failures manifesting as:
- `Bad MAC` / `Failed to decrypt`
- `No matching session`
- `Invalid PreKey ID`

These errors are the most reported issue in the repository (#1769, #2340, #2362) and have been occurring since the WhatsApp LID (Linked Identity) migration.

## Root Causes

### 1. LID/PN Transaction Race Condition
When WhatsApp sends messages via both PN (Phone Number) and LID (Linked ID) JIDs for the same contact, `decryptMessage` and `encryptMessage` use the raw JID as the transaction mutex key. Two concurrent operations for the **same logical session** (one via PN, one via LID) acquire **different locks**, allowing concurrent session state mutations that corrupt the ratchet → `Bad MAC`.

### 2. Aggressive PN Session Deletion During Migration
`migrateSession()` copies the session from PN→LID address then **deletes the PN session** (`sessionUpdates[pnAddr] = null`). Any in-flight messages still addressed to the PN JID immediately fail with `No matching session`.

### 3. Immediate PreKey Deletion
`removePreKey()` deletes the pre-key immediately after first use. When WhatsApp retransmits the same message (common during connectivity issues), the pre-key is already gone → `Invalid PreKey ID`.

## Changes

### Fix 1: Canonical JID Resolution for Transaction Locks (`src/Signal/libsignal.ts`)
Before entering a transaction in `decryptMessage` / `encryptMessage`, resolve the JID to its canonical (LID-preferred) form via the existing `LIDMappingStore`. This ensures PN and LID operations for the same contact serialize on the same mutex key.

### Fix 2: Retain PN Session During LID Migration (`src/Signal/libsignal.ts`)
In `migrateSession()`, copy the session to the LID address but **do not delete** the PN session. The PN session will naturally fall out of use as new messages arrive under the LID address. This is safe because signal storage already resolves PN→LID internally via `resolveLIDSignalAddress`.

### Fix 3: Delayed PreKey Deletion (`src/Signal/libsignal.ts`)
Replace immediate pre-key deletion with a 5-minute grace period. Used pre-keys are scheduled for deletion via a lightweight timer. Retransmissions within the grace window succeed. The timer uses `unref()` to avoid blocking process exit.

## Risk Assessment

- **Fix 1** (canonical JID lock): Low risk. Uses the existing `getLIDForPN()` lookup. Falls back to the original JID if no mapping exists. Worst case: one extra async lookup per encrypt/decrypt.
- **Fix 2** (PN session retention): Low risk. Retains data that was previously deleted. The signal storage layer already resolves PN→LID for lookups, so the retained PN session is a safety net, not a conflict source.
- **Fix 3** (delayed prekey deletion): Low risk. Pre-keys are still deleted, just after a 5-minute delay. The grace period Map is bounded by the number of pre-keys used in that window (typically single digits). Timer self-cleans when empty.

## Testing Notes

- All pre-existing TypeScript compilation errors remain unchanged; no new errors introduced
- These fixes address the **protocol-level** causes; thorough testing requires multi-device scenarios with LID migration in progress
- Recommended to test with high message volume during PN→LID transition

Fixes #1769. Related: #2340, #2362.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session encryption/decryption handling to prevent mismatches and ensure reliable transaction locking.
  * Enhanced pre-key management with a grace-period cleanup mechanism for better stability.

* **Refactor**
  * Optimized validation logic for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->