### PR TITLE
fix: per-JID assertSessions fallback for group sends

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -804,12 +804,33 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 					}
 
 					const senderKeySessionTargets = senderKeyRecipients
-					await assertSessions(senderKeySessionTargets)
+					let reachableRecipients = [...senderKeySessionTargets]
+					try {
+						await assertSessions(senderKeySessionTargets)
+					} catch(sessionErr) {
+						const isRecoverable = ['not-acceptable', 'Timed Out', 'No sessions'].includes((sessionErr as Error).message)
+						if(isRecoverable && senderKeySessionTargets.length > 1) {
+							logger.warn({ count: senderKeySessionTargets.length, err: (sessionErr as Error).message },
+								'batch assertSessions failed — retrying per-JID to skip unreachable devices')
+							reachableRecipients = []
+							for(const candidateJid of senderKeySessionTargets) {
+								try {
+									await assertSessions([candidateJid])
+									reachableRecipients.push(candidateJid)
+								} catch(e) {
+									logger.warn({ jid: candidateJid, err: (e as Error).message }, 'skipping unreachable participant device')
+								}
+							}
+						} else {
+							throw sessionErr
+						}
+					}
 
-					const result = await createParticipantNodes(senderKeyRecipients, senderKeyMsg, extraAttrs)
-					shouldIncludeDeviceIdentity = shouldIncludeDeviceIdentity || result.shouldIncludeDeviceIdentity
-
-					participants.push(...result.nodes)
+					if(reachableRecipients.length) {
+						const result = await createParticipantNodes(reachableRecipients, senderKeyMsg, extraAttrs)
+						shouldIncludeDeviceIdentity = shouldIncludeDeviceIdentity || result.shouldIncludeDeviceIdentity
+						participants.push(...result.nodes)
+					}
 				}
 
 				binaryNodeContent.push({


### PR DESCRIPTION
Fixes #2521.

Wraps the batch `assertSessions` call in the group send branch with a per-JID retry fallback. If the batch fails with a recoverable error (`not-acceptable`, `Timed Out`, `No sessions`), individual JIDs are retried and unreachable devices are skipped rather than aborting the entire send.

Degradation is graceful: if all devices are unreachable, `reachableRecipients` is empty and the send is a no-op.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents group sends from aborting when batch `assertSessions` fails by retrying per-JID and skipping unreachable devices. Messages now deliver to reachable participants even if some devices are deregistered or stale.

- **Bug Fixes**
  - Wrap batch `assertSessions` in a try/catch; on recoverable errors (`not-acceptable`, `Timed Out`, `No sessions`), retry per JID.
  - Create participant nodes only for JIDs that pass; skip unreachable devices instead of failing the whole send.
  - If no recipients are reachable, perform a safe no-op (no participants added).

<sup>Written for commit f4633feae28116369d4bab91fd768c920e6e1dfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of group message delivery by implementing intelligent per-recipient retry logic. When batch session validation encounters recoverable errors, the system now attempts delivery to each recipient individually, ensuring messages reach available contacts while maintaining detailed logs of retry attempts and unreachable devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->