### PR TITLE
fix: normalise remoteJid in reaction keys for fromMe messages

### DIFF
--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -99,10 +99,13 @@ export const cleanMessage = (message: WAMessage, meId: string, meLid: string) =>
 					// fromMe automatically becomes false
 					false
 			// set the remoteJid to being the same as the chat the message came from
-			// TODO: investigate inconsistencies
 			msgKey.remoteJid = message.key.remoteJid
 			// set participant of the message
 			msgKey.participant = msgKey.participant || message.key.participant
+		} else {
+			// fromMe reactions: normalise remoteJid to match the chat JID
+			// ensures DM reaction keys are consistent with group behavior
+			msgKey.remoteJid = message.key.remoteJid
 		}
 	}
 }


### PR DESCRIPTION
# fix: normalise remoteJid in reaction keys for fromMe messages

## Problem

In DM (individual chat) contexts, reaction messages sent by the connected user (`fromMe: true`) have an inconsistent `remoteJid` in the inner `reactionMessage.key` compared to the outer `message.key.remoteJid`.

In groups, both the outer key and the reaction's inner key consistently use the group JID as `remoteJid`. In DMs however, the inner key retains the raw protocol JID, which may differ from the normalised chat JID (e.g. different device/agent suffixes, or the contact's JID instead of the chat JID).

This makes it difficult for applications to reliably match reactions to their original messages, since the lookup key doesn't match.

Fixes #656

## Root Cause

The `normaliseKey()` function in `cleanMessage()` only runs when `message.key.fromMe` is `false` (reactions from other users). When the connected user sends a reaction (`fromMe: true`), the inner reaction key is left unnormalised — the `remoteJid` is whatever the protocol sent, rather than being mapped to `message.key.remoteJid`.

## Solution

Add an `else` branch to `normaliseKey()` that sets `msgKey.remoteJid = message.key.remoteJid` for `fromMe` reactions as well. This ensures the inner reaction key's `remoteJid` always matches the chat JID, consistent with group behavior.

The `fromMe` and `participant` fields don't need correction in this branch since the connected user's perspective is already correct for their own reactions.

## Testing

- DM: connected user reacting to own message → inner key `remoteJid` now matches chat JID
- DM: connected user reacting to contact's message → inner key `remoteJid` now matches chat JID
- Group: all 4 reaction scenarios unchanged (existing `!fromMe` path handles remote users; `fromMe` path now normalises `remoteJid` but it was already correct in groups)
- No breaking changes to the reaction event payload structure