### PR TITLE
fix: fallback group node on extractCommunityMetadata

### DIFF
--- a/src/Socket/communities.ts
+++ b/src/Socket/communities.ts
@@ -432,7 +432,7 @@ export const makeCommunitiesSocket = (config: SocketConfig) => {
 }
 
 export const extractCommunityMetadata = (result: BinaryNode) => {
-	const community = getBinaryNodeChild(result, 'community')!
+	const community = getBinaryNodeChild(result, 'community') ?? getBinaryNodeChild(result, 'group')!
 	const descChild = getBinaryNodeChild(community, 'description')
 	let desc: string | undefined
 	let descId: string | undefined


### PR DESCRIPTION
Use `group` node as a fallback to fetch community metadata, preventing to access `undefined`