### PR TITLE
Enhance button functionality and support AI messages

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -631,7 +631,8 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 			additionalNodes,
 			useUserDevicesCache,
 			useCachedGroupMetadata,
-			statusJidList
+			statusJidList,
+			ai = false
 		}: MessageRelayOptions
 	) => {
 		const meId = assertMeId(authState.creds)
@@ -657,6 +658,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		const binaryNodeContent: BinaryNode[] = []
 		const devices: DeviceWithJid[] = []
 		let reportingMessage: proto.IMessage | undefined
+		let additionalNodesPushed = false
 
 		const meMsg: proto.IMessage = {
 			deviceSentMessage: {
@@ -1071,11 +1073,39 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 			}
 
 			if (!isNewsletter && buttonType) {
-				const buttonsNode = getButtonArgs(normalizedMsg)
-				;(stanza.content as BinaryNode[]).push(buttonsNode)
+				const additionalHasButton = (additionalNodes ?? []).some(
+					n =>
+						['hsm', 'biz'].includes(n?.tag ?? '') ||
+						['interactive', 'buttons', 'list'].includes(
+							((n?.content as BinaryNode[])?.[0]?.tag ?? '')
+						) ||
+						['native_flow'].includes(
+							((n?.content as BinaryNode[])?.[0]?.content as BinaryNode[])?.[0]?.tag ?? ''
+						)
+				)
+				if (additionalHasButton) {
+					;(stanza.content as BinaryNode[]).push(...additionalNodes!)
+					additionalNodesPushed = true
+				} else {
+					;(stanza.content as BinaryNode[]).push(getButtonArgs(normalizedMsg))
+				}
 			}
 
-			if (additionalNodes && additionalNodes.length > 0) {
+			if (ai && !isGroup && !isStatus && !isNewsletter) {
+				const additionalHasBot = (additionalNodes ?? []).some(
+					n => n?.tag === 'bot' && n?.attrs?.['biz_bot'] === '1'
+				)
+				if (additionalHasBot) {
+					if (!additionalNodesPushed) {
+						;(stanza.content as BinaryNode[]).push(...additionalNodes!)
+						additionalNodesPushed = true
+					}
+				} else {
+					;(stanza.content as BinaryNode[]).push({ tag: 'bot', attrs: { biz_bot: '1' } })
+				}
+			}
+
+			if (!additionalNodesPushed && additionalNodes && additionalNodes.length > 0) {
 				;(stanza.content as BinaryNode[]).push(...additionalNodes)
 			}
 
@@ -1477,7 +1507,8 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 					useCachedGroupMetadata: options.useCachedGroupMetadata,
 					additionalAttributes,
 					statusJidList: options.statusJidList,
-					additionalNodes
+					additionalNodes,
+					ai: options.ai
 				})
 				if (config.emitOwnEvents) {
 					process.nextTick(async () => {

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -667,6 +667,8 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		}
 
 		const extraAttrs: BinaryNodeAttributes = {}
+		const normalizedMsg = normalizeMessageContent(message)
+		const buttonType = getButtonType(normalizedMsg)
 
 		if (participant) {
 			if (!isGroup && !isStatus) {
@@ -1068,6 +1070,11 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				})
 			}
 
+			if (!isNewsletter && buttonType) {
+				const buttonsNode = getButtonArgs(normalizedMsg)
+				;(stanza.content as BinaryNode[]).push(buttonsNode)
+			}
+
 			if (additionalNodes && additionalNodes.length > 0) {
 				;(stanza.content as BinaryNode[]).push(...additionalNodes)
 			}
@@ -1129,6 +1136,107 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		}, meId)
 
 		return msgId
+	}
+
+	const getButtonType = (message: proto.IMessage | null | undefined): string | undefined => {
+		if (!message) return undefined
+		if (message.listMessage) {
+			return 'list'
+		} else if (message.buttonsMessage) {
+			return 'buttons'
+		} else if (message.interactiveMessage?.nativeFlowMessage) {
+			return 'native_flow'
+		}
+		return undefined
+	}
+
+	const getButtonArgs = (message: proto.IMessage | null | undefined): BinaryNode => {
+		const nativeFlow = message?.interactiveMessage?.nativeFlowMessage
+		const firstButtonName = nativeFlow?.buttons?.[0]?.name
+		const nativeFlowSpecials = [
+			'mpm', 'cta_catalog', 'send_location',
+			'call_permission_request', 'wa_payment_transaction_details',
+			'automated_greeting_message_view_catalog'
+		]
+
+		if (nativeFlow && (firstButtonName === 'review_and_pay' || firstButtonName === 'payment_info')) {
+			return {
+				tag: 'biz',
+				attrs: {
+					native_flow_name: firstButtonName === 'review_and_pay' ? 'order_details' : firstButtonName
+				}
+			}
+		} else if (nativeFlow && nativeFlowSpecials.includes(firstButtonName!)) {
+			return {
+				tag: 'biz',
+				attrs: {
+					actual_actors: '2',
+					host_storage: '2',
+					privacy_mode_ts: unixTimestampSeconds().toString()
+				},
+				content: [
+					{
+						tag: 'interactive',
+						attrs: { type: 'native_flow', v: '1' },
+						content: [
+							{
+								tag: 'native_flow',
+								attrs: { v: '2', name: firstButtonName! }
+							}
+						]
+					},
+					{
+						tag: 'quality_control',
+						attrs: { source_type: 'third_party' }
+					}
+				]
+			}
+		} else if (nativeFlow || message?.buttonsMessage) {
+			return {
+				tag: 'biz',
+				attrs: {
+					actual_actors: '2',
+					host_storage: '2',
+					privacy_mode_ts: unixTimestampSeconds().toString()
+				},
+				content: [
+					{
+						tag: 'interactive',
+						attrs: { type: 'native_flow', v: '1' },
+						content: [
+							{
+								tag: 'native_flow',
+								attrs: { v: '9', name: 'mixed' }
+							}
+						]
+					},
+					{
+						tag: 'quality_control',
+						attrs: { source_type: 'third_party' }
+					}
+				]
+			}
+		} else {
+			// listMessage
+			return {
+				tag: 'biz',
+				attrs: {
+					actual_actors: '2',
+					host_storage: '2',
+					privacy_mode_ts: unixTimestampSeconds().toString()
+				},
+				content: [
+					{
+						tag: 'list',
+						attrs: { v: '2', type: 'product_list' }
+					},
+					{
+						tag: 'quality_control',
+						attrs: { source_type: 'third_party' }
+					}
+				]
+			}
+		}
 	}
 
 	const getMessageType = (message: proto.IMessage) => {

--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -322,6 +322,8 @@ export type MessageRelayOptions = MinimalRelayOptions & {
 	useUserDevicesCache?: boolean
 	/** jid list of participants for status@broadcast */
 	statusJidList?: string[]
+	/** send as AI/bot message (adds <bot biz_bot="1"> node in private chats) */
+	ai?: boolean
 }
 
 export type MiscMessageGenerationOptions = MinimalRelayOptions & {
@@ -341,6 +343,8 @@ export type MiscMessageGenerationOptions = MinimalRelayOptions & {
 	font?: number
 	/** if it is broadcast */
 	broadcast?: boolean
+	/** send as AI/bot message (adds <bot biz_bot="1"> node in private chats) */
+	ai?: boolean
 }
 export type MessageGenerationOptionsFromContent = MiscMessageGenerationOptions & {
 	userJid: string

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -265,7 +265,7 @@ export async function getAudioWaveform(buffer: Buffer | string | Readable, logge
 			const blockStart = blockSize * i // the location of the first sample in the block
 			let sum = 0
 			for (let j = 0; j < blockSize; j++) {
-				sum = sum + Math.abs(rawData[blockStart + j]) // find the sum of all the samples in the block
+				sum = sum + Math.abs(rawData[blockStart + j] ?? 0) // find the sum of all the samples in the block
 			}
 
 			filteredData.push(sum / blockSize) // divide the sum by the block size to get the average


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves button delivery by auto-injecting the correct biz/interactive nodes and avoiding duplicates. Adds an `ai` flag to send bot-marked messages in 1:1 chats. Also fixes a waveform edge case with undefined samples.

- New Features
  - Button messages: detect type (buttons, list, native flow) and add appropriate `biz/interactive` nodes; respect existing `additionalNodes`; avoid double-inserting; skip newsletters.
  - Native flow support: handles special variants like `review_and_pay`, `payment_info`, `cta_catalog`, `send_location`, and falls back to a mixed flow when needed.
  - Bot messages: new `ai` option in `MessageRelayOptions` and `MiscMessageGenerationOptions`; adds a `<bot biz_bot="1">` node in private chats (not groups/status/newsletters) unless already present.

- Bug Fixes
  - Audio waveform: guard against undefined samples to prevent NaN during averaging.

<sup>Written for commit 2eeb2fe95c4e014bff6952b9c17bc6d7d213fa8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI/bot message option to identify messages as AI-generated in private chats

* **Bug Fixes**
  * Fixed audio waveform generation to properly handle edge cases when audio sample lengths don't divide evenly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->