### PR TITLE
fix: normalize message content handling in getMediaType function

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -1072,35 +1072,36 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	}
 
 	const getMediaType = (message: proto.IMessage) => {
-		if (message.imageMessage) {
+		const normalized = normalizeMessageContent(message)
+		if (normalized?.imageMessage) {
 			return 'image'
-		} else if (message.videoMessage) {
-			return message.videoMessage.gifPlayback ? 'gif' : 'video'
-		} else if (message.audioMessage) {
-			return message.audioMessage.ptt ? 'ptt' : 'audio'
-		} else if (message.contactMessage) {
+		} else if (normalized?.videoMessage) {
+			return normalized.videoMessage.gifPlayback ? 'gif' : 'video'
+		} else if (normalized?.audioMessage) {
+			return normalized.audioMessage.ptt ? 'ptt' : 'audio'
+		} else if (normalized?.contactMessage) {
 			return 'vcard'
-		} else if (message.documentMessage) {
+		} else if (normalized?.documentMessage) {
 			return 'document'
-		} else if (message.contactsArrayMessage) {
+		} else if (normalized?.contactsArrayMessage) {
 			return 'contact_array'
-		} else if (message.liveLocationMessage) {
+		} else if (normalized?.liveLocationMessage) {
 			return 'livelocation'
-		} else if (message.stickerMessage) {
+		} else if (normalized?.stickerMessage) {
 			return 'sticker'
-		} else if (message.listMessage) {
+		} else if (normalized?.listMessage) {
 			return 'list'
-		} else if (message.listResponseMessage) {
+		} else if (normalized?.listResponseMessage) {
 			return 'list_response'
-		} else if (message.buttonsResponseMessage) {
+		} else if (normalized?.buttonsResponseMessage) {
 			return 'buttons_response'
-		} else if (message.orderMessage) {
+		} else if (normalized?.orderMessage) {
 			return 'order'
-		} else if (message.productMessage) {
+		} else if (normalized?.productMessage) {
 			return 'product'
-		} else if (message.interactiveResponseMessage) {
+		} else if (normalized?.interactiveResponseMessage) {
 			return 'native_flow_response'
-		} else if (message.groupInviteMessage) {
+		} else if (normalized?.groupInviteMessage) {
 			return 'url'
 		}
 


### PR DESCRIPTION
Normalize message to send message viewOnce

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize message content in getMediaType so media type detection works for viewOnce and other wrapped messages. This prevents misclassification when sending media by unwrapping content before checking image/video/gif/audio/ptt/etc.

<sup>Written for commit 2a54211528eaa3523cfbc7fb9fee0b6b05ca6fc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal message processing logic for better code maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->