### PR TITLE
docs(messages): add delivery evidence example

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,51 @@ The store also provides some simple functions such as `loadMessages` that utiliz
     sock.sendMessage(jid, content, options)
     ```
 
+### Verifying Post-Send Delivery Evidence
+
+- `sendMessage()` returning successfully means the message was accepted locally for sending.
+- If your app needs extra operational confidence for critical messages, you can correlate the returned `messageId` with later `messages.update` and `message-receipt.update` events.
+- This is useful as delivery evidence, but it should not be treated as a perfect delivery guarantee.
+
+```ts
+const sent = await sock.sendMessage(jid, { text: 'critical update' })
+const messageId = sent?.key?.id
+
+if(messageId) {
+    const cleanup = () => {
+        sock.ev.off('messages.update', onMessagesUpdate)
+        sock.ev.off('message-receipt.update', onReceiptUpdate)
+    }
+
+    const onMessagesUpdate = updates => {
+        for(const { key, update } of updates) {
+            if(key.id !== messageId || key.remoteJid !== jid) {
+                continue
+            }
+
+            if(typeof update.status !== 'undefined') {
+                console.log('observed status update for sent message')
+                cleanup()
+            }
+        }
+    }
+
+    const onReceiptUpdate = updates => {
+        for(const update of updates) {
+            if(update.key?.id !== messageId || update.key?.remoteJid !== jid) {
+                continue
+            }
+
+            console.log('observed receipt update for sent message')
+            cleanup()
+        }
+    }
+
+    sock.ev.on('messages.update', onMessagesUpdate)
+    sock.ev.on('message-receipt.update', onReceiptUpdate)
+}
+```
+
 ### Non-Media Messages
 
 #### Text Message


### PR DESCRIPTION
## Summary
- add a README section showing how to observe post-send delivery evidence
- demonstrate correlating `sendMessage()` output with `messages.update` and `message-receipt.update`
- frame the pattern as operational guidance rather than a delivery guarantee

## Why
For critical messages, some consumers want more confidence than a resolved `sendMessage()` call alone. Baileys already exposes the events needed to build that pattern, so a short docs example can help without changing the core API.

## Testing
- docs only
- not run locally in a bootstrapped checkout in this environment

## Notes
Happy to trim or relocate this section if you would prefer it under event handling instead of sending messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guidance on verifying post-send message delivery by correlating sent message IDs with subsequent delivery and receipt events
  * Included practical code example demonstrating how to set up event listeners, filter updates by message ID, and properly clean up listeners after receiving delivery confirmation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->