### PR TITLE
fix: detect view-once media on stanza 1 for linked devices + fix mediatype in enc node

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -1072,6 +1072,15 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	}
 
 	const getMediaType = (message: proto.IMessage) => {
+		// For view-once media, unwrap the viewOnceMessage wrapper before checking media type
+		const inner =
+			message.viewOnceMessage?.message ||
+			message.viewOnceMessageV2?.message ||
+			message.viewOnceMessageV2Extension?.message
+		if (inner) {
+			return getMediaType(inner)
+		}
+
 		if (message.imageMessage) {
 			return 'image'
 		} else if (message.videoMessage) {

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -319,6 +319,23 @@ export const decryptMessageNode = (
 						} else {
 							fullMessage.message = msg
 						}
+
+						// Detect view-once media on stanza 1 received by linked device.
+						// viewOnceMessage wrapper is also used for interactive messages
+						// (interactiveMessage, listMessage, nativeFlowMessage) -- those do NOT have
+						// imageMessage.viewOnce / videoMessage.viewOnce / audioMessage.viewOnce = true.
+						// Only real view-once media carries viewOnce: true on the inner media message.
+						const viewOnceInner =
+							msg.viewOnceMessage?.message ||
+							msg.viewOnceMessageV2?.message ||
+							msg.viewOnceMessageV2Extension?.message
+						if (
+							viewOnceInner?.imageMessage?.viewOnce ||
+							viewOnceInner?.videoMessage?.viewOnce ||
+							viewOnceInner?.audioMessage?.viewOnce
+						) {
+							fullMessage.key!.isViewOnce = true
+						}
 					} catch (err: any) {
 						const errorContext = {
 							key: fullMessage.key,

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -334,7 +334,7 @@ export const decryptMessageNode = (
 							viewOnceInner?.videoMessage?.viewOnce ||
 							viewOnceInner?.audioMessage?.viewOnce
 						) {
-							fullMessage.key!.isViewOnce = true
+							fullMessage.key.isViewOnce = true
 						}
 					} catch (err: any) {
 						const errorContext = {

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -326,9 +326,7 @@ export const decryptMessageNode = (
 						// imageMessage.viewOnce / videoMessage.viewOnce / audioMessage.viewOnce = true.
 						// Only real view-once media carries viewOnce: true on the inner media message.
 						const viewOnceInner =
-							msg.viewOnceMessage?.message ||
-							msg.viewOnceMessageV2?.message ||
-							msg.viewOnceMessageV2Extension?.message
+							msg.viewOnceMessage?.message || msg.viewOnceMessageV2?.message || msg.viewOnceMessageV2Extension?.message
 						if (
 							viewOnceInner?.imageMessage?.viewOnce ||
 							viewOnceInner?.videoMessage?.viewOnce ||


### PR DESCRIPTION
## Problem

Two bugs affecting view-once media (image/video/audio) on linked devices:

### Bug 1 — `decode-wa-message.ts`
When a view-once message arrives at a linked device, the server sends **two stanzas**:
- **Stanza 1** (`enc`): full media metadata — `viewOnceMessage > imageMessage/videoMessage/audioMessage { viewOnce: true, mediaKey, directPath, ... }`
- **Stanza 2** (`unavailable type="view_once"`): fanout placeholder (already handled at line 294)

Stanza 1 was decoded but `key.isViewOnce` was never set, making it indistinguishable from regular media in `messages.upsert`. Consumers had no way to know the message was view-once.

### Bug 2 — `messages-send.ts`
`getMediaType()` checks `message.imageMessage`, `message.videoMessage`, etc. directly. When `viewOnce: true` is set, `generateWAMessageContent` wraps the media inside `viewOnceMessage.message`, so `message.imageMessage` is `undefined` at the top level.

Result: `mediatype` attribute was missing from the `enc` node for all view-once media. WA servers silently dropped view-once **video** and **audio** messages (images were more lenient). Verified on production: image view-once arrived, video/audio did not — until this fix.

## Fix

**`src/Utils/decode-wa-message.ts`** (+17 lines)
After decoding `proto.Message`, inspect `viewOnceMessage` / `viewOnceMessageV2` / `viewOnceMessageV2Extension` wrappers for inner media with `viewOnce: true`. If found, set `fullMessage.key.isViewOnce = true`.

The `viewOnceMessage` wrapper is also used for interactive messages (carousel, buttons, lists) which carry `interactiveMessage` / `listMessage` inside — never `imageMessage.viewOnce = true`. The check is unambiguous.

**`src/Socket/messages-send.ts`** (+9 lines)
Before checking media fields in `getMediaType()`, unwrap `viewOnceMessage` / `viewOnceMessageV2` / `viewOnceMessageV2Extension` recursively (same pattern as `normalizeMessageContent`). This ensures `mediatype="image"/"video"/"audio"` is correctly set on the `enc` node.

## Testing

Verified on production (2026-03-20):
- ✅ Image view-once: received with `key.isViewOnce = true`, `mediatype="image"` on enc
- ✅ Video view-once: received and delivered (was silently dropped before fix)
- ✅ Audio view-once: received and delivered
- ✅ Interactive messages (carousel/buttons/lists): unaffected — `viewOnceMessage` wrapper with `interactiveMessage` inside is correctly not flagged as view-once media

## Checklist
- [x] Only touches `decode-wa-message.ts` and `messages-send.ts`
- [x] No breaking changes
- [x] Backwards compatible (interactive messages unchanged)
- [x] Branch based on `WhiskeySockets/Baileys` master (not fork-specific commits)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected detection of media inside view-once wrappers so images, videos, and audio now display with their proper media types even when nested.
  * Refined view-once status detection so messages are marked as view-once only when the inner media explicitly indicates it, improving linked-device and wrapped-message behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->