### PR TITLE
feat: expose group online count in presence updates

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -874,7 +874,8 @@ export const makeChatsSocket = (config: SocketConfig) => {
 		if (tag === 'presence') {
 			presence = {
 				lastKnownPresence: attrs.type === 'unavailable' ? 'unavailable' : 'available',
-				lastSeen: attrs.last && attrs.last !== 'deny' ? +attrs.last : undefined
+				lastSeen: attrs.last && attrs.last !== 'deny' ? +attrs.last : undefined,
+				groupOnlineCount: attrs.count ? +attrs.count : undefined
 			}
 		} else if (Array.isArray(content)) {
 			const [firstChild] = content

--- a/src/Types/Chat.ts
+++ b/src/Types/Chat.ts
@@ -36,6 +36,7 @@ export type WAPatchName = (typeof ALL_WA_PATCH_NAMES)[number]
 export interface PresenceData {
 	lastKnownPresence: WAPresence
 	lastSeen?: number
+	groupOnlineCount?: number
 }
 
 export type BotListInfo = {


### PR DESCRIPTION
Surface the `count` attr from group presence stanzas as `groupOnlineCount` on PresenceData. Name mirrors WA Web's PresenceModel.

Example:
```ts
sock.ev.on('presence.update', ({ id, presences }) => {
  if (!isJidGroup(id)) return

  const { groupOnlineCount } = presences[id] ?? {}
  if (groupOnlineCount === undefined) return

  console.log(`${id}: ${groupOnlineCount} online`)
})

await sock.presenceSubscribe(groupJid)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Presence updates now include group member online count information for improved visibility into group activity status.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2545)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->