### PR TITLE
fix: exclude music-metadata 11.12.2 which ships without .d.ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "async-mutex": "^0.5.0",
     "libsignal": "git+https://github.com/whiskeysockets/libsignal-node",
     "lru-cache": "^11.1.0",
-    "music-metadata": "^11.7.0",
+    "music-metadata": ">=11.7.0 <11.12.2 || >=11.12.3",
     "p-queue": "^9.0.0",
     "pino": "^9.6",
     "protobufjs": "^7.2.4",


### PR DESCRIPTION
## Fixes #2410

### Problem
`npm install` fails when installing Baileys from git because `music-metadata@11.12.2` dropped all `.d.ts` declaration files from the published package. The `prepare` build step fails during TypeScript compilation.

### Verification
- `music-metadata@11.12.1`: has `.d.ts` files ✅
- `music-metadata@11.12.2`: zero `.d.ts` files ❌ (confirmed via `npm pack --dry-run`)
- `music-metadata@11.12.3`: has `.d.ts` files ✅ (fixed upstream)

### Fix
Updated the version range from `^11.7.0` to `>=11.7.0 <11.12.2 || >=11.12.3` to skip only the broken release while allowing all other compatible versions including the fix in 11.12.3+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `music-metadata` dependency version constraints to exclude version 11.12.2 while maintaining compatibility with supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->