### PR TITLE
chore: bump whatsapp-rust-bridge@0.5.4 to support non simd

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "p-queue": "^9.0.0",
     "pino": "^9.6",
     "protobufjs": "^7.5.6",
-    "whatsapp-rust-bridge": "0.5.3",
+    "whatsapp-rust-bridge": "0.5.4",
     "ws": "^8.13.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3147,7 +3147,7 @@ __metadata:
     typedoc: "npm:^0.27.9"
     typedoc-plugin-markdown: "npm:4.4.2"
     typescript: "npm:^5.8.2"
-    whatsapp-rust-bridge: "npm:0.5.3"
+    whatsapp-rust-bridge: "npm:0.5.4"
     ws: "npm:^8.13.0"
   peerDependencies:
     audio-decode: ^2.1.3
@@ -8608,10 +8608,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"whatsapp-rust-bridge@npm:0.5.3":
-  version: 0.5.3
-  resolution: "whatsapp-rust-bridge@npm:0.5.3"
-  checksum: 10c0/fe9b4c6d6807fd48d51c39b4d8eb41713138b974d01e581626afdb106cfa0ac816782d0a4e3e51164b8f5d70fb55f450a70d224f6a7ed8ddaf9764a0aa1ffbcc
+"whatsapp-rust-bridge@npm:0.5.4":
+  version: 0.5.4
+  resolution: "whatsapp-rust-bridge@npm:0.5.4"
+  checksum: 10c0/bcf13eb0b933a19e701fad2666926d25442e24b59599412e59f283e321402869e846adb64e4d10f01674f871ad339bef1ba55649beeedba898de034fee651600
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Related commit https://github.com/WhiskeySockets/whatsapp-rust-bridge/commit/a4cbaf77473da87c31db5200d63e450cf1e59ba4

This is to solve problem in old machine or VPS that not support SIMD: `Wasm SIMD unsupported`

The techinique is based on existing npm packages like onnx-runtime (they also ship two version of wasm and check at runtime)

Closes: https://github.com/WhiskeySockets/Baileys/issues/2380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version to latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->