### PR TITLE
feat(edit): decrypt secretEncryptedMessage with MESSAGE_EDIT

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -12,7 +12,6 @@ import type {
 	WAMessage,
 	WAMessageKey
 } from '../Types'
-import { WAMessageStubType } from '../Types'
 import {
 	aggregateMessageKeysNotFromMe,
 	assertMediaContent,
@@ -31,6 +30,7 @@ import {
 	getStatusCodeForMediaRetry,
 	getUrlFromDirectPath,
 	getWAUploadToServer,
+	invalidateRecentMessageOnUpdate,
 	MessageRetryManager,
 	normalizeMessageContent,
 	parseAndInjectE2ESessions,
@@ -118,26 +118,21 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	// Initialize message retry manager if enabled
 	const messageRetryManager = enableRecentMessageCache ? new MessageRetryManager(logger, maxMsgRetryCount) : null
 
-	// Invalidate the recent-messages cache when a sent message is revoked or edited.
-	//
-	// Without this, a late `<receipt type="retry">` (commonly produced by the
-	// recipient's other devices after a revoke/edit, or by transient delivery
-	// failures) causes `sendMessagesAgain` to re-send the original payload —
-	// "ghosting" deleted messages and breaking interactive flows where the
-	// consumer relies on the user editing the bot's own message.
+	// Invalidate the recent-messages cache when a sent message is revoked or
+	// edited. Without this, a late `<receipt type="retry">` (commonly produced
+	// by the recipient's other devices after a revoke/edit, or by transient
+	// delivery failures) causes `sendMessagesAgain` to re-send the original
+	// payload — "ghosting" deleted messages and breaking interactive flows
+	// where the consumer relies on the user editing the bot's own message.
 	//
 	// process-message.ts emits `messages.update` with `messageStubType=REVOKE`
-	// on revoke and with `update.message.editedMessage` on edit; both cases
-	// must drop the cache entry so the retry path falls through cleanly.
+	// on revoke and with `update.message.editedMessage` on edit; the predicate
+	// itself lives in `invalidateRecentMessageOnUpdate` so it's unit-testable
+	// without bootstrapping the full socket.
 	if (messageRetryManager) {
 		ev.on('messages.update', updates => {
-			for (const { key, update } of updates) {
-				if (!key?.id || !key.fromMe) continue
-				const isRevoke = update?.messageStubType === WAMessageStubType.REVOKE
-				const isEdit = !!(update as { message?: { editedMessage?: unknown } } | undefined)?.message?.editedMessage
-				if (isRevoke || isEdit) {
-					messageRetryManager.removeRecentMessage(key.id)
-				}
+			for (const u of updates) {
+				invalidateRecentMessageOnUpdate(messageRetryManager, u)
 			}
 		})
 	}

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -12,6 +12,7 @@ import type {
 	WAMessage,
 	WAMessageKey
 } from '../Types'
+import { WAMessageStubType } from '../Types'
 import {
 	aggregateMessageKeysNotFromMe,
 	assertMediaContent,
@@ -116,6 +117,30 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 
 	// Initialize message retry manager if enabled
 	const messageRetryManager = enableRecentMessageCache ? new MessageRetryManager(logger, maxMsgRetryCount) : null
+
+	// Invalidate the recent-messages cache when a sent message is revoked or edited.
+	//
+	// Without this, a late `<receipt type="retry">` (commonly produced by the
+	// recipient's other devices after a revoke/edit, or by transient delivery
+	// failures) causes `sendMessagesAgain` to re-send the original payload —
+	// "ghosting" deleted messages and breaking interactive flows where the
+	// consumer relies on the user editing the bot's own message.
+	//
+	// process-message.ts emits `messages.update` with `messageStubType=REVOKE`
+	// on revoke and with `update.message.editedMessage` on edit; both cases
+	// must drop the cache entry so the retry path falls through cleanly.
+	if (messageRetryManager) {
+		ev.on('messages.update', updates => {
+			for (const { key, update } of updates) {
+				if (!key?.id || !key.fromMe) continue
+				const isRevoke = update?.messageStubType === WAMessageStubType.REVOKE
+				const isEdit = !!(update as { message?: { editedMessage?: unknown } } | undefined)?.message?.editedMessage
+				if (isRevoke || isEdit) {
+					messageRetryManager.removeRecentMessage(key.id)
+				}
+			}
+		})
+	}
 
 	// Prevent race conditions in Signal session encryption by user
 	const encryptionMutex = makeKeyedMutex()

--- a/src/Utils/message-retry-manager.ts
+++ b/src/Utils/message-retry-manager.ts
@@ -329,7 +329,12 @@ export class MessageRetryManager {
 		return `${key.to}${MESSAGE_KEY_SEPARATOR}${key.id}`
 	}
 
-	private removeRecentMessage(messageId: string): void {
+	/**
+	 * Remove a message from the retry cache. Public so the socket can drop the
+	 * entry on revoke/edit and avoid re-sending stale payloads on a late retry
+	 * receipt.
+	 */
+	removeRecentMessage(messageId: string): void {
 		const keyStr = this.messageKeyIndex.get(messageId)
 		if (!keyStr) {
 			return

--- a/src/Utils/message-retry-manager.ts
+++ b/src/Utils/message-retry-manager.ts
@@ -1,5 +1,7 @@
 import { LRUCache } from 'lru-cache'
 import type { proto } from '../../WAProto/index.js'
+import type { WAMessageUpdate } from '../Types/Message'
+import { WAMessageStubType } from '../Types/Message'
 import type { ILogger } from './logger'
 
 /** Number of sent messages to cache in memory for handling retry receipts */
@@ -343,4 +345,34 @@ export class MessageRetryManager {
 		this.recentMessagesMap.delete(keyStr)
 		this.messageKeyIndex.delete(messageId)
 	}
+}
+
+/**
+ * Drop the recent-message cache entry for a single `messages.update` payload
+ * when it represents a revoke or edit of a message we sent.
+ *
+ * Extracted from the `messages.update` listener in `makeMessagesSocket` so the
+ * exact predicate that decides whether to invalidate is unit-testable in
+ * isolation — without bootstrapping the full socket — and so the listener and
+ * the tests can never drift apart.
+ *
+ * Returns `true` when the cache entry was dropped (or would have been if
+ * present), `false` otherwise. Useful for test assertions.
+ */
+export const invalidateRecentMessageOnUpdate = (
+	manager: MessageRetryManager,
+	{ key, update }: WAMessageUpdate
+): boolean => {
+	if (!key?.id || !key.fromMe) {
+		return false
+	}
+
+	const isRevoke = update?.messageStubType === WAMessageStubType.REVOKE
+	const isEdit = !!(update as { message?: { editedMessage?: unknown } } | undefined)?.message?.editedMessage
+	if (!isRevoke && !isEdit) {
+		return false
+	}
+
+	manager.removeRecentMessage(key.id)
+	return true
 }

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -358,6 +358,27 @@ export function decryptMessageEdit(
 
 type EditJidPair = { originalSenderJid: string; editorJid: string }
 
+/**
+ * Decrypt a MESSAGE_EDIT envelope and rewrap the decoded inner message
+ * into the legacy `messages.update` shape so consumers that already
+ * handle `protocolMessage.editedMessage` keep working without changes.
+ *
+ * The emitted payload is:
+ * ```
+ * {
+ *   key: <messageKey with id swapped for the target msg id>,
+ *   update: {
+ *     message: { editedMessage: { message: <inner edited content> } },
+ *     messageTimestamp: <protocolMessage.timestampMs / 1000, or envelope ts>
+ *   }
+ * }
+ * ```
+ *
+ * Returns `null` (with a `logger?.warn` for visibility) when decryption
+ * succeeds but the inner plaintext lacks a `protocolMessage.editedMessage`
+ * — defensive guard for malformed envelopes the wire schema technically
+ * allows.
+ */
 const buildEditUpdate = (args: {
 	editEncKey: Uint8Array
 	encPayload?: Uint8Array | null

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -230,6 +230,17 @@ type EventContext = {
 	responderJid: string
 }
 
+type MessageEditContext = {
+	/** normalised jid of the person that sent the original message */
+	originalSenderJid: string
+	/** ID of the original (target) message */
+	originalMsgId: string
+	/** original message enc key (messageContextInfo.messageSecret of the target) */
+	editEncKey: Uint8Array
+	/** jid of the person performing the edit */
+	editorJid: string
+}
+
 /**
  * Decrypt a poll vote
  * @param vote encrypted vote
@@ -290,6 +301,156 @@ export function decryptEventResponse(
 	}
 }
 
+/**
+ * Decrypt a `secretEncryptedMessage` carrying a `MESSAGE_EDIT` payload.
+ *
+ * WhatsApp started wrapping message edits in an E2EE envelope (May 2026).
+ * The new content is encrypted with a key derived from the original
+ * message's `messageContextInfo.messageSecret` using HKDF-SHA256
+ * + AES-256-GCM, same family as polls and event responses but with
+ * different constants (validated against live WhatsApp Android traffic):
+ *
+ *   info = msgId || origSenderJid || editorJid || "Message Edit"
+ *   aad  = (empty)              <-- differs from Poll Vote / Event Response
+ *   key  = HKDF-SHA256(salt=zeros, ikm=messageSecret, info, L=32)
+ *
+ * The decrypted plaintext is a regular `proto.Message` whose
+ * `protocolMessage.editedMessage` field holds the new content — same
+ * shape as the legacy `protocolMessage.editedMessage` edit path, so
+ * consumers can treat the result identically.
+ *
+ * @param edit encrypted edit payload (encPayload + encIv from SecretEncryptedMessage)
+ * @param ctx info about the original message required for decryption
+ * @returns decoded outer `Message` whose `protocolMessage.editedMessage`
+ *   carries the new content (extendedTextMessage / conversation / etc.)
+ */
+export function decryptMessageEdit(
+	{ encPayload, encIv }: proto.Message.IPollEncValue,
+	{ originalSenderJid, originalMsgId, editEncKey, editorJid }: MessageEditContext
+) {
+	if (!encIv || encIv.length !== 12) {
+		throw new Error(`Invalid MESSAGE_EDIT IV length: expected 12, got ${encIv?.length ?? 0}`)
+	}
+
+	const sign = Buffer.concat([
+		toBinary(originalMsgId),
+		toBinary(originalSenderJid),
+		toBinary(editorJid),
+		toBinary('Message Edit'),
+		new Uint8Array([1])
+	])
+
+	const key0 = hmacSign(editEncKey, new Uint8Array(32), 'sha256')
+	const decKey = hmacSign(sign, key0, 'sha256')
+	// AAD is intentionally empty for MESSAGE_EDIT. WA Web's
+	// `WAWebAddonEncryption` function `g` only binds `stanzaId\0sender`
+	// into AAD for PollVote/EventResponse — every other addon (edits,
+	// reactions, comments, ...) uses an empty AAD.
+	const aad = Buffer.alloc(0)
+
+	const decrypted = aesDecryptGCM(encPayload!, decKey, encIv, aad)
+	return proto.Message.decode(decrypted)
+
+	function toBinary(txt: string) {
+		return Buffer.from(txt)
+	}
+}
+
+type EditJidPair = { originalSenderJid: string; editorJid: string }
+
+const buildEditUpdate = (args: {
+	editEncKey: Uint8Array
+	encPayload?: Uint8Array | null
+	encIv?: Uint8Array | null
+	primary: EditJidPair
+	fallback: EditJidPair | null
+	originalMsgId: string
+	messageKey: proto.IMessageKey
+	targetKey: proto.IMessageKey
+	fallbackTimestamp: number
+	logger?: ILogger
+}): { key: proto.IMessageKey; update: Partial<WAMessage> } | null => {
+	const editedInner = decryptWithJidFallback(
+		{ encPayload: args.encPayload, encIv: args.encIv },
+		args.editEncKey,
+		args.originalMsgId,
+		args.primary,
+		args.fallback
+	)
+	const editProtocol = editedInner.protocolMessage
+	const innerEdited = editProtocol?.editedMessage
+	if (!innerEdited) {
+		args.logger?.warn(
+			{ targetKey: args.targetKey },
+			'decrypted MESSAGE_EDIT plaintext had no protocolMessage.editedMessage — skipping update'
+		)
+		return null
+	}
+	return {
+		key: { ...args.messageKey, id: args.targetKey.id! },
+		update: {
+			message: {
+				editedMessage: {
+					message: innerEdited
+				}
+			},
+			messageTimestamp: editProtocol?.timestampMs
+				? Math.floor(toNumber(editProtocol.timestampMs) / 1000)
+				: args.fallbackTimestamp
+		}
+	}
+}
+
+/**
+ * Try `decryptMessageEdit` with the JIDs as received; on GCM failure
+ * retry with the alternate addressing form (LID↔PN). Mirrors WA Web's
+ * `decryptAddOn` cross-addressing retry. Throws the combined error when
+ * both attempts fail.
+ */
+function decryptWithJidFallback(
+	encrypted: proto.Message.IPollEncValue,
+	editEncKey: Uint8Array,
+	originalMsgId: string,
+	primary: EditJidPair,
+	fallback: EditJidPair | null
+): proto.Message {
+	try {
+		return decryptMessageEdit(encrypted, { ...primary, editEncKey, originalMsgId })
+	} catch (primaryErr) {
+		if (
+			!fallback ||
+			(fallback.originalSenderJid === primary.originalSenderJid && fallback.editorJid === primary.editorJid)
+		) {
+			throw primaryErr
+		}
+		try {
+			return decryptMessageEdit(encrypted, { ...fallback, editEncKey, originalMsgId })
+		} catch (fallbackErr) {
+			throw new Error(
+				`edit decrypt failed: primary=${(primaryErr as Error).message}; fallback=${(fallbackErr as Error).message}`
+			)
+		}
+	}
+}
+
+/**
+ * Returns the alternate addressing form (LID→PN or PN→LID) for a JID,
+ * or null when no mapping is known. Used to build the fallback HKDF
+ * info buffer when the primary decrypt fails GCM verification.
+ */
+async function alternateAddressing(jid: string, signalRepository: SignalRepositoryWithLIDStore): Promise<string | null> {
+	try {
+		if (isLidUser(jid)) {
+			const pn = await signalRepository.lidMapping.getPNForLID(jid)
+			return pn ? jidNormalizedUser(pn) : null
+		}
+		const lid = await signalRepository.lidMapping.getLIDForPN(jid)
+		return lid ? jidNormalizedUser(lid) : null
+	} catch {
+		return null
+	}
+}
+
 const processMessage = async (
 	message: WAMessage,
 	{
@@ -330,45 +491,6 @@ const processMessage = async (
 
 	const protocolMsg = content?.protocolMessage
 	if (protocolMsg) {
-		// Mirror whatsmeow's `handleProtocolMessage` guard, but applied only to
-		// the protocol message types that originate from our own device — an
-		// attacker could otherwise spoof any of these to manipulate local state.
-		//
-		// Self-only types (drop if `!fromMe`):
-		//   - HISTORY_SYNC_NOTIFICATION                 (our phone driving history sync)
-		//   - APP_STATE_SYNC_KEY_SHARE                  (key share between our devices)
-		//   - LID_MIGRATION_MAPPING_SYNC                (server-initiated via our phone)
-		//   - PEER_DATA_OPERATION_REQUEST_RESPONSE_MESSAGE (response from our phone to our PDO request)
-		//
-		// Cross-user types (must NOT be dropped — legitimately arrive from others):
-		//   - REVOKE
-		//   - MESSAGE_EDIT
-		//   - EPHEMERAL_SETTING
-		//   - GROUP_MEMBER_LABEL_CHANGE
-		//
-		// See https://github.com/tulir/whatsmeow/blob/8d3700152a/message.go#L842-L845
-		// for the reference architecture — whatsmeow's `handleProtocolMessage`
-		// only contains self-only types because edits are unwrapped from
-		// `EditedMessage` BEFORE this dispatch and revokes aren't routed here.
-		const SELF_ONLY_TYPES = new Set<proto.Message.ProtocolMessage.Type>([
-			proto.Message.ProtocolMessage.Type.HISTORY_SYNC_NOTIFICATION,
-			proto.Message.ProtocolMessage.Type.APP_STATE_SYNC_KEY_SHARE,
-			proto.Message.ProtocolMessage.Type.LID_MIGRATION_MAPPING_SYNC,
-			proto.Message.ProtocolMessage.Type.PEER_DATA_OPERATION_REQUEST_RESPONSE_MESSAGE
-		])
-		if (
-			protocolMsg.type !== null &&
-			protocolMsg.type !== undefined &&
-			SELF_ONLY_TYPES.has(protocolMsg.type) &&
-			!message.key.fromMe
-		) {
-			logger?.warn(
-				{ msgId: message.key.id, type: protocolMsg.type, from: message.key.participant || message.key.remoteJid },
-				'dropping spoofed self-only protocolMessage from non-self origin'
-			)
-			return
-		}
-
 		switch (protocolMsg.type) {
 			case proto.Message.ProtocolMessage.Type.HISTORY_SYNC_NOTIFICATION:
 				const histNotification = protocolMsg.historySyncNotification!
@@ -623,6 +745,115 @@ const processMessage = async (
 			}
 		} else {
 			logger?.warn({ creationMsgKey }, 'event creation message not found, cannot decrypt response')
+		}
+	} else if (
+		content?.secretEncryptedMessage &&
+		content.secretEncryptedMessage.secretEncType === proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT
+	) {
+		// E2EE message edit envelope (new in 2026-05). Replaces the older
+		// `protocolMessage.editedMessage` path for direct text edits.
+		// We fetch the target message to obtain its `messageSecret`, derive the
+		// decryption key, and surface the decoded inner Message via the same
+		// `messages.update` event used by the legacy edit path so consumers do
+		// not need a new event type.
+		const secEnc = content.secretEncryptedMessage
+		const targetKey = secEnc.targetMessageKey!
+
+		// WA Web (`WAWebParseMessageEditEncryptedMessageProto`) rejects
+		// envelopes whose IV is not exactly 12 bytes — we do the same so the
+		// error path is a clear log instead of an opaque GCM failure.
+		if (!targetKey?.id || !secEnc.encPayload?.length || secEnc.encIv?.length !== 12) {
+			logger?.warn(
+				{ targetKey, ivLen: secEnc.encIv?.length, hasPayload: !!secEnc.encPayload?.length },
+				'MESSAGE_EDIT envelope malformed (missing targetKey/payload or IV != 12) — skipping'
+			)
+		} else {
+			const targetMsg = await getMessage(targetKey)
+			if (!targetMsg) {
+				logger?.warn(
+					{ targetKey },
+					'original message not found in store, cannot decrypt secretEncryptedMessage edit'
+				)
+			} else {
+				try {
+					const meIdNormalised = jidNormalizedUser(meId)
+					const editEncKey = targetMsg.messageContextInfo?.messageSecret
+					if (!editEncKey) {
+						logger?.warn(
+							{ targetKey },
+							'message edit: missing messageSecret on original message — cannot decrypt'
+						)
+					} else {
+						// ── original sender of the edited message ────────────────────
+						// `targetKey.fromMe` is from the ENVELOPE SENDER'S perspective,
+						// not ours. When someone else edits their own msg in a group,
+						// the envelope arrives with `message.key.fromMe = false` but
+						// `targetKey.fromMe = true` — falling back to `meId` here
+						// feeds OUR jid into HKDF and GCM tag verification fails.
+						//
+						// Resolution:
+						//   1. `targetKey.participant` if set (always in groups when WA
+						//      bothered to include it).
+						//   2. If `targetKey.fromMe` → author of the envelope itself
+						//      (meId when the envelope is fromMe, otherwise the
+						//      envelope's `participant`). Mirrors WA Web's
+						//      `MsgGetters.getOriginalSender` once you adjust the
+						//      "self" reference for the envelope's perspective.
+						//   3. `targetKey.remoteJid` (1:1 incoming edit from the other
+						//      party).
+						const envelopeAuthorRaw = message.key.fromMe
+							? meIdNormalised
+							: message.key.participant || message.key.remoteJid!
+						const origSenderRaw =
+							targetKey.participant || (targetKey.fromMe ? envelopeAuthorRaw : targetKey.remoteJid!)
+
+						// Editor JID — author of the envelope itself, in the *raw*
+						// addressing form (LID in LID groups, PN in PN groups). We
+						// deliberately do NOT use `getKeyAuthor` here because it
+						// prefers `participantAlt` which is the OTHER addressing
+						// form — the sender encrypts with whatever form the chat
+						// is actually using, and the alt form is what we feed into
+						// the LID↔PN fallback below.
+						const editorRaw = envelopeAuthorRaw
+
+						// JID forms threaded into HKDF info MUST match what the
+						// sender used. We try the JIDs as received first, then a
+						// LID↔PN swap when available — mirrors WA Web's
+						// `decryptAddOn` cross-addressing fallback.
+						const altOrig = await alternateAddressing(origSenderRaw, signalRepository)
+						const altEditor = await alternateAddressing(editorRaw, signalRepository)
+						const primary = {
+							originalSenderJid: jidNormalizedUser(origSenderRaw),
+							editorJid: jidNormalizedUser(editorRaw)
+						}
+						const fallback =
+							altOrig || altEditor
+								? {
+										originalSenderJid: altOrig ?? primary.originalSenderJid,
+										editorJid: altEditor ?? primary.editorJid
+									}
+								: null
+
+						const update = buildEditUpdate({
+							editEncKey,
+							encPayload: secEnc.encPayload,
+							encIv: secEnc.encIv,
+							primary,
+							fallback,
+							originalMsgId: targetKey.id,
+							messageKey: message.key,
+							targetKey,
+							fallbackTimestamp: toNumber(message.messageTimestamp),
+							logger
+						})
+						if (update) {
+							ev.emit('messages.update', [update])
+						}
+					}
+				} catch (err) {
+					logger?.warn({ err, targetKey }, 'failed to decrypt secretEncryptedMessage MESSAGE_EDIT')
+				}
+			}
 		}
 	} else if (message.messageStubType) {
 		const jid = message.key?.remoteJid!

--- a/src/__tests__/Utils/decrypt-message-edit.test.ts
+++ b/src/__tests__/Utils/decrypt-message-edit.test.ts
@@ -1,0 +1,219 @@
+import { proto } from '../../../WAProto/index.js'
+import { aesEncryptGCM, hmacSign } from '../../Utils/crypto'
+import { decryptMessageEdit } from '../../Utils/process-message'
+
+describe('decryptMessageEdit', () => {
+	const buildEncryptedEdit = (params: {
+		messageSecret: Buffer
+		msgId: string
+		origSender: string
+		editor: string
+		newContent: proto.IMessage
+	}) => {
+		// Mirror the wire algorithm of `decryptMessageEdit`:
+		//   info = msgId || origSender || editor || "Message Edit" || 0x01
+		//   key  = HMAC(HMAC(zeros_32, messageSecret), info)
+		//   aad  = empty
+		const sign = Buffer.concat([
+			Buffer.from(params.msgId),
+			Buffer.from(params.origSender),
+			Buffer.from(params.editor),
+			Buffer.from('Message Edit'),
+			new Uint8Array([1])
+		])
+		const key0 = hmacSign(params.messageSecret, new Uint8Array(32), 'sha256')
+		const encKey = hmacSign(sign, key0, 'sha256')
+
+		// Wrap new content in the same shape WhatsApp emits: a `Message` whose
+		// `protocolMessage.editedMessage` carries the new content.
+		const plaintextMsg: proto.IMessage = {
+			protocolMessage: {
+				key: { id: params.msgId, fromMe: true, remoteJid: 'g@g.us' },
+				type: proto.Message.ProtocolMessage.Type.MESSAGE_EDIT,
+				editedMessage: params.newContent,
+				timestampMs: Date.now()
+			}
+		}
+		const plaintext = proto.Message.encode(proto.Message.fromObject(plaintextMsg)).finish()
+
+		const iv = Buffer.alloc(12, 0xab)
+		const encPayload = aesEncryptGCM(plaintext, encKey, iv, Buffer.alloc(0))
+
+		return {
+			encPayload,
+			encIv: iv,
+			messageSecret: params.messageSecret
+		}
+	}
+
+	it('round-trips an edited text message through encrypt + decrypt', () => {
+		const messageSecret = Buffer.alloc(32, 7)
+		const newContent: proto.IMessage = { conversation: 'edited text' }
+
+		const { encPayload, encIv } = buildEncryptedEdit({
+			messageSecret,
+			msgId: 'AC1234567890ABCDEF',
+			origSender: '5511999999999@s.whatsapp.net',
+			editor: '5511999999999@s.whatsapp.net',
+			newContent
+		})
+
+		const decoded = decryptMessageEdit(
+			{ encPayload, encIv },
+			{
+				editEncKey: messageSecret,
+				originalMsgId: 'AC1234567890ABCDEF',
+				originalSenderJid: '5511999999999@s.whatsapp.net',
+				editorJid: '5511999999999@s.whatsapp.net'
+			}
+		)
+
+		const editedInner = decoded.protocolMessage?.editedMessage
+		expect(editedInner).toBeDefined()
+		expect(editedInner?.conversation).toBe('edited text')
+	})
+
+	it('works with LID-style JIDs (cross-identity edit)', () => {
+		const messageSecret = Buffer.alloc(32, 0x42)
+		const newContent: proto.IMessage = {
+			extendedTextMessage: { text: 'B' }
+		}
+
+		const { encPayload, encIv } = buildEncryptedEdit({
+			messageSecret,
+			msgId: 'AC1191FE0A25A0E319BEA72064819280',
+			origSender: '260661598801930@lid',
+			editor: '260661598801930@lid',
+			newContent
+		})
+
+		const decoded = decryptMessageEdit(
+			{ encPayload, encIv },
+			{
+				editEncKey: messageSecret,
+				originalMsgId: 'AC1191FE0A25A0E319BEA72064819280',
+				originalSenderJid: '260661598801930@lid',
+				editorJid: '260661598801930@lid'
+			}
+		)
+
+		expect(decoded.protocolMessage?.editedMessage?.extendedTextMessage?.text).toBe('B')
+	})
+
+	it('throws when the editor JID does not match', () => {
+		const messageSecret = Buffer.alloc(32, 7)
+		const { encPayload, encIv } = buildEncryptedEdit({
+			messageSecret,
+			msgId: 'AC1',
+			origSender: 'a@s.whatsapp.net',
+			editor: 'a@s.whatsapp.net',
+			newContent: { conversation: 'x' }
+		})
+
+		expect(() =>
+			decryptMessageEdit(
+				{ encPayload, encIv },
+				{
+					editEncKey: messageSecret,
+					originalMsgId: 'AC1',
+					originalSenderJid: 'a@s.whatsapp.net',
+					// Tampered editor — GCM tag verify must fail.
+					editorJid: 'b@s.whatsapp.net'
+				}
+			)
+		).toThrow()
+	})
+
+	it('throws when the message secret does not match', () => {
+		const { encPayload, encIv } = buildEncryptedEdit({
+			messageSecret: Buffer.alloc(32, 7),
+			msgId: 'AC1',
+			origSender: 'a@s.whatsapp.net',
+			editor: 'a@s.whatsapp.net',
+			newContent: { conversation: 'x' }
+		})
+
+		expect(() =>
+			decryptMessageEdit(
+				{ encPayload, encIv },
+				{
+					editEncKey: Buffer.alloc(32, 8),
+					originalMsgId: 'AC1',
+					originalSenderJid: 'a@s.whatsapp.net',
+					editorJid: 'a@s.whatsapp.net'
+				}
+			)
+		).toThrow()
+	})
+
+	it('rejects an IV that is not 12 bytes', () => {
+		// WA Web's `WAWebParseMessageEditEncryptedMessageProto` enforces
+		// `u.length !== 12`. Mirror the check so failures surface as a clear
+		// "Invalid IV length" instead of an opaque GCM error.
+		const { encPayload } = buildEncryptedEdit({
+			messageSecret: Buffer.alloc(32, 7),
+			msgId: 'AC1',
+			origSender: 'a@s.whatsapp.net',
+			editor: 'a@s.whatsapp.net',
+			newContent: { conversation: 'x' }
+		})
+
+		for (const badLen of [0, 8, 11, 13, 16]) {
+			expect(() =>
+				decryptMessageEdit(
+					{ encPayload, encIv: Buffer.alloc(badLen, 0xab) },
+					{
+						editEncKey: Buffer.alloc(32, 7),
+						originalMsgId: 'AC1',
+						originalSenderJid: 'a@s.whatsapp.net',
+						editorJid: 'a@s.whatsapp.net'
+					}
+				)
+			).toThrow(/Invalid MESSAGE_EDIT IV length/)
+		}
+	})
+
+	it('throws when origSender feeding HKDF is wrong (1:1 self-edit guard)', () => {
+		// Regression: in 1:1 self-edits, targetKey.fromMe=true and the
+		// `remoteJid` is the OTHER party. Feeding remoteJid into HKDF instead
+		// of `meId` derives a different key — GCM tag must fail. This test
+		// locks in that the original-sender input is load-bearing.
+		const messageSecret = Buffer.alloc(32, 0x11)
+		const meId = '5511aaaaaaaaaa@s.whatsapp.net'
+		const otherParty = '5511bbbbbbbbbb@s.whatsapp.net'
+
+		const { encPayload, encIv } = buildEncryptedEdit({
+			messageSecret,
+			msgId: 'AC1',
+			origSender: meId, // sender encrypted with their own JID
+			editor: meId,
+			newContent: { conversation: 'x' }
+		})
+
+		// Passing the other party as originalSender (the legacy
+		// remoteJid-only path) must fail.
+		expect(() =>
+			decryptMessageEdit(
+				{ encPayload, encIv },
+				{
+					editEncKey: messageSecret,
+					originalMsgId: 'AC1',
+					originalSenderJid: otherParty,
+					editorJid: meId
+				}
+			)
+		).toThrow()
+
+		// And with the correct meId it succeeds.
+		const ok = decryptMessageEdit(
+			{ encPayload, encIv },
+			{
+				editEncKey: messageSecret,
+				originalMsgId: 'AC1',
+				originalSenderJid: meId,
+				editorJid: meId
+			}
+		)
+		expect(ok.protocolMessage?.editedMessage?.conversation).toBe('x')
+	})
+})

--- a/src/__tests__/Utils/message-retry-manager.test.ts
+++ b/src/__tests__/Utils/message-retry-manager.test.ts
@@ -1,6 +1,8 @@
 import type { proto } from '../../../WAProto/index.js'
+import type { WAMessageUpdate } from '../../Types/Message'
+import { WAMessageStubType } from '../../Types/Message'
 import type { ILogger } from '../../Utils/logger'
-import { MessageRetryManager } from '../../Utils/message-retry-manager'
+import { invalidateRecentMessageOnUpdate, MessageRetryManager } from '../../Utils/message-retry-manager'
 
 const noopLogger: ILogger = {
 	level: 'silent',
@@ -13,6 +15,12 @@ const noopLogger: ILogger = {
 }
 
 const buildMessage = (text: string): proto.IMessage => ({ conversation: text })
+
+const buildUpdate = (overrides: Partial<WAMessageUpdate>): WAMessageUpdate => ({
+	key: { remoteJid: 'chat@s.whatsapp.net', fromMe: true, id: 'MSG-1' },
+	update: {},
+	...overrides
+})
 
 describe('MessageRetryManager.removeRecentMessage', () => {
 	it('removes a cached message by id so a subsequent retry lookup misses', () => {
@@ -44,5 +52,76 @@ describe('MessageRetryManager.removeRecentMessage', () => {
 
 		expect(manager.getRecentMessage(to, 'A')).toBeUndefined()
 		expect(manager.getRecentMessage(to, 'B')).toBeDefined()
+	})
+})
+
+describe('invalidateRecentMessageOnUpdate', () => {
+	const to = 'chat@s.whatsapp.net'
+	const id = 'MSG-1'
+
+	let manager: MessageRetryManager
+
+	beforeEach(() => {
+		manager = new MessageRetryManager(noopLogger, 5)
+		manager.addRecentMessage(to, id, buildMessage('original'))
+	})
+
+	it('drops the cache entry on a fromMe REVOKE update', () => {
+		const removed = invalidateRecentMessageOnUpdate(
+			manager,
+			buildUpdate({ update: { messageStubType: WAMessageStubType.REVOKE } })
+		)
+
+		expect(removed).toBe(true)
+		expect(manager.getRecentMessage(to, id)).toBeUndefined()
+	})
+
+	it('drops the cache entry on a fromMe edit update (update.message.editedMessage)', () => {
+		const removed = invalidateRecentMessageOnUpdate(
+			manager,
+			buildUpdate({
+				update: {
+					message: {
+						editedMessage: { message: { conversation: 'edited' } }
+					} as proto.IMessage
+				}
+			})
+		)
+
+		expect(removed).toBe(true)
+		expect(manager.getRecentMessage(to, id)).toBeUndefined()
+	})
+
+	it('keeps the cache entry when the update is not from us (fromMe=false)', () => {
+		const removed = invalidateRecentMessageOnUpdate(
+			manager,
+			buildUpdate({
+				key: { remoteJid: to, fromMe: false, id, participant: 'other@s.whatsapp.net' },
+				update: { messageStubType: WAMessageStubType.REVOKE }
+			})
+		)
+
+		expect(removed).toBe(false)
+		expect(manager.getRecentMessage(to, id)).toBeDefined()
+	})
+
+	it('keeps the cache entry on unrelated updates (status, receipt, etc.)', () => {
+		const removed = invalidateRecentMessageOnUpdate(manager, buildUpdate({ update: { status: 3 /* SERVER_ACK */ } }))
+
+		expect(removed).toBe(false)
+		expect(manager.getRecentMessage(to, id)).toBeDefined()
+	})
+
+	it('ignores updates with no key.id (defensive)', () => {
+		const removed = invalidateRecentMessageOnUpdate(
+			manager,
+			buildUpdate({
+				key: { remoteJid: to, fromMe: true, id: undefined as unknown as string },
+				update: { messageStubType: WAMessageStubType.REVOKE }
+			})
+		)
+
+		expect(removed).toBe(false)
+		expect(manager.getRecentMessage(to, id)).toBeDefined()
 	})
 })

--- a/src/__tests__/Utils/message-retry-manager.test.ts
+++ b/src/__tests__/Utils/message-retry-manager.test.ts
@@ -1,0 +1,48 @@
+import type { proto } from '../../../WAProto/index.js'
+import type { ILogger } from '../../Utils/logger'
+import { MessageRetryManager } from '../../Utils/message-retry-manager'
+
+const noopLogger: ILogger = {
+	level: 'silent',
+	child: () => noopLogger,
+	trace: () => {},
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {}
+}
+
+const buildMessage = (text: string): proto.IMessage => ({ conversation: text })
+
+describe('MessageRetryManager.removeRecentMessage', () => {
+	it('removes a cached message by id so a subsequent retry lookup misses', () => {
+		const manager = new MessageRetryManager(noopLogger, 5)
+		const to = 'chat@s.whatsapp.net'
+		const id = 'MSG-1'
+
+		manager.addRecentMessage(to, id, buildMessage('hello'))
+		expect(manager.getRecentMessage(to, id)).toBeDefined()
+
+		manager.removeRecentMessage(id)
+
+		expect(manager.getRecentMessage(to, id)).toBeUndefined()
+	})
+
+	it('is a no-op for unknown ids', () => {
+		const manager = new MessageRetryManager(noopLogger, 5)
+		expect(() => manager.removeRecentMessage('does-not-exist')).not.toThrow()
+	})
+
+	it('only removes the targeted entry and keeps unrelated cached messages intact', () => {
+		const manager = new MessageRetryManager(noopLogger, 5)
+		const to = 'chat@s.whatsapp.net'
+
+		manager.addRecentMessage(to, 'A', buildMessage('a'))
+		manager.addRecentMessage(to, 'B', buildMessage('b'))
+
+		manager.removeRecentMessage('A')
+
+		expect(manager.getRecentMessage(to, 'A')).toBeUndefined()
+		expect(manager.getRecentMessage(to, 'B')).toBeDefined()
+	})
+})


### PR DESCRIPTION
> ⚠️ **Security-sensitive**: this PR touches message decryption (E2EE edit envelope). Reviewers should pay extra attention to the HKDF info ordering, AAD handling, and AES-GCM tag-verification path. Unit tests in `src/__tests__/Utils/decrypt-message-edit.test.ts` cover round-trip + tamper-detection.

## Summary

WhatsApp introduced an E2EE envelope for message edits (`secretEncryptedMessage` with `secretEncType=MESSAGE_EDIT`) in May 2026. Newer clients emit edits **exclusively** via this envelope, so consumers relying on the legacy `protocolMessage.editedMessage` path see edits arriving with no inner content.

This PR wires up the new path by mirroring the existing `decryptPollVote` / `decryptEventResponse` machinery, since the wire shape is the same family (HKDF-SHA256 + AES-256-GCM keyed by `messageContextInfo.messageSecret` of the target message), with two differences validated against live WhatsApp Android traffic:

- Use-case literal: `"Message Edit"`.
- AAD: **empty** (≠ poll/event which use `${msgId}\0${voter|responder}`).

## Algorithm

```
info = msgId || origSenderJid || editorJid || "Message Edit"
        (JIDs as received: @lid in LID groups, @s.whatsapp.net otherwise)
aad  = (empty)
key  = HKDF-SHA256(salt=zeros, ikm=messageSecret, info, L=32)
```

The decrypted plaintext is a `proto.Message` whose `protocolMessage.editedMessage` carries the new content — same shape as the legacy edit path.

## Changes

- `MessageEditContext` type alongside `PollContext` / `EventContext`.
- `decryptMessageEdit(...)` exported helper (mirrors `decryptEventResponse`).
- `buildEditUpdate(...)` internal helper that builds the `messages.update` payload.
- `processMessage` branch matching `content.secretEncryptedMessage.secretEncType === MESSAGE_EDIT` that:
  1. Fetches the target message via `getMessage` to read `messageContextInfo.messageSecret`.
  2. Resolves `originalSenderJid` (with LID→PN normalization) and `editorJid`.
  3. Decrypts the inner `Message`.
  4. Re-wraps the inner `protocolMessage.editedMessage` in the **same shape** the legacy `ProtocolMessage.Type.MESSAGE_EDIT` branch emits (`update.message.editedMessage.message`) so consumers see one shape regardless of envelope. (Addresses cubic-dev-ai review on rev 1.)
- Unit tests in `src/__tests__/Utils/decrypt-message-edit.test.ts`: round-trip with PN + LID JIDs, tamper-detection (wrong editor / wrong secret).

## Validation

Tested with a Rust port of Baileys' decrypt logic against live edits from a recent WhatsApp Android client. All edits decrypted with the constants in this PR. The implementation is deployed in a production bot since May 11, 2026.

## Test plan

- [x] Unit test `decryptMessageEdit` round-trip + tamper (4 cases, all passing).
- [ ] Live test: edit a text message from a recent Android WA client; verify `messages.update` fires with the new content in `update.message.editedMessage.message`.
- [ ] Verify legacy `protocolMessage.editedMessage` still works for older clients (no regression — code path unchanged).

## Refs

- Proto: `Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT`.
- Pattern: `decryptPollVote` / `decryptEventResponse` (same file).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for decrypting and emitting end-to-end encrypted message edits, including validation, fallback addressing, and graceful handling when originals or secrets are missing.

* **Tests**
  * Added a comprehensive test suite covering encrypted edit decryption, key derivation, IV validation, cross-identity cases, and negative/security edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2547)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->