### PR TITLE
fix(retry): drop recent-message cache entry on revoke/edit

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -12,7 +12,6 @@ import type {
 	WAMessage,
 	WAMessageKey
 } from '../Types'
-import { WAMessageStubType } from '../Types'
 import {
 	aggregateMessageKeysNotFromMe,
 	assertMediaContent,
@@ -31,6 +30,7 @@ import {
 	getStatusCodeForMediaRetry,
 	getUrlFromDirectPath,
 	getWAUploadToServer,
+	invalidateRecentMessageOnUpdate,
 	MessageRetryManager,
 	normalizeMessageContent,
 	parseAndInjectE2ESessions,
@@ -118,26 +118,21 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	// Initialize message retry manager if enabled
 	const messageRetryManager = enableRecentMessageCache ? new MessageRetryManager(logger, maxMsgRetryCount) : null
 
-	// Invalidate the recent-messages cache when a sent message is revoked or edited.
-	//
-	// Without this, a late `<receipt type="retry">` (commonly produced by the
-	// recipient's other devices after a revoke/edit, or by transient delivery
-	// failures) causes `sendMessagesAgain` to re-send the original payload —
-	// "ghosting" deleted messages and breaking interactive flows where the
-	// consumer relies on the user editing the bot's own message.
+	// Invalidate the recent-messages cache when a sent message is revoked or
+	// edited. Without this, a late `<receipt type="retry">` (commonly produced
+	// by the recipient's other devices after a revoke/edit, or by transient
+	// delivery failures) causes `sendMessagesAgain` to re-send the original
+	// payload — "ghosting" deleted messages and breaking interactive flows
+	// where the consumer relies on the user editing the bot's own message.
 	//
 	// process-message.ts emits `messages.update` with `messageStubType=REVOKE`
-	// on revoke and with `update.message.editedMessage` on edit; both cases
-	// must drop the cache entry so the retry path falls through cleanly.
+	// on revoke and with `update.message.editedMessage` on edit; the predicate
+	// itself lives in `invalidateRecentMessageOnUpdate` so it's unit-testable
+	// without bootstrapping the full socket.
 	if (messageRetryManager) {
 		ev.on('messages.update', updates => {
-			for (const { key, update } of updates) {
-				if (!key?.id || !key.fromMe) continue
-				const isRevoke = update?.messageStubType === WAMessageStubType.REVOKE
-				const isEdit = !!(update as { message?: { editedMessage?: unknown } } | undefined)?.message?.editedMessage
-				if (isRevoke || isEdit) {
-					messageRetryManager.removeRecentMessage(key.id)
-				}
+			for (const u of updates) {
+				invalidateRecentMessageOnUpdate(messageRetryManager, u)
 			}
 		})
 	}

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -12,6 +12,7 @@ import type {
 	WAMessage,
 	WAMessageKey
 } from '../Types'
+import { WAMessageStubType } from '../Types'
 import {
 	aggregateMessageKeysNotFromMe,
 	assertMediaContent,
@@ -116,6 +117,30 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 
 	// Initialize message retry manager if enabled
 	const messageRetryManager = enableRecentMessageCache ? new MessageRetryManager(logger, maxMsgRetryCount) : null
+
+	// Invalidate the recent-messages cache when a sent message is revoked or edited.
+	//
+	// Without this, a late `<receipt type="retry">` (commonly produced by the
+	// recipient's other devices after a revoke/edit, or by transient delivery
+	// failures) causes `sendMessagesAgain` to re-send the original payload —
+	// "ghosting" deleted messages and breaking interactive flows where the
+	// consumer relies on the user editing the bot's own message.
+	//
+	// process-message.ts emits `messages.update` with `messageStubType=REVOKE`
+	// on revoke and with `update.message.editedMessage` on edit; both cases
+	// must drop the cache entry so the retry path falls through cleanly.
+	if (messageRetryManager) {
+		ev.on('messages.update', updates => {
+			for (const { key, update } of updates) {
+				if (!key?.id || !key.fromMe) continue
+				const isRevoke = update?.messageStubType === WAMessageStubType.REVOKE
+				const isEdit = !!(update as { message?: { editedMessage?: unknown } } | undefined)?.message?.editedMessage
+				if (isRevoke || isEdit) {
+					messageRetryManager.removeRecentMessage(key.id)
+				}
+			}
+		})
+	}
 
 	// Prevent race conditions in Signal session encryption by user
 	const encryptionMutex = makeKeyedMutex()

--- a/src/Utils/message-retry-manager.ts
+++ b/src/Utils/message-retry-manager.ts
@@ -329,7 +329,12 @@ export class MessageRetryManager {
 		return `${key.to}${MESSAGE_KEY_SEPARATOR}${key.id}`
 	}
 
-	private removeRecentMessage(messageId: string): void {
+	/**
+	 * Remove a message from the retry cache. Public so the socket can drop the
+	 * entry on revoke/edit and avoid re-sending stale payloads on a late retry
+	 * receipt.
+	 */
+	removeRecentMessage(messageId: string): void {
 		const keyStr = this.messageKeyIndex.get(messageId)
 		if (!keyStr) {
 			return

--- a/src/Utils/message-retry-manager.ts
+++ b/src/Utils/message-retry-manager.ts
@@ -1,5 +1,7 @@
 import { LRUCache } from 'lru-cache'
 import type { proto } from '../../WAProto/index.js'
+import type { WAMessageUpdate } from '../Types/Message'
+import { WAMessageStubType } from '../Types/Message'
 import type { ILogger } from './logger'
 
 /** Number of sent messages to cache in memory for handling retry receipts */
@@ -343,4 +345,34 @@ export class MessageRetryManager {
 		this.recentMessagesMap.delete(keyStr)
 		this.messageKeyIndex.delete(messageId)
 	}
+}
+
+/**
+ * Drop the recent-message cache entry for a single `messages.update` payload
+ * when it represents a revoke or edit of a message we sent.
+ *
+ * Extracted from the `messages.update` listener in `makeMessagesSocket` so the
+ * exact predicate that decides whether to invalidate is unit-testable in
+ * isolation — without bootstrapping the full socket — and so the listener and
+ * the tests can never drift apart.
+ *
+ * Returns `true` when the cache entry was dropped (or would have been if
+ * present), `false` otherwise. Useful for test assertions.
+ */
+export const invalidateRecentMessageOnUpdate = (
+	manager: MessageRetryManager,
+	{ key, update }: WAMessageUpdate
+): boolean => {
+	if (!key?.id || !key.fromMe) {
+		return false
+	}
+
+	const isRevoke = update?.messageStubType === WAMessageStubType.REVOKE
+	const isEdit = !!(update as { message?: { editedMessage?: unknown } } | undefined)?.message?.editedMessage
+	if (!isRevoke && !isEdit) {
+		return false
+	}
+
+	manager.removeRecentMessage(key.id)
+	return true
 }

--- a/src/__tests__/Utils/message-retry-manager.test.ts
+++ b/src/__tests__/Utils/message-retry-manager.test.ts
@@ -1,6 +1,8 @@
 import type { proto } from '../../../WAProto/index.js'
+import type { WAMessageUpdate } from '../../Types/Message'
+import { WAMessageStubType } from '../../Types/Message'
 import type { ILogger } from '../../Utils/logger'
-import { MessageRetryManager } from '../../Utils/message-retry-manager'
+import { invalidateRecentMessageOnUpdate, MessageRetryManager } from '../../Utils/message-retry-manager'
 
 const noopLogger: ILogger = {
 	level: 'silent',
@@ -13,6 +15,12 @@ const noopLogger: ILogger = {
 }
 
 const buildMessage = (text: string): proto.IMessage => ({ conversation: text })
+
+const buildUpdate = (overrides: Partial<WAMessageUpdate>): WAMessageUpdate => ({
+	key: { remoteJid: 'chat@s.whatsapp.net', fromMe: true, id: 'MSG-1' },
+	update: {},
+	...overrides
+})
 
 describe('MessageRetryManager.removeRecentMessage', () => {
 	it('removes a cached message by id so a subsequent retry lookup misses', () => {
@@ -44,5 +52,76 @@ describe('MessageRetryManager.removeRecentMessage', () => {
 
 		expect(manager.getRecentMessage(to, 'A')).toBeUndefined()
 		expect(manager.getRecentMessage(to, 'B')).toBeDefined()
+	})
+})
+
+describe('invalidateRecentMessageOnUpdate', () => {
+	const to = 'chat@s.whatsapp.net'
+	const id = 'MSG-1'
+
+	let manager: MessageRetryManager
+
+	beforeEach(() => {
+		manager = new MessageRetryManager(noopLogger, 5)
+		manager.addRecentMessage(to, id, buildMessage('original'))
+	})
+
+	it('drops the cache entry on a fromMe REVOKE update', () => {
+		const removed = invalidateRecentMessageOnUpdate(
+			manager,
+			buildUpdate({ update: { messageStubType: WAMessageStubType.REVOKE } })
+		)
+
+		expect(removed).toBe(true)
+		expect(manager.getRecentMessage(to, id)).toBeUndefined()
+	})
+
+	it('drops the cache entry on a fromMe edit update (update.message.editedMessage)', () => {
+		const removed = invalidateRecentMessageOnUpdate(
+			manager,
+			buildUpdate({
+				update: {
+					message: {
+						editedMessage: { message: { conversation: 'edited' } }
+					} as proto.IMessage
+				}
+			})
+		)
+
+		expect(removed).toBe(true)
+		expect(manager.getRecentMessage(to, id)).toBeUndefined()
+	})
+
+	it('keeps the cache entry when the update is not from us (fromMe=false)', () => {
+		const removed = invalidateRecentMessageOnUpdate(
+			manager,
+			buildUpdate({
+				key: { remoteJid: to, fromMe: false, id, participant: 'other@s.whatsapp.net' },
+				update: { messageStubType: WAMessageStubType.REVOKE }
+			})
+		)
+
+		expect(removed).toBe(false)
+		expect(manager.getRecentMessage(to, id)).toBeDefined()
+	})
+
+	it('keeps the cache entry on unrelated updates (status, receipt, etc.)', () => {
+		const removed = invalidateRecentMessageOnUpdate(manager, buildUpdate({ update: { status: 3 /* SERVER_ACK */ } }))
+
+		expect(removed).toBe(false)
+		expect(manager.getRecentMessage(to, id)).toBeDefined()
+	})
+
+	it('ignores updates with no key.id (defensive)', () => {
+		const removed = invalidateRecentMessageOnUpdate(
+			manager,
+			buildUpdate({
+				key: { remoteJid: to, fromMe: true, id: undefined as unknown as string },
+				update: { messageStubType: WAMessageStubType.REVOKE }
+			})
+		)
+
+		expect(removed).toBe(false)
+		expect(manager.getRecentMessage(to, id)).toBeDefined()
 	})
 })

--- a/src/__tests__/Utils/message-retry-manager.test.ts
+++ b/src/__tests__/Utils/message-retry-manager.test.ts
@@ -1,0 +1,48 @@
+import type { proto } from '../../../WAProto/index.js'
+import type { ILogger } from '../../Utils/logger'
+import { MessageRetryManager } from '../../Utils/message-retry-manager'
+
+const noopLogger: ILogger = {
+	level: 'silent',
+	child: () => noopLogger,
+	trace: () => {},
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {}
+}
+
+const buildMessage = (text: string): proto.IMessage => ({ conversation: text })
+
+describe('MessageRetryManager.removeRecentMessage', () => {
+	it('removes a cached message by id so a subsequent retry lookup misses', () => {
+		const manager = new MessageRetryManager(noopLogger, 5)
+		const to = 'chat@s.whatsapp.net'
+		const id = 'MSG-1'
+
+		manager.addRecentMessage(to, id, buildMessage('hello'))
+		expect(manager.getRecentMessage(to, id)).toBeDefined()
+
+		manager.removeRecentMessage(id)
+
+		expect(manager.getRecentMessage(to, id)).toBeUndefined()
+	})
+
+	it('is a no-op for unknown ids', () => {
+		const manager = new MessageRetryManager(noopLogger, 5)
+		expect(() => manager.removeRecentMessage('does-not-exist')).not.toThrow()
+	})
+
+	it('only removes the targeted entry and keeps unrelated cached messages intact', () => {
+		const manager = new MessageRetryManager(noopLogger, 5)
+		const to = 'chat@s.whatsapp.net'
+
+		manager.addRecentMessage(to, 'A', buildMessage('a'))
+		manager.addRecentMessage(to, 'B', buildMessage('b'))
+
+		manager.removeRecentMessage('A')
+
+		expect(manager.getRecentMessage(to, 'A')).toBeUndefined()
+		expect(manager.getRecentMessage(to, 'B')).toBeDefined()
+	})
+})


### PR DESCRIPTION
## Problem

A late `<receipt type="retry">` for a sent message — commonly produced by the recipient's other devices after a revoke/edit, or by transient delivery failures — causes `sendMessagesAgain` to re-send the original payload from the in-memory recent-messages cache.

This is observable in real-world bots as:

- A deleted bot reply re-appearing seconds after the user revokes it ("ghost message").
- An interactive-menu flow where the consumer relies on the user editing the bot's own message: the consumer reads the edit via `messages.update`, then Baileys re-sends the **pre-edit** body and visually overwrites the user's edit a moment later.

Both are 100% reproducible against `master` and `v7.0.0-rc10`.

## Root cause

`process-message.ts` already correctly emits `messages.update` for `protocolMessage` type `REVOKE` (with `messageStubType=REVOKE`) and `MESSAGE_EDIT` (with `update.message.editedMessage`). However, the `MessageRetryManager.recentMessagesMap` keeps the original message body cached for the full 5-minute TTL. When `handleReceipt` later sees a retry receipt for the same id, `sendMessagesAgain` finds the entry via `getRecentMessage` (`messages-recv.ts`) and re-sends it.

The consumer-owned `getMessage` fallback can also serve a stale message; that responsibility is out of scope for this PR — the in-memory cache is fully owned by Baileys and is the path that fires first.

## Fix

Subscribe once to `messages.update` inside `makeMessagesSocket` (where `messageRetryManager` is already in scope) and drop the cache entry when:

- `update.messageStubType === WAMessageStubType.REVOKE`, **or**
- `update.message.editedMessage` is present.

The handler is gated on `key.fromMe` so it only acts on messages we sent (only those are in our cache anyway, but the early-return keeps the loop trivially cheap on inbound chatter).

`MessageRetryManager.removeRecentMessage` was previously `private`. It already does exactly what the socket needs and is now exposed — no behavior change for existing callers (`markRetrySuccess` / `markRetryFailed` already invoked it).

## Why a listener instead of touching `process-message.ts`?

`processMessage` is invoked from `chats.ts`, which is layered **below** `messages-send.ts` in the socket chain (`makeWASocket → makeCommunitiesSocket → makeBusinessSocket → makeMessagesRecvSocket → makeMessagesSocket → … → makeChatsSocket → makeSocket`), so it cannot reach `messageRetryManager` via `sock`. Threading a `messageRetryManager` parameter through `ProcessMessageContext` would either require breaking that layering or adding a setter shim. Re-using the event the layer above already emits is strictly less invasive: zero API change, zero new parameters, no extra coupling.

## Tests

- New unit tests cover `MessageRetryManager.removeRecentMessage` (3 cases): valid id, unknown id (no-op), isolation between cached entries.
- Full suite green: **406/406 passing**.
- `yarn lint`: no new warnings introduced (only the pre-existing `no-explicit-any` set elsewhere in the file).

## Diff size

```
src/Socket/messages-send.ts        | 25 +++++++++++++++++++++++++
src/Utils/message-retry-manager.ts |  7 ++++++-
src/__tests__/Utils/message-retry-manager.test.ts | 50 ++++++++++++++++++++++
```

## Out of scope

- Invalidating consumer-side `getMessage` stores. Documenting that the consumer should also return `null` for revoked/edited ids would be a separate docs PR if maintainers want it.
- `placeholderResendCache` invalidation on revoke/edit — happy to add to this PR if maintainers prefer; left out to keep the diff minimal and focused on the observed bug.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Invalidate the recent-message retry cache on revoke/edit to stop re-sending stale payloads on late retry receipts. Fixes ghost messages and pre-edit overwrites in bot flows.

- **Bug Fixes**
  - Listen to `messages.update` in `makeMessagesSocket` and invalidate our sent messages on `REVOKE` or when `update.message.editedMessage` exists via `invalidateRecentMessageOnUpdate`.
  - Expose `MessageRetryManager.removeRecentMessage`; add `invalidateRecentMessageOnUpdate(manager, WAMessageUpdate)` and use it in the socket.
  - Add unit tests for the invalidation predicate and `removeRecentMessage`; full suite passing (411/411).

<sup>Written for commit 6de99f9c9a6d3d9d218c07d226c1f2f73f09127e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retry mechanism now detects message revokes/edits and invalidates recent-message cache so deleted or edited content is no longer resent.

* **Tests**
  * Added coverage verifying removal of cached retry entries and conditional invalidation behavior for revoke/edit updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->