### PR TITLE
fix: repair broken redirect retry counter in link preview

### DIFF
--- a/src/Utils/link-preview.ts
+++ b/src/Utils/link-preview.ts
@@ -39,7 +39,7 @@ export const getUrlInfo = async (
 ): Promise<WAUrlInfo | undefined> => {
 	try {
 		// retries
-		const retries = 0
+		let retries = 0
 		const maxRetry = 5
 
 		const { getLinkPreview } = await import('link-preview-js')
@@ -63,7 +63,7 @@ export const getUrlInfo = async (
 					forwardedURLObj.hostname === 'www.' + urlObj.hostname ||
 					'www.' + forwardedURLObj.hostname === urlObj.hostname
 				) {
-					retries + 1
+					retries += 1
 					return true
 				} else {
 					return false


### PR DESCRIPTION
## Summary

- `retries` was declared as `const`, so it could never be incremented
- The increment expression `retries + 1` was a no-op (evaluates and discards the result instead of assigning)
- This meant the `retries >= maxRetry` guard in `handleRedirects` could never trigger, allowing unbounded same-host redirects

## Fix

- `const retries = 0` → `let retries = 0`
- `retries + 1` → `retries += 1`

## Test plan

- Send a WhatsApp message containing a URL that triggers same-host redirects
- Verify redirects are now capped at 5 (`maxRetry`)
- Verify link previews still generate correctly for non-redirecting URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed redirect retry logic for link preview handling to properly enforce maximum retry limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->