### PR TITLE
docs(auth): document custom auth state requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,18 @@ sock.ev.on('creds.update', saveCreds)
 > [!IMPORTANT]
 > `useMultiFileAuthState` is a utility function to help save the auth state in a single folder, this function serves as a good guide to help write auth & key states for SQL/no-SQL databases, which I would recommend in any production grade system.
 
+### Writing Your Own Auth State
+
+If you replace `useMultiFileAuthState()` with your own SQL or NoSQL storage, a few details are easy to miss:
+
+- persist both `creds` and `keys`
+- always save updates triggered by `creds.update`
+- use `BufferJSON` when serializing/deserializing auth state as JSON
+- restore `app-state-sync-key` values with `proto.Message.AppStateSyncKeyData.fromObject(...)`
+- namespace stored records per WhatsApp session if you may have more than one login
+
+The implementation in [`use-multi-file-auth-state.ts`](src/Utils/use-multi-file-auth-state.ts) is a good reference for the auth-state contract and the read/write flow.
+
 > [!NOTE]
 > When a message is received/sent, due to signal sessions needing updating, the auth keys (`authState.keys`) will update. Whenever that happens, you must save the updated keys (`authState.keys.set()` is called). Not doing so will prevent your messages from reaching the recipient & cause other unexpected consequences. The `useMultiFileAuthState` function automatically takes care of that, but for any other serious implementation -- you will need to be very careful with the key state management.
 


### PR DESCRIPTION
## Summary
- add a short README subsection for people writing their own auth-state backend
- call out `creds.update`, `BufferJSON`, `app-state-sync-key`, and per-session namespacing
- point readers to `use-multi-file-auth-state.ts` as the reference contract

## Why
The README already recommends SQL/NoSQL storage for production systems, but the implementation details that matter most are easy to miss. A short checklist can save people from subtle auth-state bugs without introducing a storage dependency into the repo.

## Testing
- docs only
- not run locally in a bootstrapped checkout in this environment

## Notes
I kept this intentionally backend-agnostic rather than proposing MySQL-specific code in-tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance on implementing custom authentication state management, covering persistence requirements, update handling, serialization, and session management best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->