### PR TITLE
docs(messages): add voice note example

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,23 @@ await sock.sendMessage(
 )
 ```
 
+#### Voice Note (PTT)
+- To send a WhatsApp voice note instead of a regular audio message, set `ptt: true`
+- Using an `ogg/opus` file is the most reliable format across devices
+
+```ts
+await sock.sendMessage(
+    jid,
+    {
+        audio: {
+            url: './Media/reply.ogg'
+        },
+        mimetype: 'audio/ogg; codecs=opus',
+        ptt: true
+    }
+)
+```
+
 #### Image Message
 ```ts
 await sock.sendMessage(


### PR DESCRIPTION
## Summary
- add a README subsection showing how to send a WhatsApp voice note
- document `ptt: true` explicitly
- recommend `ogg/opus` for the voice-note case

## Why
Baileys already supports PTT audio, but it is easy for readers to miss the difference between a regular audio message and a voice note. A short example in the existing audio section makes that much easier to discover.

## Testing
- docs only
- not run locally in a bootstrapped checkout in this environment

## Notes
I kept this focused on the Baileys payload shape only, without pulling in any provider-specific TTS or transcoding workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Voice Note (Push-to-Talk) documentation with TypeScript examples for sending WhatsApp voice notes using push-to-talk functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->