### PR TITLE
fix: ensure status@broadcast messages are not filtered by shouldIgnoreJid (#2388)

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1064,7 +1064,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			participant: attrs.participant
 		}
 
-		if (shouldIgnoreJid(remoteJid!) && remoteJid !== S_WHATSAPP_NET) {
+		if (shouldIgnoreJid(remoteJid!) && remoteJid !== S_WHATSAPP_NET && !isJidStatusBroadcast(remoteJid!)) {
 			logger.debug({ remoteJid }, 'ignoring receipt from jid')
 			await sendMessageAck(node)
 			return
@@ -1144,7 +1144,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 
 	const handleNotification = async (node: BinaryNode) => {
 		const remoteJid = node.attrs.from
-		if (shouldIgnoreJid(remoteJid!) && remoteJid !== S_WHATSAPP_NET) {
+		if (shouldIgnoreJid(remoteJid!) && remoteJid !== S_WHATSAPP_NET && !isJidStatusBroadcast(remoteJid!)) {
 			logger.debug({ remoteJid, id: node.attrs.id }, 'ignored notification')
 			await sendMessageAck(node)
 			return
@@ -1180,7 +1180,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	}
 
 	const handleMessage = async (node: BinaryNode) => {
-		if (shouldIgnoreJid(node.attrs.from!) && node.attrs.from !== S_WHATSAPP_NET) {
+		if (shouldIgnoreJid(node.attrs.from!) && node.attrs.from !== S_WHATSAPP_NET && !isJidStatusBroadcast(node.attrs.from!)) {
 			logger.debug({ key: node.attrs.key }, 'ignored message')
 			await sendMessageAck(node, NACK_REASONS.UnhandledError)
 			return


### PR DESCRIPTION
## Problem
`status@broadcast` messages are accidentally filtered out by the `shouldIgnoreJid` check, causing them to never appear in `messages.upsert` events (#2388).

## Solution
Adds `&& !isJidStatusBroadcast(remoteJid!)` to the three `shouldIgnoreJid` filter checks in `messages-recv.ts`, ensuring status broadcast messages are always processed regardless of the `shouldIgnoreJid` implementation.

This is complementary to #2398 — this PR ensures status broadcasts work by default, while #2398 lets users opt out when they cause performance issues.

## Breaking Changes
None. Status broadcasts that were previously silently dropped will now be emitted correctly.

Closes #2388