### PR TITLE
docs(example): handle append upserts alongside notify

### DIFF
--- a/Example/example.ts
+++ b/Example/example.ts
@@ -135,7 +135,7 @@ const startSock = async() => {
 
 
 
-        if (upsert.type === 'notify') {
+        if (upsert.type === 'notify' || upsert.type === 'append') {
           for (const msg of upsert.messages) {
             if (msg.message?.conversation || msg.message?.extendedTextMessage?.text) {
               const text = msg.message?.conversation || msg.message?.extendedTextMessage?.text

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ async function connectToWhatsApp () {
             console.log('opened connection')
         }
     })
-    sock.ev.on('messages.upsert', event => {
+    sock.ev.on('messages.upsert', async event => {
         if(event.type !== 'notify' && event.type !== 'append') {
             return
         }

--- a/README.md
+++ b/README.md
@@ -317,10 +317,17 @@ They're all nicely typed up, so you shouldn't have any issues with an Intellisen
 You can listen to these events like this:
 ```ts
 const sock = makeWASocket()
-sock.ev.on('messages.upsert', ({ messages }) => {
+sock.ev.on('messages.upsert', ({ messages, type }) => {
+    if(type !== 'notify' && type !== 'append') {
+        return
+    }
+
     console.log('got messages', messages)
 })
 ```
+
+> [!NOTE]
+> If your app needs to process follow-up message batches as well as fresh notifications, handle both `notify` and `append` upsert types.
 
 ### Example to Start
 
@@ -355,6 +362,10 @@ async function connectToWhatsApp () {
         }
     })
     sock.ev.on('messages.upsert', event => {
+        if(event.type !== 'notify' && event.type !== 'append') {
+            return
+        }
+
         for (const m of event.messages) {
             console.log(JSON.stringify(m, undefined, 2))
 


### PR DESCRIPTION
## Summary
- mention that some consumers should handle `append` upserts alongside `notify`
- update the README examples to show a simple guard on `type`
- align `Example/example.ts` with the same behavior

## Why
In practice, some integrations need to process follow-up message batches as well as fresh notifications. The current examples make it easy to assume `notify` is the only relevant case.

## Testing
- docs/example only
- not run locally in a bootstrapped checkout in this environment

## Notes
If you would prefer this to be README-only, I can trim the example file change and keep just the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message handling to process messages from both 'notify' and 'append' event types, ensuring comprehensive coverage across all notification scenarios.

* **Documentation**
  * Updated examples and guides to demonstrate the expanded message event handling with proper filtering for different event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->