### PR TITLE
fix: pass through phoneNumberToLidMappings from history sync

### DIFF
--- a/src/Utils/event-buffer.ts
+++ b/src/Utils/event-buffer.ts
@@ -278,6 +278,14 @@ function append<E extends BufferableEvent>(
 				}
 			}
 
+			// Accumulate LID→phone mappings from history sync
+			if ((eventData as any).lidPnMappings?.length) {
+				if (!(data.historySets as any).lidPnMappings) {
+					(data.historySets as any).lidPnMappings = []
+				}
+				(data.historySets as any).lidPnMappings.push(...(eventData as any).lidPnMappings)
+			}
+
 			data.historySets.empty = false
 			data.historySets.syncType = eventData.syncType
 			data.historySets.progress = eventData.progress
@@ -570,8 +578,9 @@ function consolidateEvents(data: BufferedEventData) {
 			syncType: data.historySets.syncType,
 			progress: data.historySets.progress,
 			isLatest: data.historySets.isLatest,
-			peerDataRequestSessionId: data.historySets.peerDataRequestSessionId
-		}
+			peerDataRequestSessionId: data.historySets.peerDataRequestSessionId,
+			...((data.historySets as any).lidPnMappings?.length ? { lidPnMappings: (data.historySets as any).lidPnMappings } : {})
+		} as any
 	}
 
 	const chatUpsertList = Object.values(data.chatUpserts)

--- a/src/Utils/history.ts
+++ b/src/Utils/history.ts
@@ -83,10 +83,20 @@ export const processHistoryMessage = (item: proto.IHistorySync) => {
 			break
 	}
 
+	const lidPnMappings: { lid: string, pn: string }[] = []
+	if (item.phoneNumberToLidMappings?.length) {
+		for (const m of item.phoneNumberToLidMappings) {
+			if (m.lidJid && m.pnJid) {
+				lidPnMappings.push({ lid: m.lidJid, pn: m.pnJid })
+			}
+		}
+	}
+
 	return {
 		chats,
 		contacts,
 		messages,
+		lidPnMappings,
 		syncType: item.syncType,
 		progress: item.progress
 	}


### PR DESCRIPTION
## Summary

- Extract `phoneNumberToLidMappings` from HistorySync proto field 15 in `processHistoryMessage()` and include as `lidPnMappings` in the return value
- Accumulate `lidPnMappings` through event buffer consolidation in `event-buffer.ts` so they reach `messaging-history.set` consumers

## Problem

The HistorySync protobuf has a `phoneNumberToLidMappings` field containing `{pnJid, lidJid}` pairs — the most complete source of LID→phone number mappings from WhatsApp. Protobuf decoding works correctly, but `processHistoryMessage()` drops this data — the return object only includes `chats, contacts, messages, syncType, progress`.

Even if the data were returned, the event buffer consolidation would drop it since it only preserves known fields when merging multiple `messaging-history.set` events.

## Changes

**`src/Utils/history.ts`**: Extract `phoneNumberToLidMappings` entries into a `lidPnMappings` array and include it in the `processHistoryMessage()` return value.

**`src/Utils/event-buffer.ts`**: Accumulate `lidPnMappings` arrays across buffered `messaging-history.set` events and include them in the consolidated output.

## Impact

In testing, this provided ~5,000 LID→phone mappings (vs ~631 from per-conversation `pnJid` alone), significantly improving contact resolution for multi-device linked clients.

## Test plan

- [ ] Verify `messaging-history.set` events now include `lidPnMappings` array
- [ ] Verify mappings are preserved when multiple history chunks are buffered
- [ ] Verify existing history sync behavior is unchanged for consumers that don't use `lidPnMappings`