### PR TITLE
fix: add ignoreStatusBroadcast option to prevent status messages from overwhelming handler (#2382)

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -72,6 +72,7 @@ export const DEFAULT_CONNECTION_CONFIG: SocketConfig = {
 		return syncType !== proto.HistorySync.HistorySyncType.FULL
 	},
 	shouldIgnoreJid: () => false,
+	ignoreStatusBroadcast: false,
 	linkPreviewImageThumbnailWidth: 192,
 	transactionOpts: { maxCommitRetries: 10, delayBetweenTriesMs: 3000 },
 	generateHighQualityLinkPreview: false,

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -72,7 +72,7 @@ import { extractGroupMetadata } from './groups'
 import { makeMessagesSocket } from './messages-send'
 
 export const makeMessagesRecvSocket = (config: SocketConfig) => {
-	const { logger, retryRequestDelayMs, maxMsgRetryCount, getMessage, shouldIgnoreJid, enableAutoSessionRecreation } =
+	const { logger, retryRequestDelayMs, maxMsgRetryCount, getMessage, shouldIgnoreJid, enableAutoSessionRecreation, ignoreStatusBroadcast } =
 		config
 	const sock = makeMessagesSocket(config)
 	const {
@@ -1070,6 +1070,12 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			return
 		}
 
+		if (ignoreStatusBroadcast && isJidStatusBroadcast(remoteJid!)) {
+			logger.debug({ remoteJid }, 'ignored status broadcast receipt')
+			await sendMessageAck(node)
+			return
+		}
+
 		const ids = [attrs.id!]
 		if (Array.isArray(content)) {
 			const items = getBinaryNodeChildren(content[0], 'item')
@@ -1150,6 +1156,12 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			return
 		}
 
+		if (ignoreStatusBroadcast && isJidStatusBroadcast(remoteJid!)) {
+			logger.debug({ remoteJid }, 'ignored status broadcast notification')
+			await sendMessageAck(node)
+			return
+		}
+
 		try {
 			await Promise.all([
 				notificationMutex.mutex(async () => {
@@ -1183,6 +1195,12 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		if (shouldIgnoreJid(node.attrs.from!) && node.attrs.from !== S_WHATSAPP_NET) {
 			logger.debug({ key: node.attrs.key }, 'ignored message')
 			await sendMessageAck(node, NACK_REASONS.UnhandledError)
+			return
+		}
+
+		if (ignoreStatusBroadcast && isJidStatusBroadcast(node.attrs.from!)) {
+			logger.debug({ key: node.attrs.key }, 'ignored status broadcast message')
+			await sendMessageAck(node)
 			return
 		}
 

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -114,6 +114,15 @@ export type SocketConfig = {
 	shouldIgnoreJid: (jid: string) => boolean | undefined
 
 	/**
+	 * Whether to ignore status@broadcast messages.
+	 * When true, status broadcast messages will be silently acknowledged
+	 * but not processed or emitted via messages.upsert.
+	 * Useful when high volumes of status messages overwhelm the handler.
+	 * @default false
+	 */
+	ignoreStatusBroadcast: boolean
+
+	/**
 	 * Optionally patch the message before sending out
 	 * */
 	patchMessageBeforeSending: (


### PR DESCRIPTION
## Problem
High volumes of status@broadcast messages overwhelm the message handler, causing regular `messages.upsert` events to stop firing or be significantly delayed (#2382).

## Solution
Adds an `ignoreStatusBroadcast` config option (default: `false`) that, when enabled, silently acknowledges status broadcast messages without processing or emitting them.

Filters at three points in `messages-recv.ts`:
- Receipt handling
- Notification handling  
- Message handling

All filtered messages are properly ACKed so WhatsApp doesn't retry delivery.

## Usage
```typescript
const sock = makeWASocket({
  ignoreStatusBroadcast: true
})
```

## Breaking Changes
None. Defaults to `false` (existing behaviour unchanged).

Closes #2382