### PR TITLE
fix: make link-preview-js gracefully optional (#2390)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "jimp": "^1.6.0",
     "jiti": "^2.4.2",
     "json": "^11.0.0",
-    "link-preview-js": "^3.0.0",
     "lru-cache": "^11.1.0",
     "open": "^8.4.2",
     "pino-pretty": "^13.1.1",

--- a/src/Utils/link-preview.ts
+++ b/src/Utils/link-preview.ts
@@ -42,7 +42,14 @@ export const getUrlInfo = async (
 		const retries = 0
 		const maxRetry = 5
 
-		const { getLinkPreview } = await import('link-preview-js')
+		let getLinkPreview: any
+		try {
+			const mod = await import('link-preview-js')
+			getLinkPreview = mod.getLinkPreview
+		} catch {
+			opts.logger?.debug('link-preview-js is not installed, skipping link preview generation')
+			return undefined
+		}
 		let previewLink = text
 		if (!text.startsWith('https://') && !text.startsWith('http://')) {
 			previewLink = 'https://' + previewLink


### PR DESCRIPTION
## Problem
The `link-preview-js` dependency causes issues for some users (#2390) — installation failures, security concerns, and unnecessary bloat when link previews aren't needed.

## Solution
- Wraps the dynamic `import('link-preview-js')` in a try/catch in `src/Utils/link-preview.ts`
- If the module isn't installed, gracefully returns `undefined` (no link preview generated)
- Removes `link-preview-js` from `devDependencies` — users who want link previews install it themselves
- Logs a debug message when skipping

## Usage
```bash
# Without link previews (default after this change)
npm install @whiskeysockets/baileys

# With link previews
npm install @whiskeysockets/baileys link-preview-js
```

## Breaking Changes
Link previews will no longer be generated unless `link-preview-js` is explicitly installed. This is intentional — the dependency should be opt-in, not forced.

Closes #2390