### PR TITLE
Fix 463 MissingTcToken recovery flow and dedupe concurrent token re-issuance

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1575,7 +1575,8 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 								result,
 								fallbackJid: tcStorageJid,
 								keys: authState.keys,
-								getLIDForPN
+								getLIDForPN,
+								onNewJidStored: trackTcTokenJid
 							})
 							logger.debug({ from: ackFrom }, 'completed 463 token recovery issuance')
 						} catch (err: any) {

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1556,6 +1556,35 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 					{ msgId: attrs.id, from: attrs.from },
 					'error 463: account restricted or missing tctoken for contact'
 				)
+
+				const ackFrom = attrs.from
+				if (ackFrom && !inFlight463Recoveries.has(ackFrom)) {
+					inFlight463Recoveries.add(ackFrom)
+					void (async() => {
+						try {
+							const getPNForLID = signalRepository.lidMapping.getPNForLID.bind(signalRepository.lidMapping)
+							const tcStorageJid = await resolveTcTokenJid(ackFrom, getLIDForPN)
+							const issueJid = await resolveIssuanceJid(
+								ackFrom,
+								sock.serverProps.lidTrustedTokenIssueToLid,
+								getLIDForPN,
+								getPNForLID
+							)
+							const result = await issuePrivacyTokens([issueJid], unixTimestampSeconds())
+							await storeTcTokensFromIqResult({
+								result,
+								fallbackJid: tcStorageJid,
+								keys: authState.keys,
+								getLIDForPN
+							})
+							logger.debug({ from: ackFrom }, 'completed 463 token recovery issuance')
+						} catch (err: any) {
+							logger.debug({ from: ackFrom, err: err?.message }, 'failed 463 token recovery issuance')
+						} finally {
+							inFlight463Recoveries.delete(ackFrom)
+						}
+					})()
+				}
 			} else if (attrs.error === SERVER_ERROR_CODES.SmaxInvalid) {
 				logger.warn(
 					{ msgId: attrs.id, from: attrs.from },
@@ -1693,6 +1722,8 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 
 	/** timestamp of last tctoken prune run — throttles to once per 24h */
 	let lastTcTokenPruneTs = 0
+	/** dedupe in-flight 463 recovery token issuance by target JID */
+	const inFlight463Recoveries = new Set<string>()
 
 	ev.on('connection.update', ({ isOnline, connection }) => {
 		if (typeof isOnline !== 'undefined') {


### PR DESCRIPTION
This PR improves how Baileys handles ACK error 463 (MissingTcToken).

What changed
Added a self-healing recovery path in messages-recv when the server returns ACK error 463.

On 463, the client now:

Resolves the correct storage and issuance JIDs,

Calls issuePrivacyTokens(...),

Persists the returned token via storeTcTokensFromIqResult(...).

Added an in-flight dedupe set (inFlight463Recoveries) to avoid starting multiple recovery jobs for the same contact at the same time.

Kept this flow non-blocking and preserved existing behavior (no automatic message resend loop).

Why
Previously, 463 was mostly logged, which could leave the session stuck without a refreshed token for that contact.
With this change, the client proactively recovers token state so subsequent sends can succeed more reliably.

Safety / behavior notes
No message auto-retry was introduced (to avoid retry loops and extra reachout pressure).

Recovery is best-effort and isolated; failures are logged and dedupe state is always released in finally.

Testing
Ran focused token tests:

npm test -- --runInBand src/__tests__/Utils/tc-token.test.ts

Result: PASS (all tests passed).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience for missing token errors: the system now automatically initiates an asynchronous recovery to re-issue required privacy tokens, persist them, and log outcomes. Concurrent recovery attempts are deduplicated to avoid redundancy. Recovery markers are reliably cleared on completion or failure to allow future retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->