### PR TITLE
fix: resolve pairing code rejection due to timing and platform validation issues

### DIFF
--- a/Example/example.ts
+++ b/Example/example.ts
@@ -1,7 +1,7 @@
 import { Boom } from '@hapi/boom'
 import NodeCache from '@cacheable/node-cache'
 import readline from 'readline'
-import makeWASocket, { CacheStore, DEFAULT_CONNECTION_CONFIG, DisconnectReason, fetchLatestBaileysVersion, generateMessageIDV2, getAggregateVotesInPollMessage, isJidNewsletter, makeCacheableSignalKeyStore, proto, useMultiFileAuthState, WAMessageContent, WAMessageKey } from '../src'
+import makeWASocket, { Browsers, CacheStore, DEFAULT_CONNECTION_CONFIG, DisconnectReason, fetchLatestBaileysVersion, generateMessageIDV2, getAggregateVotesInPollMessage, isJidNewsletter, makeCacheableSignalKeyStore, proto, useMultiFileAuthState, WAMessageContent, WAMessageKey } from '../src'
 import P from 'pino'
 
 const logger = P({
@@ -56,6 +56,11 @@ const startSock = async() => {
 			/** caching makes the store faster to send/recv messages */
 			keys: makeCacheableSignalKeyStore(state.keys, logger),
 		},
+		// browser[0] = OS/brand shown in WhatsApp's Linked Devices list (DeviceProps.os).
+		// browser[1] = browser type; must be a web-browser name (Chrome, Firefox, Edge, Safari, Opera)
+		//              so the pairing IQ sends a valid companion_platform_id (1-6).
+		//              "Desktop" maps to platform_id=7 which the server rejects in the pairing flow.
+		browser: ['Baileys', 'Chrome', '7.0.0'],
 		msgRetryCounterCache,
 		generateHighQualityLinkPreview: true,
 		// ignore all broadcast messages -- to receive the same
@@ -83,13 +88,16 @@ const startSock = async() => {
 						logger.fatal('Connection closed. You are logged out.')
 					}
 				}
-
 				if (qr) {
 					// Pairing code for Web clients
 					if (usePairingCode && !sock.authState.creds.registered) {
 						const phoneNumber = await question('Please enter your phone number:\n')
-						const code = await sock.requestPairingCode(phoneNumber)
-						console.log(`Pairing code: ${code}`)
+						try {
+							const code = await sock.requestPairingCode(phoneNumber)
+							console.log(`Pairing code: ${code}`)
+						} catch (err) {
+							logger.error({ err }, 'pairing code request failed')
+						}
 					}
 				}
 

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -36,7 +36,7 @@ import {
 	signedKeyPair,
 	xmppSignedPreKey
 } from '../Utils'
-import { getPlatformId } from '../Utils/browser-utils'
+import { getPlatformDisplayName, getPlatformId } from '../Utils/browser-utils'
 import {
 	assertNodeErrorFree,
 	type BinaryNode,
@@ -378,6 +378,11 @@ export const makeSocket = (config: SocketConfig) => {
 	let qrTimer: NodeJS.Timeout
 	let closed = false
 
+	let pairingReady = false
+	let pairingInProgress = false
+	let pendingPairingResolve: (() => void) | undefined
+	let pendingPairingReject: ((err: Error) => void) | undefined
+
 	/** log & process any unexpected errors */
 	const onUnexpectedError = (err: Error | Boom, msg: string) => {
 		logger.error({ err }, `unexpected error in '${msg}'`)
@@ -631,6 +636,20 @@ export const makeSocket = (config: SocketConfig) => {
 		clearInterval(keepAliveReq)
 		clearTimeout(qrTimer)
 
+		if (pendingPairingReject) {
+			pendingPairingReject(
+				error ||
+					new Boom('Connection closed before pairing completed', {
+						statusCode: DisconnectReason.connectionClosed
+					})
+			)
+			pendingPairingResolve = undefined
+			pendingPairingReject = undefined
+		}
+
+		pairingReady = false
+		pairingInProgress = false
+
 		ws.removeAllListeners('close')
 		ws.removeAllListeners('open')
 		ws.removeAllListeners('message')
@@ -745,7 +764,7 @@ export const makeSocket = (config: SocketConfig) => {
 		void end(new Boom(msg || 'Intentional Logout', { statusCode: DisconnectReason.loggedOut }))
 	}
 
-	const requestPairingCode = async (phoneNumber: string, customPairingCode?: string): Promise<string> => {
+	const sendPairingIQ = async (phoneNumber: string, customPairingCode?: string): Promise<string> => {
 		const pairingCode = customPairingCode ?? bytesToCrockford(randomBytes(5))
 
 		if (customPairingCode && customPairingCode?.length !== 8) {
@@ -754,12 +773,19 @@ export const makeSocket = (config: SocketConfig) => {
 
 		authState.creds.pairingCode = pairingCode
 
-		authState.creds.me = {
-			id: jidEncode(phoneNumber, 's.whatsapp.net'),
-			name: '~'
-		}
-		ev.emit('creds.update', authState.creds)
-		await sendNode({
+		const jid = jidEncode(phoneNumber, 's.whatsapp.net')
+		// The server only accepts browser-type platform IDs (CHROME=1 through EDGE=6) in the pairing
+		// IQ — DESKTOP (7) and other non-browser types are rejected with 400. The OS part of
+		// companion_platform_display must also be a canonical OS name; custom brand names (e.g.
+		// "Zapper") belong in browser[0] → DeviceProps.os, which is what WhatsApp shows in Linked
+		// Devices.
+		const rawPlatformId = parseInt(getPlatformId(browser[1]))
+		const isBrowserPlatform = rawPlatformId >= 1 && rawPlatformId <= 6
+		const pairingPlatformId = (isBrowserPlatform ? rawPlatformId : 1).toString()
+		const pairingPlatformName = isBrowserPlatform ? getPlatformDisplayName(browser[1]) : 'Chrome'
+		const pairingPlatformHost = browser[0] === 'Mac OS' || browser[0] === 'Windows' ? browser[0] : 'Mac OS'
+
+		await query({
 			tag: 'iq',
 			attrs: {
 				to: S_WHATSAPP_NET,
@@ -771,9 +797,8 @@ export const makeSocket = (config: SocketConfig) => {
 				{
 					tag: 'link_code_companion_reg',
 					attrs: {
-						jid: authState.creds.me.id,
+						jid,
 						stage: 'companion_hello',
-
 						should_show_push_notification: 'true'
 					},
 					content: [
@@ -790,12 +815,12 @@ export const makeSocket = (config: SocketConfig) => {
 						{
 							tag: 'companion_platform_id',
 							attrs: {},
-							content: getPlatformId(browser[1])
+							content: pairingPlatformId
 						},
 						{
 							tag: 'companion_platform_display',
 							attrs: {},
-							content: `${browser[1]} (${browser[0]})`
+							content: `${pairingPlatformName} (${pairingPlatformHost})`
 						},
 						{
 							tag: 'link_code_pairing_nonce',
@@ -806,7 +831,44 @@ export const makeSocket = (config: SocketConfig) => {
 				}
 			]
 		})
+
+		authState.creds.me = { id: jid, name: '~' }
+		ev.emit('creds.update', authState.creds)
+
 		return authState.creds.pairingCode
+	}
+
+	const requestPairingCode = async (phoneNumber: string, customPairingCode?: string): Promise<string> => {
+		if (pairingInProgress) {
+			throw new Boom('A pairing request is already in progress', { statusCode: 400 })
+		}
+
+		pairingInProgress = true
+
+		if (pairingReady) {
+			try {
+				return await sendPairingIQ(phoneNumber, customPairingCode)
+			} finally {
+				pairingInProgress = false
+			}
+		}
+
+		logger.debug('pairing not ready yet, queuing request until pair-device is received')
+		return new Promise<string>((resolve, reject) => {
+			pendingPairingResolve = () => {
+				sendPairingIQ(phoneNumber, customPairingCode)
+					.then(resolve)
+					.catch(reject)
+					.finally(() => {
+						pairingInProgress = false
+					})
+			}
+
+			pendingPairingReject = (err: Error) => {
+				pairingInProgress = false
+				reject(err)
+			}
+		})
 	}
 
 	async function generatePairingKey() {
@@ -863,6 +925,15 @@ export const makeSocket = (config: SocketConfig) => {
 			}
 		}
 		await sendNode(iq)
+
+		pairingReady = true
+		if (pendingPairingResolve) {
+			logger.debug('pair-device received, flushing queued pairing request')
+			const resolve = pendingPairingResolve
+			pendingPairingResolve = undefined
+			pendingPairingReject = undefined
+			resolve()
+		}
 
 		const pairDeviceNode = getBinaryNodeChild(stanza, 'pair-device')
 		const refNodes = getBinaryNodeChildren(pairDeviceNode, 'ref')

--- a/src/Utils/browser-utils.ts
+++ b/src/Utils/browser-utils.ts
@@ -27,5 +27,10 @@ export const Browsers: BrowsersMap = {
 
 export const getPlatformId = (browser: string) => {
 	const platformType = proto.DeviceProps.PlatformType[browser.toUpperCase() as any]
-	return platformType ? platformType.toString() : '1' //chrome
+	return (platformType || proto.DeviceProps.PlatformType.CHROME).toString()
+}
+
+export const getPlatformDisplayName = (browser: string) => {
+	const platformType = proto.DeviceProps.PlatformType[browser.toUpperCase() as any]
+	return platformType ? browser : 'Chrome'
 }


### PR DESCRIPTION

requestPairingCode was sending the link_code_companion_reg IQ before the server signaled readiness via pair-device, and setting creds.me before server confirmation — causing 428, 401, and 400 responses.

Changes:
- Extract sendPairingIQ from requestPairingCode to separate IQ dispatch from readiness gate logic
- Add pairingReady gate: queue requestPairingCode calls that arrive before pair-device is received, flushing them when the event fires
- Add pairingInProgress guard to reject concurrent pairing requests
- Defer creds.me assignment to after the companion_hello query succeeds, preventing reconnects from taking the login path instead of registration
- Reject pending pairing promises and reset state on socket close/error
- Fix getPlatformId return value (now consistently returns string)
- Add getPlatformDisplayName to resolve the display label for a platform type

The pairing IQ now validates companion_platform_id and companion_platform_display against server-accepted values: only browser-type platform IDs (CHROME=1..EDGE=6) are accepted; DESKTOP (7) is rejected. Custom brand names in browser[0] are preserved through DeviceProps.os (shown in WhatsApp's Linked Devices list) but are normalised to a canonical OS name in the pairing IQ itself.