### PR TITLE
fix: add LID support to onWhatsApp (#1522)

### DIFF
--- a/src/Signal/libsignal.ts
+++ b/src/Signal/libsignal.ts
@@ -456,9 +456,7 @@ function signalStorage(
 			const { [wireJid]: existingKey } = await keys.get('identity-key', [wireJid])
 
 			const keysMatch =
-				existingKey &&
-				existingKey.length === identityKey.length &&
-				existingKey.every((byte, i) => byte === identityKey[i])
+				existingKey?.length === identityKey.length && existingKey.every((byte, i) => byte === identityKey[i])
 
 			if (existingKey && !keysMatch) {
 				// Identity changed - clear session and update key

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -312,12 +312,12 @@ export const makeSocket = (config: SocketConfig) => {
 
 	const onWhatsApp = async (...phoneNumber: string[]) => {
 		let usyncQuery = new USyncQuery()
+		const lidQuery = new USyncQuery().withLIDProtocol()
 
 		let contactEnabled = false
 		for (const jid of phoneNumber) {
 			if (isLidUser(jid)) {
-				logger?.warn('LIDs are not supported with onWhatsApp')
-				continue
+				lidQuery.withUser(new USyncUser().withLid(jid))
 			} else {
 				if (!contactEnabled) {
 					contactEnabled = true
@@ -329,15 +329,27 @@ export const makeSocket = (config: SocketConfig) => {
 			}
 		}
 
-		if (usyncQuery.users.length === 0) {
-			return [] // return early without forcing an empty query
+		const output: { jid: string; exists: boolean }[] = []
+
+		if (usyncQuery.users.length > 0) {
+			const results = await executeUSyncQuery(usyncQuery)
+			if (results) {
+				const mapped = results.list.filter(a => !!a.contact).map(({ contact, id }) => ({ jid: id, exists: contact as boolean }))
+				output.push(...mapped)
+			}
 		}
 
-		const results = await executeUSyncQuery(usyncQuery)
-
-		if (results) {
-			return results.list.filter(a => !!a.contact).map(({ contact, id }) => ({ jid: id, exists: contact as boolean }))
+		if (lidQuery.users.length > 0) {
+			const lidResults = await executeUSyncQuery(lidQuery)
+			if (lidResults) {
+				const mapped = lidResults.list
+					.filter(a => !!a.lid)
+					.map(({ lid, id }) => ({ jid: id, exists: true, lid: lid as string }))
+				output.push(...mapped)
+			}
 		}
+
+		return output
 	}
 
 	const pnFromLIDUSync = async (jids: string[]): Promise<LIDMapping[] | undefined> => {

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -334,7 +334,9 @@ export const makeSocket = (config: SocketConfig) => {
 		if (usyncQuery.users.length > 0) {
 			const results = await executeUSyncQuery(usyncQuery)
 			if (results) {
-				const mapped = results.list.filter(a => !!a.contact).map(({ contact, id }) => ({ jid: id, exists: contact as boolean }))
+				const mapped = results.list
+					.filter(a => !!a.contact)
+					.map(({ contact, id }) => ({ jid: id, exists: contact as boolean }))
 				output.push(...mapped)
 			}
 		}

--- a/src/WAUSync/USyncQuery.ts
+++ b/src/WAUSync/USyncQuery.ts
@@ -46,7 +46,7 @@ export class USyncQuery {
 	}
 
 	parseUSyncQueryResult(result: BinaryNode | undefined): USyncQueryResult | undefined {
-		if (!result || result.attrs.type !== 'result') {
+		if (result?.attrs.type !== 'result') {
 			return
 		}
 


### PR DESCRIPTION
## Problem
Passing a LID (e.g. `xxxxx@lid`) to `onWhatsApp()` returns an empty array. LIDs are simply skipped with a warning (#1522).

## Solution
Instead of skipping LID inputs, creates a separate USyncQuery with `withLIDProtocol()` for LID users. Executes both JID and LID queries and merges results.

```typescript
// Now works with both JIDs and LIDs
const results = await sock.onWhatsApp(
  '27821234567@s.whatsapp.net',
  '2064xxxxx@lid'
)
// Returns: [{ jid, exists }, ...]
```

## Breaking Changes
None. Previously LIDs returned empty — now they return actual results.

Closes #1522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended contact presence checking to support LID users in addition to phone-based contacts.

* **Bug Fixes**
  * Enhanced error handling in identity key comparison and query result parsing to prevent potential runtime failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->