### PR TITLE
fix: add timeout to fetchLatestBaileysVersion/fetchLatestWaWebVersion to prevent hang (#1990)

### DIFF
--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -235,14 +235,18 @@ export const bindWaitForConnectionUpdate = (ev: BaileysEventEmitter) => bindWait
  * utility that fetches latest baileys version from the master branch.
  * Use to ensure your WA connection is always on the latest version
  */
-export const fetchLatestBaileysVersion = async (options: RequestInit = {}) => {
+export const fetchLatestBaileysVersion = async (options: RequestInit & { timeout?: number } = {}) => {
 	const URL = 'https://raw.githubusercontent.com/WhiskeySockets/Baileys/master/src/Defaults/index.ts'
 	try {
+		const controller = new AbortController()
+		const timer = setTimeout(() => controller.abort(), options.timeout ?? 5000)
 		const response = await fetch(URL, {
 			dispatcher: options.dispatcher,
 			method: 'GET',
-			headers: options.headers
+			headers: options.headers,
+			signal: controller.signal
 		})
+		clearTimeout(timer)
 		if (!response.ok) {
 			throw new Boom(`Failed to fetch latest Baileys version: ${response.statusText}`, { statusCode: response.status })
 		}
@@ -276,7 +280,7 @@ export const fetchLatestBaileysVersion = async (options: RequestInit = {}) => {
  * A utility that fetches the latest web version of whatsapp.
  * Use to ensure your WA connection is always on the latest version
  */
-export const fetchLatestWaWebVersion = async (options: RequestInit = {}) => {
+export const fetchLatestWaWebVersion = async (options: RequestInit & { timeout?: number } = {}) => {
 	try {
 		// Absolute minimal headers required to bypass anti-bot detection
 		const defaultHeaders = {
@@ -287,11 +291,15 @@ export const fetchLatestWaWebVersion = async (options: RequestInit = {}) => {
 
 		const headers = { ...defaultHeaders, ...options.headers }
 
+		const controller = new AbortController()
+		const timer = setTimeout(() => controller.abort(), options.timeout ?? 5000)
 		const response = await fetch('https://web.whatsapp.com/sw.js', {
 			...options,
 			method: 'GET',
-			headers
+			headers,
+			signal: controller.signal
 		})
+		clearTimeout(timer)
 
 		if (!response.ok) {
 			throw new Boom(`Failed to fetch sw.js: ${response.statusText}`, { statusCode: response.status })


### PR DESCRIPTION
## Problem
`fetchLatestBaileysVersion()` and `fetchLatestWaWebVersion()` have no timeout on their HTTP requests. If the network is slow or the endpoint is down, they hang forever, blocking the WhatsApp connection entirely (#1990).

## Solution
Adds an `AbortController` with a configurable timeout (default: 5 seconds) to both functions. On timeout or failure, they fall back to the hardcoded default version — the connection proceeds regardless.

## Usage
```typescript
// Default 5s timeout
const { version } = await fetchLatestBaileysVersion()

// Custom timeout
const { version } = await fetchLatestBaileysVersion({ timeout: 10000 })
```

## Breaking Changes
None. Adds optional `timeout` parameter, defaults to 5000ms.

Closes #1990