### PR TITLE
feat: robust WA version override + fallback chain with 405 retry

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -53,6 +53,9 @@ export const PROCESSABLE_HISTORY_TYPES = [
 
 export const DEFAULT_CONNECTION_CONFIG: SocketConfig = {
 	version: version as WAVersion,
+	versionOverride: undefined,
+	enableVersionFallbackRetry: true,
+	versionCachePath: undefined,
 	browser: Browsers.macOS('Chrome'),
 	waWebSocketUrl: 'wss://web.whatsapp.com/ws/chat',
 	connectTimeoutMs: 20_000,

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -9,6 +9,11 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		...config
 	}
 
+	const hasLegacyVersion = Object.prototype.hasOwnProperty.call(config, 'version')
+	if (hasLegacyVersion && !newConfig.versionOverride) {
+		newConfig.versionOverride = config.version
+	}
+
 	return makeCommunitiesSocket(newConfig)
 }
 

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -6,6 +6,7 @@ import { proto } from '../../WAProto/index.js'
 import {
 	DEF_CALLBACK_PREFIX,
 	DEF_TAG_PREFIX,
+	DEFAULT_CONNECTION_CONFIG,
 	INITIAL_PREKEY_COUNT,
 	MIN_PREKEY_COUNT,
 	MIN_UPLOAD_INTERVAL,
@@ -14,7 +15,7 @@ import {
 	TimeMs,
 	UPLOAD_TIMEOUT
 } from '../Defaults'
-import type { LIDMapping, SocketConfig } from '../Types'
+import type { LIDMapping, SocketConfig, WAVersion } from '../Types'
 import { DisconnectReason } from '../Types'
 import {
 	addTransactionCapability,
@@ -37,6 +38,7 @@ import {
 	xmppSignedPreKey
 } from '../Utils'
 import { getPlatformId } from '../Utils/browser-utils'
+import { resolveWaVersion, saveLastKnownGoodVersion, type VersionSource } from '../Utils/versioning'
 import {
 	assertNodeErrorFree,
 	type BinaryNode,
@@ -110,14 +112,56 @@ export const makeSocket = (config: SocketConfig) => {
 	}
 
 	/** ephemeral key pair used to encrypt/decrypt communication. Unique for each connection */
-	const ephemeralKeyPair = Curve.generateKeyPair()
+	let ephemeralKeyPair = Curve.generateKeyPair()
 	/** WA noise protocol wrapper */
-	const noise = makeNoiseHandler({
+	let noise = makeNoiseHandler({
 		keyPair: ephemeralKeyPair,
 		NOISE_HEADER: NOISE_WA_HEADER,
 		logger,
 		routingInfo: authState?.creds?.routingInfo
 	})
+
+	let lastKnownGoodVersion: WAVersion | undefined
+	let currentVersionSource: VersionSource = 'default'
+	let latestVersionRejected = false
+	let hasAttemptedVersionFallbackRetry = false
+	let isPerformingVersionRetry = false
+	let currentConnectionVersion = config.version
+
+	const resetNoiseState = () => {
+		ephemeralKeyPair = Curve.generateKeyPair()
+		noise = makeNoiseHandler({
+			keyPair: ephemeralKeyPair,
+			NOISE_HEADER: NOISE_WA_HEADER,
+			logger,
+			routingInfo: authState?.creds?.routingInfo
+		})
+	}
+
+	const resolveConnectionVersion = async (allowLatestFetch: boolean) => {
+		const resolved = await resolveWaVersion({
+			logger,
+			versionOverride: config.versionOverride,
+			allowLatestFetch,
+			defaultVersion: DEFAULT_CONNECTION_CONFIG.version,
+			fetchOptions: config.options,
+			cachedLastKnownGoodVersion: lastKnownGoodVersion,
+			versionCachePath: config.versionCachePath
+		})
+
+		lastKnownGoodVersion = resolved.lastKnownGoodVersion
+		currentVersionSource = resolved.source
+		currentConnectionVersion = [...resolved.version] as WAVersion
+		config.version = currentConnectionVersion
+
+		logger.info(
+			{
+				version: currentConnectionVersion,
+				versionSource: currentVersionSource
+			},
+			'resolved WA version for current connection attempt'
+		)
+	}
 
 	const ws = new WebSocketClient(url, config)
 
@@ -383,6 +427,91 @@ export const makeSocket = (config: SocketConfig) => {
 		logger.error({ err }, `unexpected error in '${msg}'`)
 	}
 
+	const getStatusCodeFromError = (error: unknown) => {
+		if (error instanceof Boom) {
+			return error.output?.statusCode
+		}
+
+		const maybeBoom = error as { output?: { statusCode?: number } } | undefined
+		return maybeBoom?.output?.statusCode
+	}
+
+	const is405Error = (error: unknown) => getStatusCodeFromError(error) === 405
+
+	const scheduleVersionFallbackRetry = async (error: Error | Boom, trigger: string) => {
+		if (!config.enableVersionFallbackRetry) {
+			return false
+		}
+
+		if (config.versionOverride) {
+			logger.warn(
+				{
+					trigger,
+					versionOverride: config.versionOverride
+				},
+				'version override is set, skipping automatic 405 fallback retry'
+			)
+			return false
+		}
+
+		if (hasAttemptedVersionFallbackRetry) {
+			logger.warn({ trigger }, 'automatic 405 fallback retry already attempted once, not retrying again')
+			return false
+		}
+
+		hasAttemptedVersionFallbackRetry = true
+		const previousVersion = [...currentConnectionVersion] as WAVersion
+		const previousSource = currentVersionSource
+
+		if (previousSource === 'latest') {
+			latestVersionRejected = true
+		}
+
+		await resolveConnectionVersion(!latestVersionRejected)
+
+		const fallbackIsSameVersion = currentConnectionVersion.every((part, idx) => part === previousVersion[idx])
+		if (fallbackIsSameVersion) {
+			logger.warn(
+				{
+					trigger,
+					version: currentConnectionVersion,
+					versionSource: currentVersionSource
+				},
+				'resolved fallback version is identical to previous version, skipping automatic retry'
+			)
+			return false
+		}
+
+		logger.warn(
+			{
+				trigger,
+				error,
+				fromVersion: previousVersion,
+				fromSource: previousSource,
+				toVersion: currentConnectionVersion,
+				toSource: currentVersionSource
+			},
+			'retrying socket once with fallback WA version after 405'
+		)
+
+		isPerformingVersionRetry = true
+		clearInterval(keepAliveReq)
+		clearTimeout(qrTimer)
+		resetNoiseState()
+
+		try {
+			if (!ws.isClosed && !ws.isClosing) {
+				await ws.close()
+			}
+		} catch (closeError) {
+			logger.debug({ closeError }, 'socket close failed during 405 fallback retry, reconnecting anyway')
+		}
+
+		isPerformingVersionRetry = false
+		ws.connect()
+		return true
+	}
+
 	/** await the next incoming message */
 	const awaitNextMessage = async <T>(sendMsg?: Uint8Array) => {
 		if (!ws.isOpen) {
@@ -620,6 +749,11 @@ export const makeSocket = (config: SocketConfig) => {
 	}
 
 	const end = async (error: Error | undefined) => {
+		if (isPerformingVersionRetry) {
+			logger.debug({ trace: error?.stack }, 'skipping end() because socket retry is in progress')
+			return
+		}
+
 		if (closed) {
 			logger.trace({ trace: error?.stack }, 'connection already closed')
 			return
@@ -839,14 +973,26 @@ export const makeSocket = (config: SocketConfig) => {
 
 	ws.on('open', async () => {
 		try {
+			await resolveConnectionVersion(!latestVersionRejected)
 			await validateConnection()
 		} catch (err: any) {
+			if (is405Error(err) && (await scheduleVersionFallbackRetry(err, 'validateConnection'))) {
+				return
+			}
+
 			logger.error({ err }, 'error in validating connection')
 			void end(err)
 		}
 	})
 	ws.on('error', mapWebSocketError(end))
-	ws.on('close', () => void end(new Boom('Connection Terminated', { statusCode: DisconnectReason.connectionClosed })))
+	ws.on('close', () => {
+		if (isPerformingVersionRetry) {
+			logger.info('connection closed to perform version fallback retry')
+			return
+		}
+
+		void end(new Boom('Connection Terminated', { statusCode: DisconnectReason.connectionClosed }))
+	})
 	// the server terminated the connection
 	ws.on(
 		'CB:xmlstreamend',
@@ -922,6 +1068,12 @@ export const makeSocket = (config: SocketConfig) => {
 			updateServerTimeOffset(node)
 			await uploadPreKeysToServerIfRequired()
 			await sendPassiveIq('active')
+			await saveLastKnownGoodVersion({
+				logger,
+				version: currentConnectionVersion,
+				versionCachePath: config.versionCachePath
+			})
+			lastKnownGoodVersion = [...currentConnectionVersion] as WAVersion
 
 			// After successful login, validate our key-bundle against server
 			try {
@@ -969,18 +1121,28 @@ export const makeSocket = (config: SocketConfig) => {
 		}
 	})
 
-	ws.on('CB:stream:error', (node: BinaryNode) => {
+	ws.on('CB:stream:error', async (node: BinaryNode) => {
 		const [reasonNode] = getAllBinaryNodeChildren(node)
 		logger.error({ reasonNode, fullErrorNode: node }, 'stream errored out')
 
 		const { reason, statusCode } = getErrorCodeFromStreamError(node)
+		const error = new Boom(`Stream Errored (${reason})`, { statusCode, data: reasonNode || node })
 
-		void end(new Boom(`Stream Errored (${reason})`, { statusCode, data: reasonNode || node }))
+		if (statusCode === 405 && (await scheduleVersionFallbackRetry(error, 'stream:error'))) {
+			return
+		}
+
+		void end(error)
 	})
 	// stream fail, possible logout
-	ws.on('CB:failure', (node: BinaryNode) => {
+	ws.on('CB:failure', async (node: BinaryNode) => {
 		const reason = +(node.attrs.reason || 500)
-		void end(new Boom('Connection Failure', { statusCode: reason, data: node.attrs }))
+		const error = new Boom('Connection Failure', { statusCode: reason, data: node.attrs })
+		if (reason === 405 && (await scheduleVersionFallbackRetry(error, 'stream:failure'))) {
+			return
+		}
+
+		void end(error)
 	})
 
 	ws.on('CB:ib,,downgrade_webclient', () => {

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -984,7 +984,17 @@ export const makeSocket = (config: SocketConfig) => {
 			void end(err)
 		}
 	})
-	ws.on('error', mapWebSocketError(end))
+	ws.on(
+		'error',
+		mapWebSocketError(error => {
+			if (isPerformingVersionRetry) {
+				logger.info({ error }, 'ignoring websocket error event during version fallback retry')
+				return
+			}
+
+			void end(error)
+		})
+	)
 	ws.on('close', () => {
 		if (isPerformingVersionRetry) {
 			logger.info('connection closed to perform version fallback retry')

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -48,6 +48,12 @@ export type SocketConfig = {
 	logger: ILogger
 	/** version to connect with */
 	version: WAVersion
+	/** manually force a specific WA Web version (priority over auto resolution) */
+	versionOverride?: WAVersion
+	/** enable a one-shot automatic reconnect with fallback version when WA returns 405 */
+	enableVersionFallbackRetry: boolean
+	/** optional file path used to persist/reload last known good WA version */
+	versionCachePath?: string
 	/** override browser config */
 	browser: WABrowserDescription
 	/** agent used for fetch requests -- uploading/downloading media */

--- a/src/Utils/versioning.ts
+++ b/src/Utils/versioning.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from 'fs/promises'
 import { dirname, join } from 'path'
 import type { SocketConfig, WAVersion } from '../Types'
-import { fetchLatestBaileysVersion } from './generics'
+import { fetchLatestBaileysVersion, fetchLatestWaWebVersion } from './generics'
 import type { ILogger } from './logger'
 
 export type VersionSource = 'env/manual' | 'latest' | 'lastKnownGood' | 'default'
@@ -16,7 +16,8 @@ type ResolveVersionParams = {
 	fetchOptions: SocketConfig['options']
 	cachedLastKnownGoodVersion?: WAVersion
 	versionCachePath?: string
-	fetchLatestVersion?: FetchLatestVersionFn
+	fetchLatestWaWebVersionFn?: FetchLatestVersionFn
+	fetchLatestBaileysVersionFn?: FetchLatestVersionFn
 }
 
 type ResolveVersionResult = {
@@ -116,7 +117,8 @@ export const resolveWaVersion = async ({
 	fetchOptions,
 	cachedLastKnownGoodVersion,
 	versionCachePath,
-	fetchLatestVersion = fetchLatestBaileysVersion
+	fetchLatestWaWebVersionFn = fetchLatestWaWebVersion,
+	fetchLatestBaileysVersionFn = fetchLatestBaileysVersion
 }: ResolveVersionParams): Promise<ResolveVersionResult> => {
 	if (versionOverride && isWAVersion(versionOverride)) {
 		return {
@@ -127,16 +129,27 @@ export const resolveWaVersion = async ({
 	}
 
 	if (allowLatestFetch) {
-		const latest = await fetchLatestVersion(fetchOptions)
-		if (latest.isLatest && isWAVersion(latest.version)) {
+		const latestWaWeb = await fetchLatestWaWebVersionFn(fetchOptions)
+		if (latestWaWeb.isLatest && isWAVersion(latestWaWeb.version)) {
 			return {
-				version: cloneVersion(latest.version),
+				version: cloneVersion(latestWaWeb.version),
 				source: 'latest',
 				lastKnownGoodVersion: cachedLastKnownGoodVersion
 			}
 		}
 
-		logger.warn({ latest }, 'latest version fetch failed; attempting fallback chain')
+		logger.warn({ latestWaWeb }, 'latest WA Web version fetch failed; attempting Baileys latest fallback')
+
+		const latestBaileys = await fetchLatestBaileysVersionFn(fetchOptions)
+		if (latestBaileys.isLatest && isWAVersion(latestBaileys.version)) {
+			return {
+				version: cloneVersion(latestBaileys.version),
+				source: 'latest',
+				lastKnownGoodVersion: cachedLastKnownGoodVersion
+			}
+		}
+
+		logger.warn({ latestBaileys }, 'latest Baileys version fetch failed; attempting fallback chain')
 	}
 
 	const resolvedLastKnownGood =

--- a/src/Utils/versioning.ts
+++ b/src/Utils/versioning.ts
@@ -27,7 +27,7 @@ type ResolveVersionResult = {
 }
 
 const DEFAULT_VERSION_CACHE_FILENAME = '.baileys-last-known-good-version.json'
-let memoryLastKnownGoodVersion: WAVersion | undefined
+const memoryLastKnownGoodVersionByPath = new Map<string, WAVersion>()
 
 const isWAVersion = (value: unknown): value is WAVersion => {
 	return Array.isArray(value) && value.length === 3 && value.every(item => Number.isInteger(item) && Number(item) >= 0)
@@ -65,13 +65,15 @@ export const getLastKnownGoodVersion = async (
 	logger: ILogger,
 	versionCachePath?: string
 ): Promise<WAVersion | undefined> => {
-	if (memoryLastKnownGoodVersion) {
-		return cloneVersion(memoryLastKnownGoodVersion)
+	const cachePath = getVersionCachePath(versionCachePath)
+	const memoryVersion = memoryLastKnownGoodVersionByPath.get(cachePath)
+	if (memoryVersion) {
+		return cloneVersion(memoryVersion)
 	}
 
 	const diskVersion = await readVersionFromDisk(logger, versionCachePath)
 	if (diskVersion) {
-		memoryLastKnownGoodVersion = cloneVersion(diskVersion)
+		memoryLastKnownGoodVersionByPath.set(cachePath, cloneVersion(diskVersion))
 	}
 
 	return diskVersion
@@ -83,13 +85,13 @@ export const saveLastKnownGoodVersion = async (params: {
 	versionCachePath?: string
 }) => {
 	const { logger, version, versionCachePath } = params
-	memoryLastKnownGoodVersion = cloneVersion(version)
+	const cachePath = getVersionCachePath(versionCachePath)
+	memoryLastKnownGoodVersionByPath.set(cachePath, cloneVersion(version))
 
-	const path = getVersionCachePath(versionCachePath)
 	try {
-		await mkdir(dirname(path), { recursive: true })
+		await mkdir(dirname(cachePath), { recursive: true })
 		await writeFile(
-			path,
+			cachePath,
 			JSON.stringify(
 				{
 					version,
@@ -101,12 +103,17 @@ export const saveLastKnownGoodVersion = async (params: {
 			'utf-8'
 		)
 	} catch (error) {
-		logger.warn({ err: error, path }, 'failed persisting lastKnownGoodVersion to disk')
+		logger.warn({ err: error, path: cachePath }, 'failed persisting lastKnownGoodVersion to disk')
 	}
 }
 
-export const clearLastKnownGoodVersionMemoryCache = () => {
-	memoryLastKnownGoodVersion = undefined
+export const clearLastKnownGoodVersionMemoryCache = (versionCachePath?: string) => {
+	if (versionCachePath) {
+		memoryLastKnownGoodVersionByPath.delete(getVersionCachePath(versionCachePath))
+		return
+	}
+
+	memoryLastKnownGoodVersionByPath.clear()
 }
 
 export const resolveWaVersion = async ({
@@ -129,7 +136,13 @@ export const resolveWaVersion = async ({
 	}
 
 	if (allowLatestFetch) {
-		const latestWaWeb = await fetchLatestWaWebVersionFn(fetchOptions)
+		let latestWaWeb: Awaited<ReturnType<FetchLatestVersionFn>>
+		try {
+			latestWaWeb = await fetchLatestWaWebVersionFn(fetchOptions)
+		} catch (error) {
+			latestWaWeb = { version: defaultVersion, isLatest: false, error } as Awaited<ReturnType<FetchLatestVersionFn>>
+		}
+
 		if (latestWaWeb.isLatest && isWAVersion(latestWaWeb.version)) {
 			return {
 				version: cloneVersion(latestWaWeb.version),
@@ -140,7 +153,13 @@ export const resolveWaVersion = async ({
 
 		logger.warn({ latestWaWeb }, 'latest WA Web version fetch failed; attempting Baileys latest fallback')
 
-		const latestBaileys = await fetchLatestBaileysVersionFn(fetchOptions)
+		let latestBaileys: Awaited<ReturnType<FetchLatestVersionFn>>
+		try {
+			latestBaileys = await fetchLatestBaileysVersionFn(fetchOptions)
+		} catch (error) {
+			latestBaileys = { version: defaultVersion, isLatest: false, error } as Awaited<ReturnType<FetchLatestVersionFn>>
+		}
+
 		if (latestBaileys.isLatest && isWAVersion(latestBaileys.version)) {
 			return {
 				version: cloneVersion(latestBaileys.version),

--- a/src/Utils/versioning.ts
+++ b/src/Utils/versioning.ts
@@ -41,6 +41,23 @@ const cloneVersion = (version: WAVersion): WAVersion => {
 	return [...version] as WAVersion
 }
 
+const summarizeError = (error: unknown) => {
+	const err = error as { code?: string; message?: string; name?: string } | undefined
+	return {
+		code: err?.code,
+		name: err?.name || 'Error',
+		message: err?.message || 'Unknown error'
+	}
+}
+
+const summarizeLatestResult = (result: Awaited<ReturnType<FetchLatestVersionFn>>) => {
+	return {
+		isLatest: result.isLatest,
+		version: isWAVersion(result.version) ? result.version : undefined,
+		hasError: 'error' in result && typeof result.error !== 'undefined'
+	}
+}
+
 const readVersionFromDisk = async (logger: ILogger, versionCachePath?: string): Promise<WAVersion | undefined> => {
 	const path = getVersionCachePath(versionCachePath)
 	try {
@@ -50,11 +67,11 @@ const readVersionFromDisk = async (logger: ILogger, versionCachePath?: string): 
 			return cloneVersion(parsed.version)
 		}
 
-		logger.warn({ path, parsed }, 'ignoring invalid lastKnownGoodVersion cache payload')
+		logger.warn({ path, hasVersionField: typeof parsed.version !== 'undefined' }, 'ignoring invalid lastKnownGoodVersion cache payload')
 	} catch (error) {
 		const fileError = error as { code?: string } | undefined
 		if (fileError?.code !== 'ENOENT') {
-			logger.warn({ err: error, path }, 'failed reading lastKnownGoodVersion cache from disk')
+			logger.warn({ path, error: summarizeError(error) }, 'failed reading lastKnownGoodVersion cache from disk')
 		}
 	}
 
@@ -103,7 +120,7 @@ export const saveLastKnownGoodVersion = async (params: {
 			'utf-8'
 		)
 	} catch (error) {
-		logger.warn({ err: error, path: cachePath }, 'failed persisting lastKnownGoodVersion to disk')
+		logger.warn({ path: cachePath, error: summarizeError(error) }, 'failed persisting lastKnownGoodVersion to disk')
 	}
 }
 
@@ -140,7 +157,11 @@ export const resolveWaVersion = async ({
 		try {
 			latestWaWeb = await fetchLatestWaWebVersionFn(fetchOptions)
 		} catch (error) {
-			latestWaWeb = { version: defaultVersion, isLatest: false, error } as Awaited<ReturnType<FetchLatestVersionFn>>
+			logger.warn(
+				{ error: summarizeError(error) },
+				'latest WA Web version fetch threw; attempting Baileys latest fallback'
+			)
+			latestWaWeb = { version: defaultVersion, isLatest: false } as Awaited<ReturnType<FetchLatestVersionFn>>
 		}
 
 		if (latestWaWeb.isLatest && isWAVersion(latestWaWeb.version)) {
@@ -151,13 +172,17 @@ export const resolveWaVersion = async ({
 			}
 		}
 
-		logger.warn({ latestWaWeb }, 'latest WA Web version fetch failed; attempting Baileys latest fallback')
+		logger.warn(
+			{ latestWaWeb: summarizeLatestResult(latestWaWeb) },
+			'latest WA Web version fetch failed; attempting Baileys latest fallback'
+		)
 
 		let latestBaileys: Awaited<ReturnType<FetchLatestVersionFn>>
 		try {
 			latestBaileys = await fetchLatestBaileysVersionFn(fetchOptions)
 		} catch (error) {
-			latestBaileys = { version: defaultVersion, isLatest: false, error } as Awaited<ReturnType<FetchLatestVersionFn>>
+			logger.warn({ error: summarizeError(error) }, 'latest Baileys version fetch threw; attempting fallback chain')
+			latestBaileys = { version: defaultVersion, isLatest: false } as Awaited<ReturnType<FetchLatestVersionFn>>
 		}
 
 		if (latestBaileys.isLatest && isWAVersion(latestBaileys.version)) {
@@ -168,7 +193,7 @@ export const resolveWaVersion = async ({
 			}
 		}
 
-		logger.warn({ latestBaileys }, 'latest Baileys version fetch failed; attempting fallback chain')
+		logger.warn({ latestBaileys: summarizeLatestResult(latestBaileys) }, 'latest Baileys version fetch failed; attempting fallback chain')
 	}
 
 	const resolvedLastKnownGood =

--- a/src/Utils/versioning.ts
+++ b/src/Utils/versioning.ts
@@ -67,7 +67,10 @@ const readVersionFromDisk = async (logger: ILogger, versionCachePath?: string): 
 			return cloneVersion(parsed.version)
 		}
 
-		logger.warn({ path, hasVersionField: typeof parsed.version !== 'undefined' }, 'ignoring invalid lastKnownGoodVersion cache payload')
+		logger.warn(
+			{ path, hasVersionField: typeof parsed.version !== 'undefined' },
+			'ignoring invalid lastKnownGoodVersion cache payload'
+		)
 	} catch (error) {
 		const fileError = error as { code?: string } | undefined
 		if (fileError?.code !== 'ENOENT') {
@@ -193,7 +196,10 @@ export const resolveWaVersion = async ({
 			}
 		}
 
-		logger.warn({ latestBaileys: summarizeLatestResult(latestBaileys) }, 'latest Baileys version fetch failed; attempting fallback chain')
+		logger.warn(
+			{ latestBaileys: summarizeLatestResult(latestBaileys) },
+			'latest Baileys version fetch failed; attempting fallback chain'
+		)
 	}
 
 	const resolvedLastKnownGood =

--- a/src/Utils/versioning.ts
+++ b/src/Utils/versioning.ts
@@ -41,6 +41,10 @@ const cloneVersion = (version: WAVersion): WAVersion => {
 	return [...version] as WAVersion
 }
 
+const cloneOptionalVersion = (version?: WAVersion): WAVersion | undefined => {
+	return version ? cloneVersion(version) : undefined
+}
+
 const summarizeError = (error: unknown) => {
 	const err = error as { code?: string; message?: string; name?: string } | undefined
 	return {
@@ -106,7 +110,8 @@ export const saveLastKnownGoodVersion = async (params: {
 }) => {
 	const { logger, version, versionCachePath } = params
 	const cachePath = getVersionCachePath(versionCachePath)
-	memoryLastKnownGoodVersionByPath.set(cachePath, cloneVersion(version))
+	const versionToPersist = cloneVersion(version)
+	memoryLastKnownGoodVersionByPath.set(cachePath, versionToPersist)
 
 	try {
 		await mkdir(dirname(cachePath), { recursive: true })
@@ -114,7 +119,7 @@ export const saveLastKnownGoodVersion = async (params: {
 			cachePath,
 			JSON.stringify(
 				{
-					version,
+					version: versionToPersist,
 					updatedAt: new Date().toISOString()
 				},
 				null,
@@ -151,7 +156,7 @@ export const resolveWaVersion = async ({
 		return {
 			version: cloneVersion(versionOverride),
 			source: 'env/manual',
-			lastKnownGoodVersion: cachedLastKnownGoodVersion
+			lastKnownGoodVersion: cloneOptionalVersion(cachedLastKnownGoodVersion)
 		}
 	}
 
@@ -171,7 +176,7 @@ export const resolveWaVersion = async ({
 			return {
 				version: cloneVersion(latestWaWeb.version),
 				source: 'latest',
-				lastKnownGoodVersion: cachedLastKnownGoodVersion
+				lastKnownGoodVersion: cloneOptionalVersion(cachedLastKnownGoodVersion)
 			}
 		}
 
@@ -192,7 +197,7 @@ export const resolveWaVersion = async ({
 			return {
 				version: cloneVersion(latestBaileys.version),
 				source: 'latest',
-				lastKnownGoodVersion: cachedLastKnownGoodVersion
+				lastKnownGoodVersion: cloneOptionalVersion(cachedLastKnownGoodVersion)
 			}
 		}
 
@@ -209,9 +214,9 @@ export const resolveWaVersion = async ({
 
 	if (resolvedLastKnownGood) {
 		return {
-			version: resolvedLastKnownGood,
+			version: cloneVersion(resolvedLastKnownGood),
 			source: 'lastKnownGood',
-			lastKnownGoodVersion: resolvedLastKnownGood
+			lastKnownGoodVersion: cloneVersion(resolvedLastKnownGood)
 		}
 	}
 

--- a/src/Utils/versioning.ts
+++ b/src/Utils/versioning.ts
@@ -1,0 +1,160 @@
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import { dirname, join } from 'path'
+import type { SocketConfig, WAVersion } from '../Types'
+import { fetchLatestBaileysVersion } from './generics'
+import type { ILogger } from './logger'
+
+export type VersionSource = 'env/manual' | 'latest' | 'lastKnownGood' | 'default'
+
+type FetchLatestVersionFn = typeof fetchLatestBaileysVersion
+
+type ResolveVersionParams = {
+	logger: ILogger
+	versionOverride?: WAVersion
+	allowLatestFetch: boolean
+	defaultVersion: WAVersion
+	fetchOptions: SocketConfig['options']
+	cachedLastKnownGoodVersion?: WAVersion
+	versionCachePath?: string
+	fetchLatestVersion?: FetchLatestVersionFn
+}
+
+type ResolveVersionResult = {
+	version: WAVersion
+	source: VersionSource
+	lastKnownGoodVersion?: WAVersion
+}
+
+const DEFAULT_VERSION_CACHE_FILENAME = '.baileys-last-known-good-version.json'
+let memoryLastKnownGoodVersion: WAVersion | undefined
+
+const isWAVersion = (value: unknown): value is WAVersion => {
+	return Array.isArray(value) && value.length === 3 && value.every(item => Number.isInteger(item) && Number(item) >= 0)
+}
+
+const getVersionCachePath = (pathOverride?: string) => {
+	return pathOverride || process.env.BAILEYS_VERSION_CACHE_PATH || join(process.cwd(), DEFAULT_VERSION_CACHE_FILENAME)
+}
+
+const cloneVersion = (version: WAVersion): WAVersion => {
+	return [...version] as WAVersion
+}
+
+const readVersionFromDisk = async (logger: ILogger, versionCachePath?: string): Promise<WAVersion | undefined> => {
+	const path = getVersionCachePath(versionCachePath)
+	try {
+		const raw = await readFile(path, 'utf-8')
+		const parsed = JSON.parse(raw) as { version?: unknown }
+		if (isWAVersion(parsed.version)) {
+			return cloneVersion(parsed.version)
+		}
+
+		logger.warn({ path, parsed }, 'ignoring invalid lastKnownGoodVersion cache payload')
+	} catch (error) {
+		const fileError = error as { code?: string } | undefined
+		if (fileError?.code !== 'ENOENT') {
+			logger.warn({ err: error, path }, 'failed reading lastKnownGoodVersion cache from disk')
+		}
+	}
+
+	return undefined
+}
+
+export const getLastKnownGoodVersion = async (
+	logger: ILogger,
+	versionCachePath?: string
+): Promise<WAVersion | undefined> => {
+	if (memoryLastKnownGoodVersion) {
+		return cloneVersion(memoryLastKnownGoodVersion)
+	}
+
+	const diskVersion = await readVersionFromDisk(logger, versionCachePath)
+	if (diskVersion) {
+		memoryLastKnownGoodVersion = cloneVersion(diskVersion)
+	}
+
+	return diskVersion
+}
+
+export const saveLastKnownGoodVersion = async (params: {
+	logger: ILogger
+	version: WAVersion
+	versionCachePath?: string
+}) => {
+	const { logger, version, versionCachePath } = params
+	memoryLastKnownGoodVersion = cloneVersion(version)
+
+	const path = getVersionCachePath(versionCachePath)
+	try {
+		await mkdir(dirname(path), { recursive: true })
+		await writeFile(
+			path,
+			JSON.stringify(
+				{
+					version,
+					updatedAt: new Date().toISOString()
+				},
+				null,
+				2
+			),
+			'utf-8'
+		)
+	} catch (error) {
+		logger.warn({ err: error, path }, 'failed persisting lastKnownGoodVersion to disk')
+	}
+}
+
+export const clearLastKnownGoodVersionMemoryCache = () => {
+	memoryLastKnownGoodVersion = undefined
+}
+
+export const resolveWaVersion = async ({
+	logger,
+	versionOverride,
+	allowLatestFetch,
+	defaultVersion,
+	fetchOptions,
+	cachedLastKnownGoodVersion,
+	versionCachePath,
+	fetchLatestVersion = fetchLatestBaileysVersion
+}: ResolveVersionParams): Promise<ResolveVersionResult> => {
+	if (versionOverride && isWAVersion(versionOverride)) {
+		return {
+			version: cloneVersion(versionOverride),
+			source: 'env/manual',
+			lastKnownGoodVersion: cachedLastKnownGoodVersion
+		}
+	}
+
+	if (allowLatestFetch) {
+		const latest = await fetchLatestVersion(fetchOptions)
+		if (latest.isLatest && isWAVersion(latest.version)) {
+			return {
+				version: cloneVersion(latest.version),
+				source: 'latest',
+				lastKnownGoodVersion: cachedLastKnownGoodVersion
+			}
+		}
+
+		logger.warn({ latest }, 'latest version fetch failed; attempting fallback chain')
+	}
+
+	const resolvedLastKnownGood =
+		cachedLastKnownGoodVersion && isWAVersion(cachedLastKnownGoodVersion)
+			? cloneVersion(cachedLastKnownGoodVersion)
+			: await getLastKnownGoodVersion(logger, versionCachePath)
+
+	if (resolvedLastKnownGood) {
+		return {
+			version: resolvedLastKnownGood,
+			source: 'lastKnownGood',
+			lastKnownGoodVersion: resolvedLastKnownGood
+		}
+	}
+
+	return {
+		version: cloneVersion(defaultVersion),
+		source: 'default',
+		lastKnownGoodVersion: undefined
+	}
+}

--- a/src/__tests__/Utils/versioning.test.ts
+++ b/src/__tests__/Utils/versioning.test.ts
@@ -40,8 +40,12 @@ describe('versioning', () => {
 	})
 
 	it('prioritizes versionOverride over all other sources', async () => {
-		const fetchLatestVersion = jest.fn(async () => ({
+		const fetchLatestWaWebVersionFn = jest.fn(async () => ({
 			version: [2, 9999, 1] as [number, number, number],
+			isLatest: true
+		}))
+		const fetchLatestBaileysVersionFn = jest.fn(async () => ({
+			version: [2, 8888, 1] as [number, number, number],
 			isLatest: true
 		}))
 		const result = await resolveWaVersion({
@@ -51,32 +55,62 @@ describe('versioning', () => {
 			defaultVersion: [2, 3000, 1] as [number, number, number],
 			fetchOptions: {},
 			versionCachePath: cachePath,
-			fetchLatestVersion
+			fetchLatestWaWebVersionFn,
+			fetchLatestBaileysVersionFn
 		})
 
-		expect(fetchLatestVersion).not.toHaveBeenCalled()
+		expect(fetchLatestWaWebVersionFn).not.toHaveBeenCalled()
+		expect(fetchLatestBaileysVersionFn).not.toHaveBeenCalled()
 		expect(result.source).toBe('env/manual')
 		expect(result.version).toEqual([2, 3000, 111])
 	})
 
-	it('uses latest version when fetch succeeds', async () => {
+	it('uses WA Web latest version first when fetch succeeds', async () => {
+		const fetchLatestBaileysVersionFn = jest.fn(async () => ({
+			version: [2, 3000, 111] as [number, number, number],
+			isLatest: true
+		}))
 		const result = await resolveWaVersion({
 			logger,
 			allowLatestFetch: true,
 			defaultVersion: [2, 3000, 1] as [number, number, number],
 			fetchOptions: {},
 			versionCachePath: cachePath,
-			fetchLatestVersion: async () => ({
+			fetchLatestWaWebVersionFn: async () => ({
 				version: [2, 3000, 999] as [number, number, number],
+				isLatest: true
+			}),
+			fetchLatestBaileysVersionFn
+		})
+
+		expect(fetchLatestBaileysVersionFn).not.toHaveBeenCalled()
+		expect(result.source).toBe('latest')
+		expect(result.version).toEqual([2, 3000, 999])
+	})
+
+	it('falls back to Baileys latest when WA Web latest fails', async () => {
+		const result = await resolveWaVersion({
+			logger,
+			allowLatestFetch: true,
+			defaultVersion: [2, 3000, 1] as [number, number, number],
+			fetchOptions: {},
+			versionCachePath: cachePath,
+			fetchLatestWaWebVersionFn: async () => ({
+				version: [2, 3000, 1] as [number, number, number],
+				isLatest: false,
+				error: new Error('wa web fetch failed')
+			}),
+			fetchLatestBaileysVersionFn: async () => ({
+				version: [2, 3000, 888] as [number, number, number],
 				isLatest: true
 			})
 		})
 
 		expect(result.source).toBe('latest')
-		expect(result.version).toEqual([2, 3000, 999])
+		expect(result.version).toEqual([2, 3000, 888])
 	})
 
-	it('falls back to lastKnownGood when latest fetch fails', async () => {
+	it('falls back to lastKnownGood when all latest fetches fail', async () => {
 		await saveLastKnownGoodVersion({
 			logger,
 			version: [2, 3000, 555] as [number, number, number],
@@ -89,10 +123,15 @@ describe('versioning', () => {
 			defaultVersion: [2, 3000, 1] as [number, number, number],
 			fetchOptions: {},
 			versionCachePath: cachePath,
-			fetchLatestVersion: async () => ({
+			fetchLatestWaWebVersionFn: async () => ({
 				version: [2, 3000, 1] as [number, number, number],
 				isLatest: false,
-				error: new Error('fetch failed')
+				error: new Error('wa web fetch failed')
+			}),
+			fetchLatestBaileysVersionFn: async () => ({
+				version: [2, 3000, 1] as [number, number, number],
+				isLatest: false,
+				error: new Error('baileys fetch failed')
 			})
 		})
 

--- a/src/__tests__/Utils/versioning.test.ts
+++ b/src/__tests__/Utils/versioning.test.ts
@@ -162,4 +162,52 @@ describe('versioning', () => {
 		const loaded = await getLastKnownGoodVersion(logger, cachePath)
 		expect(loaded).toEqual([2, 3000, 777])
 	})
+
+	it('keeps memory cache isolated per cache path', async () => {
+		const cachePathOne = join(dir, 'cache-one.json')
+		const cachePathTwo = join(dir, 'cache-two.json')
+
+		await saveLastKnownGoodVersion({
+			logger,
+			version: [2, 3000, 111] as [number, number, number],
+			versionCachePath: cachePathOne
+		})
+
+		await saveLastKnownGoodVersion({
+			logger,
+			version: [2, 3000, 222] as [number, number, number],
+			versionCachePath: cachePathTwo
+		})
+
+		const loadedOne = await getLastKnownGoodVersion(logger, cachePathOne)
+		const loadedTwo = await getLastKnownGoodVersion(logger, cachePathTwo)
+
+		expect(loadedOne).toEqual([2, 3000, 111])
+		expect(loadedTwo).toEqual([2, 3000, 222])
+	})
+
+	it('continues fallback chain when latest fetchers throw', async () => {
+		await saveLastKnownGoodVersion({
+			logger,
+			version: [2, 3000, 444] as [number, number, number],
+			versionCachePath: cachePath
+		})
+
+		const result = await resolveWaVersion({
+			logger,
+			allowLatestFetch: true,
+			defaultVersion: [2, 3000, 1] as [number, number, number],
+			fetchOptions: {},
+			versionCachePath: cachePath,
+			fetchLatestWaWebVersionFn: async () => {
+				throw new Error('wa web fetch exception')
+			},
+			fetchLatestBaileysVersionFn: async () => {
+				throw new Error('baileys fetch exception')
+			}
+		})
+
+		expect(result.source).toBe('lastKnownGood')
+		expect(result.version).toEqual([2, 3000, 444])
+	})
 })

--- a/src/__tests__/Utils/versioning.test.ts
+++ b/src/__tests__/Utils/versioning.test.ts
@@ -211,4 +211,38 @@ describe('versioning', () => {
 		expect(result.source).toBe('lastKnownGood')
 		expect(result.version).toEqual([2, 3000, 444])
 	})
+
+	it('snapshots version before async disk persistence', async () => {
+		const version = [2, 3000, 901] as [number, number, number]
+		const savePromise = saveLastKnownGoodVersion({
+			logger,
+			version,
+			versionCachePath: cachePath
+		})
+
+		version[2] = 999
+		await savePromise
+
+		clearLastKnownGoodVersionMemoryCache(cachePath)
+		const loaded = await getLastKnownGoodVersion(logger, cachePath)
+		expect(loaded).toEqual([2, 3000, 901])
+	})
+
+	it('returns independent clones for resolved lastKnownGood result fields', async () => {
+		const result = await resolveWaVersion({
+			logger,
+			allowLatestFetch: false,
+			defaultVersion: [2, 3000, 1] as [number, number, number],
+			fetchOptions: {},
+			cachedLastKnownGoodVersion: [2, 3000, 123] as [number, number, number],
+			versionCachePath: cachePath
+		})
+
+		expect(result.source).toBe('lastKnownGood')
+		expect(result.version).toEqual([2, 3000, 123])
+		expect(result.lastKnownGoodVersion).toEqual([2, 3000, 123])
+
+		result.version[2] = 777
+		expect(result.lastKnownGoodVersion).toEqual([2, 3000, 123])
+	})
 })

--- a/src/__tests__/Utils/versioning.test.ts
+++ b/src/__tests__/Utils/versioning.test.ts
@@ -1,0 +1,126 @@
+import { jest } from '@jest/globals'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { ILogger } from '../../Utils/logger'
+import {
+	clearLastKnownGoodVersionMemoryCache,
+	getLastKnownGoodVersion,
+	resolveWaVersion,
+	saveLastKnownGoodVersion
+} from '../../Utils/versioning'
+
+const makeLogger = (): ILogger => {
+	const noop = () => {}
+
+	return {
+		level: 'silent',
+		child: () => makeLogger(),
+		trace: noop,
+		debug: noop,
+		info: noop,
+		warn: noop,
+		error: noop
+	}
+}
+
+describe('versioning', () => {
+	const logger = makeLogger()
+	let dir: string
+	let cachePath: string
+
+	beforeEach(async () => {
+		clearLastKnownGoodVersionMemoryCache()
+		dir = await mkdtemp(join(tmpdir(), 'baileys-versioning-'))
+		cachePath = join(dir, 'last-known-good.json')
+	})
+
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true })
+	})
+
+	it('prioritizes versionOverride over all other sources', async () => {
+		const fetchLatestVersion = jest.fn(async () => ({
+			version: [2, 9999, 1] as [number, number, number],
+			isLatest: true
+		}))
+		const result = await resolveWaVersion({
+			logger,
+			versionOverride: [2, 3000, 111] as [number, number, number],
+			allowLatestFetch: true,
+			defaultVersion: [2, 3000, 1] as [number, number, number],
+			fetchOptions: {},
+			versionCachePath: cachePath,
+			fetchLatestVersion
+		})
+
+		expect(fetchLatestVersion).not.toHaveBeenCalled()
+		expect(result.source).toBe('env/manual')
+		expect(result.version).toEqual([2, 3000, 111])
+	})
+
+	it('uses latest version when fetch succeeds', async () => {
+		const result = await resolveWaVersion({
+			logger,
+			allowLatestFetch: true,
+			defaultVersion: [2, 3000, 1] as [number, number, number],
+			fetchOptions: {},
+			versionCachePath: cachePath,
+			fetchLatestVersion: async () => ({
+				version: [2, 3000, 999] as [number, number, number],
+				isLatest: true
+			})
+		})
+
+		expect(result.source).toBe('latest')
+		expect(result.version).toEqual([2, 3000, 999])
+	})
+
+	it('falls back to lastKnownGood when latest fetch fails', async () => {
+		await saveLastKnownGoodVersion({
+			logger,
+			version: [2, 3000, 555] as [number, number, number],
+			versionCachePath: cachePath
+		})
+
+		const result = await resolveWaVersion({
+			logger,
+			allowLatestFetch: true,
+			defaultVersion: [2, 3000, 1] as [number, number, number],
+			fetchOptions: {},
+			versionCachePath: cachePath,
+			fetchLatestVersion: async () => ({
+				version: [2, 3000, 1] as [number, number, number],
+				isLatest: false,
+				error: new Error('fetch failed')
+			})
+		})
+
+		expect(result.source).toBe('lastKnownGood')
+		expect(result.version).toEqual([2, 3000, 555])
+	})
+
+	it('falls back to default when no other source is available', async () => {
+		const result = await resolveWaVersion({
+			logger,
+			allowLatestFetch: false,
+			defaultVersion: [2, 3000, 1] as [number, number, number],
+			fetchOptions: {},
+			versionCachePath: cachePath
+		})
+
+		expect(result.source).toBe('default')
+		expect(result.version).toEqual([2, 3000, 1])
+	})
+
+	it('persists and reloads lastKnownGoodVersion from disk', async () => {
+		await saveLastKnownGoodVersion({
+			logger,
+			version: [2, 3000, 777] as [number, number, number],
+			versionCachePath: cachePath
+		})
+
+		const loaded = await getLastKnownGoodVersion(logger, cachePath)
+		expect(loaded).toEqual([2, 3000, 777])
+	})
+})

--- a/src/__tests__/Utils/versioning.test.ts
+++ b/src/__tests__/Utils/versioning.test.ts
@@ -159,6 +159,7 @@ describe('versioning', () => {
 			versionCachePath: cachePath
 		})
 
+		clearLastKnownGoodVersionMemoryCache(cachePath)
 		const loaded = await getLastKnownGoodVersion(logger, cachePath)
 		expect(loaded).toEqual([2, 3000, 777])
 	})


### PR DESCRIPTION
## Summary
This PR adds native version resilience for fast WhatsApp Web protocol windows by introducing:
- Manual version override (`versionOverride`)
- Deterministic version resolution chain
- `lastKnownGoodVersion` persistence (memory + disk)
- Explicit version source logging
- One-shot automatic retry with fallback on `405`

Related issue: https://github.com/WhiskeySockets/Baileys/issues/2485

## Why this helps
When WA rolls out quickly, clients may temporarily hit `405` due to version mismatch/rejection.
This change lets operators hotfix version selection immediately (without waiting for a new library release), while also giving Baileys a safer automatic fallback path.

## What was implemented
### 1) New `SocketConfig` capabilities
- `versionOverride?: [number, number, number]`
- `enableVersionFallbackRetry: boolean`
- `versionCachePath?: string`

### 2) Version resolution strategy
The connection version is resolved with strict priority:
1. `versionOverride` (`env/manual`)
2. `fetchLatestWaWebVersion()` (`latest`, primary)
3. `fetchLatestBaileysVersion()` (`latest`, secondary fallback)
4. `lastKnownGoodVersion` (`lastKnownGood`, memory/disk)
5. `DEFAULT_CONNECTION_CONFIG.version` (`default`)

### 3) Last known good persistence
After successful login, the connected version is persisted as `lastKnownGoodVersion` and reused when latest resolution fails or is rejected.

### 4) Operational logging
Each connection attempt logs both resolved version and source:
- `env/manual`
- `latest`
- `lastKnownGood`
- `default`

### 5) Automatic retry on `405`
If handshake/stream failure returns `405`, Baileys performs one controlled retry using resolved fallback version (unless `versionOverride` is explicitly set).

### 6) Backward compatibility
If callers already set legacy `config.version`, it is promoted internally to `versionOverride` in the user-facing socket entrypoint.

## Files changed
- `src/Types/Socket.ts`
- `src/Defaults/index.ts`
- `src/Socket/index.ts`
- `src/Socket/socket.ts`
- `src/Utils/versioning.ts` (new)
- `src/__tests__/Utils/versioning.test.ts` (new)

## Test & validation report
### Local library validation
- `npx tsc -p tsconfig.json`: ✅ pass
- `jest src/__tests__/Utils/versioning.test.ts`: ✅ pass (`6/6`)
- `npm run build`: ✅ pass
- `npm run test`: ✅ pass (`17 suites`, `180 tests`)

Note on lint status:
- `npm run lint` currently fails due to pre-existing repository issues unrelated to this PR:
  - `src/Signal/libsignal.ts:459` (`prefer-optional-chain`)
  - `src/WAUSync/USyncQuery.ts:49` (`prefer-optional-chain`)

### Real integration report (consumer project)
Date: **April 19, 2026**

Scope executed:
- Dependency switched to `github:kaikybrofc/Baileys#feat/version-override-fallback-405`
- Installed and applied local patch (`patch-package`)
- Build + automated tests
- Real active WA connection via PM2
- Controlled fallback-path testing (`manual/latest/lastKnownGood/default`)

Results:
- Consumer `npm run build`: ✅ pass
- Consumer `npm run test`: ✅ pass (`19 files`, `101 tests`)
- PM2 app (`zyra`) stayed `online`
- Real WA connection opened successfully (no `405` in the observed production cycle)
- Logs confirmed new resolver path:
  - `versionSource: "env/manual"`
  - `version: [2,3000,1035194821]`
- Controlled fallback scenarios: ✅ `5/5` passed
  - manual override priority
  - invalid/latest failure -> `lastKnownGood` (memory/disk)
  - no latest + no valid cache -> `default`

Evidence captured in consumer app:
- `.baileys-last-known-good-version.json` persisted
- lockfile pinned to test branch dependency

Observed note:
- A transient Redis reconnect error happened once and recovered; WA connection normalized afterward.

## Risk / behavior notes
- Real production `405` is not deterministic to force; treatment paths were validated through controlled tests.
- Retry behavior is one-shot and guarded to avoid reconnect loops.

## Outcome
This improves resilience during rapid protocol/version transitions and provides immediate operator control with clearer observability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds robust WhatsApp Web version handling with manual override, a clear fallback chain, and a one-shot 405 retry to improve connection resilience. Also isolates per-path caches, adds safer retry guards, and snapshots/clones versions to prevent mutation leaks.

- New Features
  - `SocketConfig`: `versionOverride`, `enableVersionFallbackRetry` (default `true`), `versionCachePath`.
  - Deterministic version resolution: override > latest WA Web > latest Baileys > `lastKnownGood` > default.
  - Persist `lastKnownGoodVersion` (memory + disk per `versionCachePath`); saved after successful login.
  - One-shot 405 retry with fallback version; resets noise and guards WS `error/close`; skipped when `versionOverride` is set.
  - Legacy `config.version` auto-promoted to `versionOverride`.
  - Logs resolved version and source.

- Bug Fixes
  - Guard global WS `error/close` during retry to avoid duplicate shutdowns.
  - Per-path memory cache isolation for `lastKnownGoodVersion`.
  - Continue fallback chain when latest fetchers throw.
  - Snapshot version before writing to disk and return cloned versions from resolver to avoid accidental mutation.

<sup>Written for commit 0a9e656b21e63c57be24dff30729d2e1abac527e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-shot automatic fallback retry on server 405 responses with automatic protocol-version resolution and optional persistence to improve reconnections.
* **Configuration**
  * New options to override the protocol version, enable/disable the fallback retry, and specify a path for storing the last-known-good version.
* **Bug Fixes**
  * Improved reconnection flow to avoid duplicate shutdowns and support retrying with alternate versions.
* **Tests**
  * Added tests covering version resolution, persistence, and fallback selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review Updates (April 19, 2026)
Addressed CodeRabbit actionable comments:
- Added guard in global WebSocket `error` handler to ignore errors while version fallback retry is in progress (mirrors `close` guard behavior).
- Reworked in-memory `lastKnownGoodVersion` cache to be isolated per cache path (`Map<cachePath, version>`), avoiding cross-path bleed.
- Wrapped injected latest-version fetchers in `try/catch` so thrown rejections no longer break the fallback chain.
- Added tests covering per-path memory cache isolation and thrown-fetcher fallback continuity.

Validation rerun after fixes:
- `npx tsc -p tsconfig.json` ✅
- `jest src/__tests__/Utils/versioning.test.ts` ✅ (`8/8`)
