### PR TITLE
fix: duplicate imports in chats.ts

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -56,8 +56,6 @@ import {
 	isPnUser,
 	jidDecode,
 	jidNormalizedUser,
-	isPnUser,
-	isLidUser,
 	isHostedLidUser,
 	isHostedPnUser,
 	reduceBinaryNodeToDictionary,


### PR DESCRIPTION
Happend to pull the latest code while the broken version was in main. Here's the resolution. Fixes: #2495 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code cleanup and optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed duplicate imports of `isPnUser` and `isLidUser` in `src/Socket/chats.ts` to fix the broken build and clean up the import list.

<sup>Written for commit ed89789534e375d497a758e758500ba184261095. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

