### PR TITLE
fix: fallback waveform for PTT audio without audio-decode (#2433)

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -239,21 +239,50 @@ export async function getAudioDuration(buffer: Buffer | string | Readable) {
 }
 
 /**
+ * Generates a natural-looking fallback waveform when audio-decode is unavailable.
+ * Uses deterministic pseudo-random values based on audio content.
+ */
+const generateFallbackWaveform = (audioData: Buffer): Uint8Array => {
+	const samples = 64
+	const waveform = new Uint8Array(samples)
+
+	let seed = audioData.length
+	for(let i = 0; i < Math.min(audioData.length, 100); i++) {
+		seed = (seed * 31 + audioData[i]) >>> 0
+	}
+
+	const random = () => {
+		seed = (seed * 1664525 + 1013904223) >>> 0
+		return (seed >>> 16) / 65536
+	}
+
+	for(let i = 0; i < samples; i++) {
+		const position = i / samples
+		const envelope = Math.sin(position * Math.PI)
+		const baseAmplitude = 30 + random() * 40
+		waveform[i] = Math.min(100, Math.max(0, Math.floor(baseAmplitude * envelope)))
+	}
+
+	return waveform
+}
+
+/**
   referenced from and modifying https://github.com/wppconnect-team/wa-js/blob/main/src/chat/functions/prepareAudioWaveform.ts
  */
 export async function getAudioWaveform(buffer: Buffer | string | Readable, logger?: ILogger) {
+	let audioData: Buffer
+	if (Buffer.isBuffer(buffer)) {
+		audioData = buffer
+	} else if (typeof buffer === 'string') {
+		const rStream = createReadStream(buffer)
+		audioData = await toBuffer(rStream)
+	} else {
+		audioData = await toBuffer(buffer)
+	}
+
 	try {
 		// @ts-ignore
 		const { default: decoder } = await import('audio-decode')
-		let audioData: Buffer
-		if (Buffer.isBuffer(buffer)) {
-			audioData = buffer
-		} else if (typeof buffer === 'string') {
-			const rStream = createReadStream(buffer)
-			audioData = await toBuffer(rStream)
-		} else {
-			audioData = await toBuffer(buffer)
-		}
 
 		const audioBuffer = await decoder(audioData)
 
@@ -280,7 +309,8 @@ export async function getAudioWaveform(buffer: Buffer | string | Readable, logge
 
 		return waveform
 	} catch (e) {
-		logger?.debug('Failed to generate waveform: ' + e)
+		logger?.debug('Failed to generate waveform using audio-decode, using fallback: ' + e)
+		return generateFallbackWaveform(audioData)
 	}
 }
 

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -248,7 +248,7 @@ const generateFallbackWaveform = (audioData: Buffer): Uint8Array => {
 
 	let seed = audioData.length
 	for(let i = 0; i < Math.min(audioData.length, 100); i++) {
-		seed = (seed * 31 + audioData[i]) >>> 0
+		seed = (seed * 31 + (audioData[i] ?? 0)) >>> 0
 	}
 
 	const random = () => {


### PR DESCRIPTION
## Problem

When sending PTT audio via Baileys, WhatsApp displays a flat line instead of sound waves (#2433). This happens because `getAudioWaveform()` silently returns `undefined` when the optional `audio-decode` peer dependency isn't installed — which is the case for most users.

## Solution

Added a lightweight fallback waveform generator that produces natural-looking waveforms without any additional dependencies:

- **If `audio-decode` is installed**: Uses accurate audio analysis (existing behavior, unchanged)
- **If `audio-decode` is NOT installed**: Generates a deterministic pseudo-random waveform based on the audio buffer content

The fallback creates 64 amplitude samples (0-100) with a sine envelope for natural rise/fall, so PTT messages always display visible waveforms in WhatsApp.

## Changes

- `src/Utils/messages-media.ts`: Added `generateFallbackWaveform()` function, restructured `getAudioWaveform()` to use fallback instead of returning `undefined`

## Notes

- Zero new dependencies
- Fully backwards compatible
- Deterministic: same audio always produces same waveform pattern
- Waveform format matches WhatsApp expectations (Uint8Array, 64 samples, 0-100 range)

Fixes #2433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio waveform display reliability. The audio visualization now generates a fallback waveform when decoding fails, instead of showing no waveform at all. This ensures audio content displays properly even if standard decoding encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->