### PR TITLE
fix: use MACOS platform to resolve 405 Connection Failure

### DIFF
--- a/src/Utils/validate-connection.ts
+++ b/src/Utils/validate-connection.ts
@@ -20,7 +20,7 @@ const getUserAgent = (config: SocketConfig): proto.ClientPayload.IUserAgent => {
 			secondary: config.version[1],
 			tertiary: config.version[2]
 		},
-		platform: proto.ClientPayload.UserAgent.Platform.WEB,
+		platform: proto.ClientPayload.UserAgent.Platform.MACOS,
 		releaseChannel: proto.ClientPayload.UserAgent.ReleaseChannel.RELEASE,
 		osVersion: '0.1',
 		device: 'Desktop',


### PR DESCRIPTION
## Problem

Since February 2026, WhatsApp servers have started rejecting `UserAgent.Platform.WEB` (value `14`) for new device pairing. This causes an immediate 405 Connection Failure before QR code generation, making it impossible to pair new devices.

Affected issues: #2370, #1939, #1913, #1476, #999, #807

## Fix

Change the platform from `WEB` to `MACOS` in `getUserAgent()`:

```diff
- platform: proto.ClientPayload.UserAgent.Platform.WEB,
+ platform: proto.ClientPayload.UserAgent.Platform.MACOS,
```

## Testing

Verified working on February 26, 2026 with `@whiskeysockets/baileys@7.0.0-rc.9`. After this change, device pairing (both QR and pairing code) succeeds immediately.

Note: This is the same fix proposed in PR #2365 by @kobie3717.