### PR TITLE
Add support for AI labels

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -1088,6 +1088,17 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				})
 			}
 
+			const normalizedContent = normalizeMessageContent(message)
+			const isProtocolMsg = !!normalizedContent?.protocolMessage
+			const hasBizNode = additionalNodes?.some(node => node.tag === 'biz')
+
+			if (!isProtocolMsg && !isNewsletter && !isStatus && !isGroup) {
+				;(stanza.content as BinaryNode[]).push({ tag: 'bot', attrs: { biz_bot: '1' } })
+				if (!hasBizNode) {
+					;(stanza.content as BinaryNode[]).push({ tag: 'biz', attrs: {} })
+				}
+			}
+
 			if (additionalNodes && additionalNodes.length > 0) {
 				;(stanza.content as BinaryNode[]).push(...additionalNodes)
 			}
@@ -1098,7 +1109,6 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 
 			// Fire-and-forget: issue our token to the contact AFTER message send.
 			// WA Web skips protocol messages and PSA/bot contacts (TcTokenChatAction: isRegularUser)
-			const isProtocolMsg = !!normalizeMessageContent(message)?.protocolMessage
 			const isBotOrPSA = destinationJid === PSA_WID || isJidBot(destinationJid) || isJidMetaAI(destinationJid)
 			if (
 				is1on1Send &&


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds bot labeling to outgoing messages by inserting a `bot` node (`biz_bot: '1'`) and ensuring a `biz` node when the message isn’t a protocol, newsletter, status, or group message. Also computes `isProtocolMsg` once by normalizing content up front.

<sup>Written for commit 53e0afd6d9d70cc0a13284cac93ddeb448d0f1b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced message handling for bot-related and newsletter messages to ensure proper stanza assembly.
* Improved message protocol detection logic for more reliable message routing and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->