### PR TITLE
fix: add timeout to fetchLatestBaileysVersion to prevent hanging connections

### DIFF
--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -235,14 +235,18 @@ export const bindWaitForConnectionUpdate = (ev: BaileysEventEmitter) => bindWait
  * utility that fetches latest baileys version from the master branch.
  * Use to ensure your WA connection is always on the latest version
  */
-export const fetchLatestBaileysVersion = async (options: RequestInit = {}) => {
+export const fetchLatestBaileysVersion = async (options: RequestInit & { timeout?: number } = {}) => {
 	const URL = 'https://raw.githubusercontent.com/WhiskeySockets/Baileys/master/src/Defaults/index.ts'
 	try {
+		const controller = new AbortController()
+		const timeout = setTimeout(() => controller.abort(), options.timeout ?? 5000)
 		const response = await fetch(URL, {
 			dispatcher: options.dispatcher,
 			method: 'GET',
-			headers: options.headers
+			headers: options.headers,
+			signal: controller.signal
 		})
+		clearTimeout(timeout)
 		if (!response.ok) {
 			throw new Boom(`Failed to fetch latest Baileys version: ${response.statusText}`, { statusCode: response.status })
 		}


### PR DESCRIPTION
# fix: add timeout to fetchLatestBaileysVersion to prevent hanging connections

## Problem

`fetchLatestBaileysVersion()` makes an HTTP request to GitHub with no timeout. If the request hangs (due to DNS issues, network problems, GitHub outages, or firewall restrictions), the function never resolves, permanently blocking WhatsApp connection startup.

This is a critical issue because:
- The function is typically called before `makeWASocket()`, so a hang prevents any connection
- There is no way for the caller to recover without manually aborting the process
- The existing try/catch fallback to `baileysVersion` is never reached if the request hangs

Fixes #1990

## Solution

Add an `AbortController` with a 5-second timeout (configurable via `options.timeout`) to the `fetch()` call. If the request doesn't complete within the timeout, it aborts and falls through to the existing catch block, which returns the bundled `baileysVersion` as a fallback.

Changes:
- Create an `AbortController` and pass its `signal` to `fetch()`
- Set a `setTimeout` to abort after 5 seconds (default)
- Allow callers to override via `options.timeout`
- Clean up the timeout on successful response

The existing fallback behavior (returning `{ version: baileysVersion, isLatest: false, error }`) is preserved — no breaking changes.

## Testing

- Verified normal operation: successful fetch returns latest version as before
- Verified timeout: with `timeout: 1` (1ms), the function falls back to bundled version
- Verified network failure: with no internet, falls back gracefully within timeout
- Verified backwards compatibility: calling without options works as before