### PR TITLE
fix: use newsletter-specific upload paths for channel media

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -106,7 +106,10 @@ export const NEWSLETTER_MEDIA_PATH_MAP: { [T in MediaType]?: string } = {
 	video: '/newsletter/newsletter-video',
 	document: '/newsletter/newsletter-document',
 	audio: '/newsletter/newsletter-audio',
-	sticker: '/newsletter/newsletter-image',
+	gif: '/newsletter/newsletter-gif',
+	ptt: '/newsletter/newsletter-ptt',
+	ptv: '/newsletter/newsletter-ptv',
+	sticker: '/newsletter/newsletter-sticker-pack',
 	'thumbnail-link': '/newsletter/newsletter-image'
 }
 

--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -101,6 +101,15 @@ export const MEDIA_PATH_MAP: { [T in MediaType]?: string } = {
 	'biz-cover-photo': '/pps/biz-cover-photo'
 }
 
+export const NEWSLETTER_MEDIA_PATH_MAP: { [T in MediaType]?: string } = {
+	image: '/newsletter/newsletter-image',
+	video: '/newsletter/newsletter-video',
+	document: '/newsletter/newsletter-document',
+	audio: '/newsletter/newsletter-audio',
+	sticker: '/newsletter/newsletter-image',
+	'thumbnail-link': '/newsletter/newsletter-image'
+}
+
 export const MEDIA_HKDF_KEY_MAPPING = {
 	audio: 'Audio',
 	document: 'Document',

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -671,7 +671,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				const bytes = encodeNewsletterMessage(patched as proto.IMessage)
 				binaryNodeContent.push({
 					tag: 'plaintext',
-					attrs: {},
+					attrs: mediaType ? { mediatype: mediaType } : {},
 					content: bytes
 				})
 				const stanza: BinaryNode = {

--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -332,7 +332,7 @@ export type MessageGenerationOptionsFromContent = MiscMessageGenerationOptions &
 
 export type WAMediaUploadFunction = (
 	encFilePath: string,
-	opts: { fileEncSha256B64: string; mediaType: MediaType; timeoutMs?: number }
+	opts: { fileEncSha256B64: string; mediaType: MediaType; timeoutMs?: number; newsletter?: boolean }
 ) => Promise<{ mediaUrl: string; directPath: string; meta_hmac?: string; ts?: number; fbid?: number }>
 
 export type MediaGenerationOptions = {

--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -334,7 +334,7 @@ export type WAMediaUploadFunction = (
 	encFilePath: string,
 	opts: { fileEncSha256B64: string; mediaType: MediaType; timeoutMs?: number; newsletter?: boolean }
 ) => Promise<{
-	mediaUrl: string
+	mediaUrl: string | undefined
 	directPath: string
 	meta_hmac?: string
 	ts?: number

--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -333,7 +333,15 @@ export type MessageGenerationOptionsFromContent = MiscMessageGenerationOptions &
 export type WAMediaUploadFunction = (
 	encFilePath: string,
 	opts: { fileEncSha256B64: string; mediaType: MediaType; timeoutMs?: number; newsletter?: boolean }
-) => Promise<{ mediaUrl: string; directPath: string; meta_hmac?: string; ts?: number; fbid?: number }>
+) => Promise<{
+	mediaUrl: string
+	directPath: string
+	meta_hmac?: string
+	ts?: number
+	fbid?: number
+	thumbnailDirectPath?: string
+	thumbnailSha256?: string
+}>
 
 export type MediaGenerationOptions = {
 	logger?: ILogger

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -10,7 +10,13 @@ import { join } from 'path'
 import { Readable, Transform } from 'stream'
 import { URL } from 'url'
 import { proto } from '../../WAProto/index.js'
-import { DEFAULT_ORIGIN, MEDIA_HKDF_KEY_MAPPING, MEDIA_PATH_MAP, type MediaType } from '../Defaults'
+import {
+	DEFAULT_ORIGIN,
+	MEDIA_HKDF_KEY_MAPPING,
+	MEDIA_PATH_MAP,
+	type MediaType,
+	NEWSLETTER_MEDIA_PATH_MAP
+} from '../Defaults'
 import type {
 	BaileysEventMap,
 	DownloadableMessage,
@@ -810,7 +816,7 @@ export const getWAUploadToServer = (
 	{ customUploadHosts, fetchAgent, logger, options }: SocketConfig,
 	refreshMediaConn: (force: boolean) => Promise<MediaConnInfo>
 ): WAMediaUploadFunction => {
-	return async (filePath, { mediaType, fileEncSha256B64, timeoutMs }) => {
+	return async (filePath, { mediaType, fileEncSha256B64, timeoutMs, newsletter }) => {
 		// send a query JSON to obtain the url & auth token to upload our media
 		let uploadInfo = await refreshMediaConn(false)
 
@@ -836,7 +842,11 @@ export const getWAUploadToServer = (
 			logger.debug(`uploading to "${hostname}"`)
 
 			const auth = encodeURIComponent(uploadInfo.auth)
-			const url = `https://${hostname}${MEDIA_PATH_MAP[mediaType]}/${fileEncSha256B64}?auth=${auth}&token=${fileEncSha256B64}`
+			const mediaPath = (newsletter ? NEWSLETTER_MEDIA_PATH_MAP[mediaType] : undefined) || MEDIA_PATH_MAP[mediaType]
+			let url = `https://${hostname}${mediaPath}/${fileEncSha256B64}?auth=${auth}&token=${fileEncSha256B64}`
+			if (newsletter) {
+				url += '&server_thumb_gen=1'
+			}
 
 			let result: MediaUploadResult | undefined
 			try {

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -860,6 +860,9 @@ export const getWAUploadToServer = (
 			let url = `https://${hostname}${mediaPath}/${fileEncSha256B64}?auth=${auth}&token=${fileEncSha256B64}`
 			if (newsletter) {
 				url += '&server_thumb_gen=1'
+				if (mediaType === 'video' || mediaType === 'gif' || mediaType === 'ptv') {
+					url += '&server_transcode=1'
+				}
 			}
 
 			let result: MediaUploadResult | undefined

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -672,6 +672,10 @@ type MediaUploadResult = {
 	meta_hmac?: string
 	ts?: number
 	fbid?: number
+	thumbnail_info?: {
+		thumbnail_sha256?: string
+		thumbnail_direct_path?: string
+	}
 }
 
 export type UploadParams = {
@@ -820,7 +824,17 @@ export const getWAUploadToServer = (
 		// send a query JSON to obtain the url & auth token to upload our media
 		let uploadInfo = await refreshMediaConn(false)
 
-		let urls: { mediaUrl: string; directPath: string; meta_hmac?: string; ts?: number; fbid?: number } | undefined
+		let urls:
+			| {
+					mediaUrl: string
+					directPath: string
+					meta_hmac?: string
+					ts?: number
+					fbid?: number
+					thumbnailDirectPath?: string
+					thumbnailSha256?: string
+			  }
+			| undefined
 		const hosts = [...customUploadHosts, ...uploadInfo.hosts]
 
 		fileEncSha256B64 = encodeBase64EncodedStringForUpload(fileEncSha256B64)
@@ -867,7 +881,9 @@ export const getWAUploadToServer = (
 						directPath: result.direct_path!,
 						meta_hmac: result.meta_hmac,
 						fbid: result.fbid,
-						ts: result.ts
+						ts: result.ts,
+						thumbnailDirectPath: result.thumbnail_info?.thumbnail_direct_path,
+						thumbnailSha256: result.thumbnail_info?.thumbnail_sha256
 					}
 					break
 				} else {

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -877,7 +877,7 @@ export const getWAUploadToServer = (
 
 				if (result?.url || result?.direct_path) {
 					urls = {
-						mediaUrl: result.url!,
+						mediaUrl: result.url || result.direct_path!,
 						directPath: result.direct_path!,
 						meta_hmac: result.meta_hmac,
 						fbid: result.fbid,

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -183,7 +183,7 @@ export const prepareWAMessageMedia = async (
 		)
 
 		const fileSha256B64 = fileSha256.toString('base64')
-		const { mediaUrl, directPath } = await options.upload(filePath, {
+		const { mediaUrl, directPath, thumbnailDirectPath, thumbnailSha256 } = await options.upload(filePath, {
 			fileEncSha256B64: fileSha256B64,
 			mediaType: mediaType,
 			timeoutMs: options.mediaUploadTimeoutMs,
@@ -198,7 +198,10 @@ export const prepareWAMessageMedia = async (
 				url: mediaUrl,
 				directPath,
 				fileSha256,
+				fileEncSha256: fileSha256,
 				fileLength,
+				thumbnailDirectPath,
+				thumbnailSha256: thumbnailSha256 ? Buffer.from(thumbnailSha256, 'base64') : undefined,
 				...uploadData,
 				media: undefined
 			})

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -183,7 +183,7 @@ export const prepareWAMessageMedia = async (
 		)
 
 		const fileSha256B64 = fileSha256.toString('base64')
-		const { mediaUrl, directPath, thumbnailDirectPath, thumbnailSha256 } = await options.upload(filePath, {
+		const { directPath, thumbnailDirectPath, thumbnailSha256 } = await options.upload(filePath, {
 			fileEncSha256B64: fileSha256B64,
 			mediaType: mediaType,
 			timeoutMs: options.mediaUploadTimeoutMs,
@@ -195,10 +195,9 @@ export const prepareWAMessageMedia = async (
 		const obj = WAProto.Message.fromObject({
 			// todo: add more support here
 			[`${mediaType}Message`]: (MessageTypeProto as any)[mediaType].fromObject({
-				url: mediaUrl,
+				// url intentionally omitted — newsletters use directPath only
 				directPath,
 				fileSha256,
-				fileEncSha256: fileSha256,
 				fileLength,
 				thumbnailDirectPath,
 				thumbnailSha256: thumbnailSha256 ? Buffer.from(thumbnailSha256, 'base64') : undefined,

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -186,7 +186,8 @@ export const prepareWAMessageMedia = async (
 		const { mediaUrl, directPath } = await options.upload(filePath, {
 			fileEncSha256B64: fileSha256B64,
 			mediaType: mediaType,
-			timeoutMs: options.mediaUploadTimeoutMs
+			timeoutMs: options.mediaUploadTimeoutMs,
+			newsletter: true
 		})
 
 		await fs.unlink(filePath)


### PR DESCRIPTION
## Summary

- **Fixes #2199** — Newsletter media uploads (images, video, etc.) were using regular `/mms/*` paths, causing the server to return `/o1/` `directPath` values instead of `/m1/`. This made media invisible in channels and triggered ACK error 479.
- Adds `NEWSLETTER_MEDIA_PATH_MAP` with `/newsletter/newsletter-*` paths (confirmed via network capture of official WhatsApp Web) and routes newsletter uploads through them.
- Appends `server_thumb_gen=1` query param for newsletter uploads, matching official client behavior.

### Changes

| File | Change |
|------|--------|
| `src/Types/Message.ts` | Added optional `newsletter?: boolean` to `WAMediaUploadFunction` opts (backwards-compatible) |
| `src/Defaults/index.ts` | Added `NEWSLETTER_MEDIA_PATH_MAP` constant |
| `src/Utils/messages-media.ts` | `getWAUploadToServer` selects newsletter paths when `newsletter: true` |
| `src/Utils/messages.ts` | `prepareWAMessageMedia` passes `newsletter: true` in the `isNewsletter` branch |

## Test plan

- [x] `yarn build` — no type errors
- [x] `yarn lint` — no new errors (0 errors, only pre-existing warnings)
- [x] `yarn test` — all 174 tests pass
- [x] Manual E2E: send image to a newsletter JID and verify upload URL uses `/newsletter/newsletter-image`, `directPath` starts with `/m1/`, image appears, no ACK 479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled media uploads for newsletter messages with enhanced handling
  * Added automatic thumbnail generation and caching for newsletter media
  * Implemented media transcoding support for video content in newsletters
  * Improved media type validation and tracking across newsletter messaging
  * Enhanced media metadata capture in upload responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->