### PR TITLE
fix(retry): process <keys> bundle and embed SKDM on resend (#2506)

### DIFF
--- a/src/Signal/libsignal.ts
+++ b/src/Signal/libsignal.ts
@@ -174,11 +174,54 @@ export function makeLibSignalRepository(
 			}, group)
 		},
 
+		async getSenderKeyDistributionMessage({ group, meId }) {
+			const senderName = jidToSignalSenderKeyName(group, meId)
+			const builder = new GroupSessionBuilder(storage)
+			const senderNameStr = senderName.toString()
+
+			return parsedKeys.transaction(async () => {
+				const { [senderNameStr]: senderKey } = await auth.keys.get('sender-key', [senderNameStr])
+				if (!senderKey) {
+					await storage.storeSenderKey(senderName, new SenderKeyRecord())
+				}
+
+				const senderKeyDistributionMessage = await builder.create(senderName)
+				return senderKeyDistributionMessage.serialize()
+			}, group)
+		},
+
+		async hasSenderKey({ group, meId }) {
+			const senderName = jidToSignalSenderKeyName(group, meId).toString()
+			const { [senderName]: key } = await auth.keys.get('sender-key', [senderName])
+			return !!key
+		},
+
+		async getSessionInfo(jid) {
+			const addr = jidToSignalProtocolAddress(jid).toString()
+			const session = (await storage.loadSession(addr)) as {
+				getOpenSession?: () => { indexInfo?: { baseKey?: Buffer }; registrationId?: number } | undefined
+			} | null
+			if (!session) {
+				return null
+			}
+
+			const open = session.getOpenSession?.()
+			const baseKey = open?.indexInfo?.baseKey
+			const registrationId = open?.registrationId
+			if (!baseKey || typeof registrationId !== 'number') {
+				return null
+			}
+
+			return { baseKey: new Uint8Array(baseKey), registrationId }
+		},
+
 		async injectE2ESession({ jid, session }) {
 			logger.trace({ jid }, 'injecting E2EE session')
 			const cipher = new libsignal.SessionBuilder(storage, jidToSignalProtocolAddress(jid))
 			return parsedKeys.transaction(async () => {
-				await cipher.initOutgoing(session)
+				// libsignal runtime accepts an absent prekey (initOutgoing checks `device.preKey && ...`)
+				// but the bundled .d.ts marks it required.
+				await cipher.initOutgoing(session as unknown as Parameters<typeof cipher.initOutgoing>[0])
 			}, jid)
 		},
 		jidToSignalProtocolAddress(jid) {

--- a/src/Signal/libsignal.ts
+++ b/src/Signal/libsignal.ts
@@ -62,6 +62,18 @@ export function makeLibSignalRepository(
 		updateAgeOnGet: true
 	})
 
+	const ensureSenderKeyAndCreateSkdm = async (group: string, meId: string) => {
+		const senderName = jidToSignalSenderKeyName(group, meId)
+		const senderNameStr = senderName.toString()
+		const { [senderNameStr]: senderKey } = await auth.keys.get('sender-key', [senderNameStr])
+		if (!senderKey) {
+			await storage.storeSenderKey(senderName, new SenderKeyRecord())
+		}
+
+		const skdm = await new GroupSessionBuilder(storage).create(senderName)
+		return { senderName, skdm }
+	}
+
 	const repository: SignalRepositoryWithLIDStore = {
 		decryptGroupMessage({ group, authorJid, msg }) {
 			const senderName = jidToSignalSenderKeyName(group, authorJid)
@@ -152,41 +164,17 @@ export function makeLibSignalRepository(
 		},
 
 		async encryptGroupMessage({ group, meId, data }) {
-			const senderName = jidToSignalSenderKeyName(group, meId)
-			const builder = new GroupSessionBuilder(storage)
-
-			const senderNameStr = senderName.toString()
-
 			return parsedKeys.transaction(async () => {
-				const { [senderNameStr]: senderKey } = await auth.keys.get('sender-key', [senderNameStr])
-				if (!senderKey) {
-					await storage.storeSenderKey(senderName, new SenderKeyRecord())
-				}
-
-				const senderKeyDistributionMessage = await builder.create(senderName)
-				const session = new GroupCipher(storage, senderName)
-				const ciphertext = await session.encrypt(data)
-
-				return {
-					ciphertext,
-					senderKeyDistributionMessage: senderKeyDistributionMessage.serialize()
-				}
+				const { senderName, skdm } = await ensureSenderKeyAndCreateSkdm(group, meId)
+				const ciphertext = await new GroupCipher(storage, senderName).encrypt(data)
+				return { ciphertext, senderKeyDistributionMessage: skdm.serialize() }
 			}, group)
 		},
 
 		async getSenderKeyDistributionMessage({ group, meId }) {
-			const senderName = jidToSignalSenderKeyName(group, meId)
-			const builder = new GroupSessionBuilder(storage)
-			const senderNameStr = senderName.toString()
-
 			return parsedKeys.transaction(async () => {
-				const { [senderNameStr]: senderKey } = await auth.keys.get('sender-key', [senderNameStr])
-				if (!senderKey) {
-					await storage.storeSenderKey(senderName, new SenderKeyRecord())
-				}
-
-				const senderKeyDistributionMessage = await builder.create(senderName)
-				return senderKeyDistributionMessage.serialize()
+				const { skdm } = await ensureSenderKeyAndCreateSkdm(group, meId)
+				return skdm.serialize()
 			}, group)
 		},
 

--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -52,12 +52,12 @@ import {
 	type BinaryNode,
 	getBinaryNodeChild,
 	getBinaryNodeChildren,
+	isHostedLidUser,
+	isHostedPnUser,
 	isLidUser,
 	isPnUser,
 	jidDecode,
 	jidNormalizedUser,
-	isHostedLidUser,
-	isHostedPnUser,
 	reduceBinaryNodeToDictionary,
 	S_WHATSAPP_NET
 } from '../WABinary'

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -35,6 +35,7 @@ import {
 	encodeBigEndian,
 	encodeSignedDeviceIdentity,
 	extractAddressingContext,
+	extractE2ESessionFromRetryReceipt,
 	getCallStatusFromNode,
 	getHistoryMsg,
 	getNextPreKeys,
@@ -71,6 +72,7 @@ import {
 	getBinaryNodeChildBuffer,
 	getBinaryNodeChildren,
 	getBinaryNodeChildString,
+	getBinaryNodeChildUInt,
 	isJidGroup,
 	isJidNewsletter,
 	isJidStatusBroadcast,
@@ -1022,11 +1024,17 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		await msgRetryCache.set(key, newValue)
 	}
 
-	const sendMessagesAgain = async (key: WAMessageKey, ids: string[], retryNode: BinaryNode) => {
+	const sendMessagesAgain = async (
+		key: WAMessageKey,
+		ids: string[],
+		retryNode: BinaryNode,
+		receiptNode: BinaryNode
+	) => {
 		const remoteJid = key.remoteJid!
 		const participant = key.participant || remoteJid
 
 		const retryCount = +retryNode.attrs.count! || 1
+		const msgId = ids[0]
 
 		// Try to get messages from cache first, then fallback to getMessage
 		const msgs: (proto.IMessage | undefined)[] = []
@@ -1065,14 +1073,56 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		// prevents the first message decryption failure
 		const sendToAll = !jidDecode(participant)?.device
 
-		// Check if we should recreate session for this retry
+		const sessionId = signalRepository.jidToSignalProtocolAddress(participant)
+		let injectedFromBundle = false
+
+		const bundle = extractE2ESessionFromRetryReceipt(receiptNode)
+		if (bundle) {
+			try {
+				await signalRepository.injectE2ESession({ jid: participant, session: bundle })
+				injectedFromBundle = true
+				logger.debug({ participant, retryCount }, 'injected session from retry receipt key bundle')
+			} catch (error) {
+				logger.warn({ error, participant }, 'failed to inject session from retry receipt')
+			}
+		}
+
+		if (!injectedFromBundle) {
+			const receivedRegId = getBinaryNodeChildUInt(receiptNode, 'registration', 4)
+			if (typeof receivedRegId === 'number' && Number.isInteger(receivedRegId)) {
+				const info = await signalRepository.getSessionInfo(participant)
+				if (info && info.registrationId !== 0 && info.registrationId !== receivedRegId) {
+					logger.info(
+						{ participant, stored: info.registrationId, received: receivedRegId },
+						'reg id mismatch on retry without bundle, deleting session'
+					)
+					await authState.keys.set({ session: { [sessionId]: null } })
+				}
+			}
+		}
+
+		const BASE_KEY_CHECK_RETRY = 2
+		if (msgId && messageRetryManager) {
+			const info = await signalRepository.getSessionInfo(participant)
+			if (info) {
+				if (retryCount === BASE_KEY_CHECK_RETRY) {
+					messageRetryManager.saveBaseKey(sessionId, msgId, info.baseKey)
+				} else if (retryCount > BASE_KEY_CHECK_RETRY) {
+					if (messageRetryManager.hasSameBaseKey(sessionId, msgId, info.baseKey)) {
+						logger.warn({ participant, retryCount }, 'base key collision on retry, forcing fresh session')
+						await authState.keys.set({ session: { [sessionId]: null } })
+					}
+
+					messageRetryManager.deleteBaseKey(sessionId, msgId)
+				}
+			}
+		}
+
 		let shouldRecreateSession = false
 		let recreateReason = ''
 
-		if (enableAutoSessionRecreation && messageRetryManager && retryCount > 1) {
+		if (enableAutoSessionRecreation && messageRetryManager && retryCount > 1 && !injectedFromBundle) {
 			try {
-				const sessionId = signalRepository.jidToSignalProtocolAddress(participant)
-
 				const hasSession = await signalRepository.validateSession(participant)
 				const result = messageRetryManager.shouldRecreateSession(participant, hasSession.exists)
 				shouldRecreateSession = result.recreate
@@ -1087,13 +1137,18 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			}
 		}
 
-		await assertSessions([participant], true)
+		if (!injectedFromBundle) {
+			await assertSessions([participant], true)
+		}
 
 		if (isJidGroup(remoteJid)) {
 			await authState.keys.set({ 'sender-key-memory': { [remoteJid]: null } })
 		}
 
-		logger.debug({ participant, sendToAll, shouldRecreateSession, recreateReason }, 'forced new session for retry recp')
+		logger.debug(
+			{ participant, sendToAll, shouldRecreateSession, recreateReason, injectedFromBundle },
+			'prepared session for retry resend'
+		)
 
 		for (const [i, msg] of msgs.entries()) {
 			if (!ids[i]) continue
@@ -1186,7 +1241,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 								try {
 									await updateSendMessageAgainCount(ids[0], key.participant)
 									logger.debug({ attrs, key }, 'recv retry request')
-									await sendMessagesAgain(key, ids, retryNode!)
+									await sendMessagesAgain(key, ids, retryNode!, node)
 								} catch (error: unknown) {
 									logger.error(
 										{ key, ids, trace: error instanceof Error ? error.stack : 'Unknown error' },
@@ -1490,14 +1545,14 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				status
 			}
 
-      if (status === 'relaylatency') {
-        const latencyValue = infoChild.attrs.latency || infoChild.attrs['latency_ms'] || infoChild.attrs['latency-ms']
-        const latencyMs = latencyValue ? Number(latencyValue) : undefined
-        if (Number.isFinite(latencyMs)) {
-          call.latencyMs = latencyMs
-        }
-      }
-      
+			if (status === 'relaylatency') {
+				const latencyValue = infoChild.attrs.latency || infoChild.attrs['latency_ms'] || infoChild.attrs['latency-ms']
+				const latencyMs = latencyValue ? Number(latencyValue) : undefined
+				if (Number.isFinite(latencyMs)) {
+					call.latencyMs = latencyMs
+				}
+			}
+
 			if (status === 'offer') {
 				call.isVideo = !!getBinaryNodeChild(infoChild, 'video')
 				call.isGroup = infoChild.attrs.type === 'group' || !!infoChild.attrs['group-jid']
@@ -1625,6 +1680,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			)
 			ignoreJid = !isNodeFromMe || isJidGroup(attrs.from) ? attrs.from : attrs.recipient
 		}
+
 		if (ignoreJid && ignoreJid !== S_WHATSAPP_NET && shouldIgnoreJid(ignoreJid)) {
 			await sendMessageAck(node, type === 'message' ? NACK_REASONS.UnhandledError : undefined)
 			return

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -940,16 +940,20 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 					}
 
 					if (groupSenderIdentity) {
-						const skdm = await signalRepository.getSenderKeyDistributionMessage({
-							group: destinationJid,
-							meId: groupSenderIdentity
-						})
-						messageToSend = {
-							...message,
-							senderKeyDistributionMessage: {
-								groupId: destinationJid,
-								axolotlSenderKeyDistributionMessage: skdm
+						try {
+							const skdm = await signalRepository.getSenderKeyDistributionMessage({
+								group: destinationJid,
+								meId: groupSenderIdentity
+							})
+							messageToSend = {
+								...message,
+								senderKeyDistributionMessage: {
+									groupId: destinationJid,
+									axolotlSenderKeyDistributionMessage: skdm
+								}
 							}
+						} catch (err) {
+							logger.warn({ err, jid: destinationJid }, 'failed to build SKDM for retry, sending without it')
 						}
 					}
 				}

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -930,14 +930,38 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				const isParticipantLid = isLidUser(participant!.jid)
 				const isMe = areJidsSameUser(participant!.jid, isParticipantLid ? meLid : meId)
 
+				let messageToSend = message
+				if (isGroupOrStatus) {
+					let groupSenderIdentity: string | undefined
+					if (meLid && (await signalRepository.hasSenderKey({ group: destinationJid, meId: meLid }))) {
+						groupSenderIdentity = meLid
+					} else if (await signalRepository.hasSenderKey({ group: destinationJid, meId })) {
+						groupSenderIdentity = meId
+					}
+
+					if (groupSenderIdentity) {
+						const skdm = await signalRepository.getSenderKeyDistributionMessage({
+							group: destinationJid,
+							meId: groupSenderIdentity
+						})
+						messageToSend = {
+							...message,
+							senderKeyDistributionMessage: {
+								groupId: destinationJid,
+								axolotlSenderKeyDistributionMessage: skdm
+							}
+						}
+					}
+				}
+
 				const encodedMessageToSend = isMe
 					? encodeWAMessage({
 							deviceSentMessage: {
 								destinationJid,
-								message
+								message: messageToSend
 							}
 						})
-					: encodeWAMessage(message)
+					: encodeWAMessage(messageToSend)
 
 				const { type, ciphertext: encryptedContent } = await signalRepository.encryptMessage({
 					data: encodedMessageToSend,

--- a/src/Types/Signal.ts
+++ b/src/Types/Signal.ts
@@ -29,6 +29,11 @@ type EncryptGroupMessageOpts = {
 	meId: string
 }
 
+type GetSenderKeyDistributionMessageOpts = {
+	group: string
+	meId: string
+}
+
 type PreKey = {
 	keyId: number
 	publicKey: Uint8Array
@@ -42,7 +47,7 @@ type E2ESession = {
 	registrationId: number
 	identityKey: Uint8Array
 	signedPreKey: SignedPreKey
-	preKey: PreKey
+	preKey?: PreKey
 }
 
 type E2ESessionOpts = {
@@ -62,6 +67,9 @@ export type SignalRepository = {
 		senderKeyDistributionMessage: Uint8Array
 		ciphertext: Uint8Array
 	}>
+	getSenderKeyDistributionMessage(opts: GetSenderKeyDistributionMessageOpts): Promise<Uint8Array>
+	hasSenderKey(opts: GetSenderKeyDistributionMessageOpts): Promise<boolean>
+	getSessionInfo(jid: string): Promise<{ baseKey: Uint8Array; registrationId: number } | null>
 	injectE2ESession(opts: E2ESessionOpts): Promise<void>
 	validateSession(jid: string): Promise<{ exists: boolean; reason?: string }>
 	jidToSignalProtocolAddress(jid: string): string

--- a/src/Utils/message-retry-manager.ts
+++ b/src/Utils/message-retry-manager.ts
@@ -85,6 +85,11 @@ export class MessageRetryManager {
 		ttlAutopurge: true,
 		updateAgeOnGet: true
 	}) // 15 minutes TTL
+	private baseKeys = new LRUCache<string, Uint8Array>({
+		max: 1024,
+		ttl: 15 * 60 * 1000,
+		ttlAutopurge: true
+	})
 	private pendingPhoneRequests: PendingPhoneRequest = {}
 	private readonly maxMsgRetryCount: number = 5
 	private statistics: RetryStatistics = {
@@ -277,6 +282,27 @@ export class MessageRetryManager {
 			delete this.pendingPhoneRequests[messageId]
 			this.logger.debug(`Cancelled pending phone request for message ${messageId}`)
 		}
+	}
+
+	saveBaseKey(addr: string, msgId: string, baseKey: Uint8Array): void {
+		this.baseKeys.set(`${addr}:${msgId}`, baseKey)
+	}
+
+	hasSameBaseKey(addr: string, msgId: string, baseKey: Uint8Array): boolean {
+		const stored = this.baseKeys.get(`${addr}:${msgId}`)
+		if (!stored || stored.length !== baseKey.length) {
+			return false
+		}
+
+		for (let i = 0; i < stored.length; i++) {
+			if (stored[i] !== baseKey[i]) return false
+		}
+
+		return true
+	}
+
+	deleteBaseKey(addr: string, msgId: string): void {
+		this.baseKeys.delete(`${addr}:${msgId}`)
 	}
 
 	private keyToString(key: RecentMessageKey): string {

--- a/src/Utils/signal.ts
+++ b/src/Utils/signal.ts
@@ -87,6 +87,50 @@ export const xmppPreKey = (pair: KeyPair, id: number): BinaryNode => ({
 	]
 })
 
+const isValidUInt = (n: number | undefined): n is number => typeof n === 'number' && Number.isInteger(n)
+
+export const extractE2ESessionFromRetryReceipt = (receipt: BinaryNode) => {
+	const keysNode = getBinaryNodeChild(receipt, 'keys')
+	if (!keysNode) return null
+
+	const identity = getBinaryNodeChildBuffer(keysNode, 'identity')
+	const skey = getBinaryNodeChild(keysNode, 'skey')
+	if (!identity || identity.length !== 32 || !skey) return null
+
+	const registrationId = getBinaryNodeChildUInt(receipt, 'registration', 4)
+	if (!isValidUInt(registrationId)) return null
+
+	const signedPubKey = getBinaryNodeChildBuffer(skey, 'value')
+	const signedSig = getBinaryNodeChildBuffer(skey, 'signature')
+	const signedKeyId = getBinaryNodeChildUInt(skey, 'id', 3)
+	if (!signedPubKey || signedPubKey.length !== 32 || !signedSig || !isValidUInt(signedKeyId)) {
+		return null
+	}
+
+	const preKeyNode = getBinaryNodeChild(keysNode, 'key')
+	let preKey: { keyId: number; publicKey: Uint8Array } | undefined
+	if (preKeyNode) {
+		const preKeyPub = getBinaryNodeChildBuffer(preKeyNode, 'value')
+		const preKeyId = getBinaryNodeChildUInt(preKeyNode, 'id', 3)
+		if (!preKeyPub || preKeyPub.length !== 32 || !isValidUInt(preKeyId)) {
+			return null
+		}
+
+		preKey = { keyId: preKeyId, publicKey: generateSignalPubKey(preKeyPub) }
+	}
+
+	return {
+		registrationId,
+		identityKey: generateSignalPubKey(identity),
+		signedPreKey: {
+			keyId: signedKeyId,
+			publicKey: generateSignalPubKey(signedPubKey),
+			signature: signedSig
+		},
+		preKey
+	}
+}
+
 export const parseAndInjectE2ESessions = async (node: BinaryNode, repository: SignalRepositoryWithLIDStore) => {
 	const extractKey = (key: BinaryNode) =>
 		key

--- a/src/Utils/signal.ts
+++ b/src/Utils/signal.ts
@@ -93,6 +93,9 @@ export const extractE2ESessionFromRetryReceipt = (receipt: BinaryNode) => {
 	const keysNode = getBinaryNodeChild(receipt, 'keys')
 	if (!keysNode) return null
 
+	const typeBuf = getBinaryNodeChildBuffer(keysNode, 'type')
+	if (!typeBuf || typeBuf.length !== 1 || typeBuf[0] !== KEY_BUNDLE_TYPE[0]) return null
+
 	const identity = getBinaryNodeChildBuffer(keysNode, 'identity')
 	const skey = getBinaryNodeChild(keysNode, 'skey')
 	if (!identity || identity.length !== 32 || !skey) return null


### PR DESCRIPTION
Fixes #2506.

Two gaps in the retry path were causing the intermittent "No session found to decrypt message" with an empty `SenderKeyRecord`:

When we receive a retry receipt for a message we sent, the peer ships a fresh prekey bundle in `<keys>`. We were ignoring it and doing an extra IQ to fetch prekeys from the server, which can hand back a different bundle than the one the peer expects us to use.

When we resend to a group, the SKDM block in `messages-send.ts` was gated on `!isRetryResend`, so the resend went out as pairwise ciphertext only. If the peer's SenderKeyRecord was empty (the original SKDM never landed), they still couldn't decrypt the original `skmsg`.

## What changed

I followed `WAWebUpdateLocalSignalSession` and `RetryMsgJob`, cross-checked against [whatsmeow's `retry.go`](https://github.com/tulir/whatsmeow/blob/master/retry.go) and [whatsapp-rust's `retry.rs`](https://github.com/oxidezap/whatsapp-rust/blob/master/src/retry.rs).

In `sendMessagesAgain`:
* Parse `<keys>` + `<registration>` and call `injectE2ESession`. Skip the prekey IQ when we used the bundle.
* If there's no bundle and the received regId differs from the stored one, delete the session.
* On `retry==2` save the current base key. On `retry>2` with the same base key, delete the session to force a fresh one.

In the retry branch of `relayMessage`:
* For groups and status, embed `senderKeyDistributionMessage` in the message protobuf before pairwise encrypt. The sender identity is picked from whichever `(group, meLid|meId)` sender key already exists, so we don't accidentally rotate to a different addressing mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved sender-key distribution support during retries and ability to inject E2E session bundles from receipts
  * New APIs to fetch sender-key distribution messages and per-JID session base info; in-memory base-key tracking for retries

* **Bug Fixes**
  * Better session lifecycle handling on retries, including base-key collision detection and safer session deletion
  * Allow sessions to exist without a pre-key to avoid runtime errors during injection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->