### PR TITLE
fix(newsletter): handle null picture / partial fields in newsletterCreate response

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -108,6 +108,15 @@ export const MEDIA_PATH_MAP: { [T in MediaType]?: string } = {
 	'biz-cover-photo': '/pps/biz-cover-photo'
 }
 
+export const NEWSLETTER_MEDIA_PATH_MAP: { [T in MediaType]?: string } = {
+	image: '/newsletter/newsletter-image',
+	video: '/newsletter/newsletter-video',
+	document: '/newsletter/newsletter-document',
+	audio: '/newsletter/newsletter-audio',
+	sticker: '/newsletter/newsletter-image',
+	'thumbnail-link': '/newsletter/newsletter-image'
+}
+
 export const MEDIA_HKDF_KEY_MAPPING = {
 	audio: 'Audio',
 	document: 'Document',

--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -113,7 +113,10 @@ export const NEWSLETTER_MEDIA_PATH_MAP: { [T in MediaType]?: string } = {
 	video: '/newsletter/newsletter-video',
 	document: '/newsletter/newsletter-document',
 	audio: '/newsletter/newsletter-audio',
-	sticker: '/newsletter/newsletter-image',
+	gif: '/newsletter/newsletter-gif',
+	ptt: '/newsletter/newsletter-ptt',
+	ptv: '/newsletter/newsletter-ptv',
+	sticker: '/newsletter/newsletter-sticker-pack',
 	'thumbnail-link': '/newsletter/newsletter-image'
 }
 

--- a/src/Socket/Client/websocket.ts
+++ b/src/Socket/Client/websocket.ts
@@ -45,6 +45,13 @@ export class WebSocketClient extends AbstractSocketClient {
 			return
 		}
 
+		// If the underlying ws is already CLOSED, the 'close' event won't fire
+		// again — awaiting it would deadlock. Drop the reference and return.
+		if (this.isClosed) {
+			this.socket = null
+			return
+		}
+
 		const closePromise = new Promise<void>(resolve => {
 			this.socket?.once('close', resolve)
 		})

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -684,7 +684,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				const bytes = encodeNewsletterMessage(patched as proto.IMessage)
 				binaryNodeContent.push({
 					tag: 'plaintext',
-					attrs: {},
+					attrs: mediaType ? { mediatype: mediaType } : {},
 					content: bytes
 				})
 				const stanza: BinaryNode = {

--- a/src/Socket/newsletter.ts
+++ b/src/Socket/newsletter.ts
@@ -6,22 +6,29 @@ import { getBinaryNodeChild } from '../WABinary'
 import { makeGroupsSocket } from './groups'
 import { executeWMexQuery as genericExecuteWMexQuery } from './mex'
 
-const parseNewsletterCreateResponse = (response: NewsletterCreateResponse): NewsletterMetadata => {
+const parseNewsletterCreateResponse = (response: NewsletterCreateResponse | null | undefined): NewsletterMetadata => {
+	if (!response) {
+		throw new Error('newsletterCreate: server returned an empty response')
+	}
+
 	const { id, thread_metadata: thread, viewer_metadata: viewer } = response
 	return {
 		id: id,
 		owner: undefined,
-		name: thread.name.text,
-		creation_time: parseInt(thread.creation_time, 10),
-		description: thread.description.text,
-		invite: thread.invite,
-		subscribers: parseInt(thread.subscribers_count, 10),
-		verification: thread.verification,
-		picture: {
-			id: thread.picture.id,
-			directPath: thread.picture.direct_path
-		},
-		mute_state: viewer.mute
+		name: thread?.name?.text,
+		creation_time: thread?.creation_time ? parseInt(thread.creation_time, 10) : undefined,
+		description: thread?.description?.text,
+		invite: thread?.invite,
+		subscribers: thread?.subscribers_count ? parseInt(thread.subscribers_count, 10) : undefined,
+		verification: thread?.verification,
+		// A freshly-created newsletter has no picture set: the server returns
+		// `thread.picture: null`. Guard against the null so the parse doesn't
+		// throw `Cannot read properties of null (reading 'id')` on every
+		// successful create.
+		picture: thread?.picture
+			? { id: thread.picture.id, directPath: thread.picture.direct_path }
+			: undefined,
+		mute_state: viewer?.mute
 	}
 }
 

--- a/src/Socket/newsletter.ts
+++ b/src/Socket/newsletter.ts
@@ -1,3 +1,4 @@
+import { Boom } from '@hapi/boom'
 import type { NewsletterCreateResponse, SocketConfig, WAMediaUpload } from '../Types'
 import type { NewsletterMetadata, NewsletterUpdate } from '../Types'
 import { QueryIds, XWAPaths } from '../Types'
@@ -6,9 +7,12 @@ import { getBinaryNodeChild } from '../WABinary'
 import { makeGroupsSocket } from './groups'
 import { executeWMexQuery as genericExecuteWMexQuery } from './mex'
 
-const parseNewsletterCreateResponse = (response: NewsletterCreateResponse | null | undefined): NewsletterMetadata => {
+// executeWMexQuery throws Boom on missing data, so a populated response is
+// the only non-throwing path. Keep a defensive guard but use Boom for
+// consistency with the rest of the protocol layer.
+const parseNewsletterCreateResponse = (response: NewsletterCreateResponse): NewsletterMetadata => {
 	if (!response) {
-		throw new Error('newsletterCreate: server returned an empty response')
+		throw new Boom('newsletterCreate: server returned an empty response', { statusCode: 400 })
 	}
 
 	const { id, thread_metadata: thread, viewer_metadata: viewer } = response

--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -349,7 +349,15 @@ export type MessageGenerationOptionsFromContent = MiscMessageGenerationOptions &
 export type WAMediaUploadFunction = (
 	encFilePath: string,
 	opts: { fileEncSha256B64: string; mediaType: MediaType; timeoutMs?: number; newsletter?: boolean }
-) => Promise<{ mediaUrl: string; directPath: string; meta_hmac?: string; ts?: number; fbid?: number }>
+) => Promise<{
+	mediaUrl: string
+	directPath: string
+	meta_hmac?: string
+	ts?: number
+	fbid?: number
+	thumbnailDirectPath?: string
+	thumbnailSha256?: string
+}>
 
 export type MediaGenerationOptions = {
 	logger?: ILogger

--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -350,7 +350,7 @@ export type WAMediaUploadFunction = (
 	encFilePath: string,
 	opts: { fileEncSha256B64: string; mediaType: MediaType; timeoutMs?: number; newsletter?: boolean }
 ) => Promise<{
-	mediaUrl: string
+	mediaUrl: string | undefined
 	directPath: string
 	meta_hmac?: string
 	ts?: number

--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -348,7 +348,7 @@ export type MessageGenerationOptionsFromContent = MiscMessageGenerationOptions &
 
 export type WAMediaUploadFunction = (
 	encFilePath: string,
-	opts: { fileEncSha256B64: string; mediaType: MediaType; timeoutMs?: number }
+	opts: { fileEncSha256B64: string; mediaType: MediaType; timeoutMs?: number; newsletter?: boolean }
 ) => Promise<{ mediaUrl: string; directPath: string; meta_hmac?: string; ts?: number; fbid?: number }>
 
 export type MediaGenerationOptions = {

--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -10,6 +10,7 @@ export * from './Product'
 export * from './Call'
 export * from './Signal'
 export * from './Mex'
+export * from './LabelAssociation'
 
 import type { AuthenticationState } from './Auth'
 import type { SocketConfig } from './Socket'

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -10,7 +10,13 @@ import { join } from 'path'
 import { Readable, Transform } from 'stream'
 import { URL } from 'url'
 import { proto } from '../../WAProto/index.js'
-import { DEFAULT_ORIGIN, MEDIA_HKDF_KEY_MAPPING, MEDIA_PATH_MAP, type MediaType } from '../Defaults'
+import {
+	DEFAULT_ORIGIN,
+	MEDIA_HKDF_KEY_MAPPING,
+	MEDIA_PATH_MAP,
+	type MediaType,
+	NEWSLETTER_MEDIA_PATH_MAP
+} from '../Defaults'
 import type {
 	BaileysEventMap,
 	DownloadableMessage,
@@ -825,7 +831,7 @@ export const getWAUploadToServer = (
 	{ customUploadHosts, fetchAgent, logger, options }: SocketConfig,
 	refreshMediaConn: (force: boolean) => Promise<MediaConnInfo>
 ): WAMediaUploadFunction => {
-	return async (filePath, { mediaType, fileEncSha256B64, timeoutMs }) => {
+	return async (filePath, { mediaType, fileEncSha256B64, timeoutMs, newsletter }) => {
 		// send a query JSON to obtain the url & auth token to upload our media
 		let uploadInfo = await refreshMediaConn(false)
 
@@ -851,7 +857,11 @@ export const getWAUploadToServer = (
 			logger.debug(`uploading to "${hostname}"`)
 
 			const auth = encodeURIComponent(uploadInfo.auth)
-			const url = `https://${hostname}${MEDIA_PATH_MAP[mediaType]}/${fileEncSha256B64}?auth=${auth}&token=${fileEncSha256B64}`
+			const mediaPath = (newsletter ? NEWSLETTER_MEDIA_PATH_MAP[mediaType] : undefined) || MEDIA_PATH_MAP[mediaType]
+			let url = `https://${hostname}${mediaPath}/${fileEncSha256B64}?auth=${auth}&token=${fileEncSha256B64}`
+			if (newsletter) {
+				url += '&server_thumb_gen=1'
+			}
 
 			let result: MediaUploadResult | undefined
 			try {

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -872,6 +872,11 @@ export const getWAUploadToServer = (
 
 			const auth = encodeURIComponent(uploadInfo.auth)
 			const mediaPath = (newsletter ? NEWSLETTER_MEDIA_PATH_MAP[mediaType] : undefined) || MEDIA_PATH_MAP[mediaType]
+			if (!mediaPath) {
+				// Fail fast — building a URL with `undefined` in the path would
+				// produce a 404 retry loop on every host.
+				throw new Boom(`No media upload path for type: ${mediaType}`, { statusCode: 400 })
+			}
 			let url = `https://${hostname}${mediaPath}/${fileEncSha256B64}?auth=${auth}&token=${fileEncSha256B64}`
 			if (newsletter) {
 				url += '&server_thumb_gen=1'

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -892,7 +892,7 @@ export const getWAUploadToServer = (
 
 				if (result?.url || result?.direct_path) {
 					urls = {
-						mediaUrl: result.url!,
+						mediaUrl: result.url || result.direct_path!,
 						directPath: result.direct_path!,
 						meta_hmac: result.meta_hmac,
 						fbid: result.fbid,

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -687,6 +687,10 @@ type MediaUploadResult = {
 	meta_hmac?: string
 	ts?: number
 	fbid?: number
+	thumbnail_info?: {
+		thumbnail_sha256?: string
+		thumbnail_direct_path?: string
+	}
 }
 
 export type UploadParams = {
@@ -835,7 +839,17 @@ export const getWAUploadToServer = (
 		// send a query JSON to obtain the url & auth token to upload our media
 		let uploadInfo = await refreshMediaConn(false)
 
-		let urls: { mediaUrl: string; directPath: string; meta_hmac?: string; ts?: number; fbid?: number } | undefined
+		let urls:
+			| {
+					mediaUrl: string
+					directPath: string
+					meta_hmac?: string
+					ts?: number
+					fbid?: number
+					thumbnailDirectPath?: string
+					thumbnailSha256?: string
+			  }
+			| undefined
 		const hosts = [...customUploadHosts, ...uploadInfo.hosts]
 
 		fileEncSha256B64 = encodeBase64EncodedStringForUpload(fileEncSha256B64)
@@ -882,7 +896,9 @@ export const getWAUploadToServer = (
 						directPath: result.direct_path!,
 						meta_hmac: result.meta_hmac,
 						fbid: result.fbid,
-						ts: result.ts
+						ts: result.ts,
+						thumbnailDirectPath: result.thumbnail_info?.thumbnail_direct_path,
+						thumbnailSha256: result.thumbnail_info?.thumbnail_sha256
 					}
 					break
 				} else {

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -875,6 +875,9 @@ export const getWAUploadToServer = (
 			let url = `https://${hostname}${mediaPath}/${fileEncSha256B64}?auth=${auth}&token=${fileEncSha256B64}`
 			if (newsletter) {
 				url += '&server_thumb_gen=1'
+				if (mediaType === 'video' || mediaType === 'gif' || mediaType === 'ptv') {
+					url += '&server_transcode=1'
+				}
 			}
 
 			let result: MediaUploadResult | undefined

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -183,7 +183,7 @@ export const prepareWAMessageMedia = async (
 		)
 
 		const fileSha256B64 = fileSha256.toString('base64')
-		const { mediaUrl, directPath } = await options.upload(filePath, {
+		const { mediaUrl, directPath, thumbnailDirectPath, thumbnailSha256 } = await options.upload(filePath, {
 			fileEncSha256B64: fileSha256B64,
 			mediaType: mediaType,
 			timeoutMs: options.mediaUploadTimeoutMs,
@@ -198,7 +198,10 @@ export const prepareWAMessageMedia = async (
 				url: mediaUrl,
 				directPath,
 				fileSha256,
+				fileEncSha256: fileSha256,
 				fileLength,
+				thumbnailDirectPath,
+				thumbnailSha256: thumbnailSha256 ? Buffer.from(thumbnailSha256, 'base64') : undefined,
 				...uploadData,
 				media: undefined
 			})

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -183,7 +183,7 @@ export const prepareWAMessageMedia = async (
 		)
 
 		const fileSha256B64 = fileSha256.toString('base64')
-		const { mediaUrl, directPath, thumbnailDirectPath, thumbnailSha256 } = await options.upload(filePath, {
+		const { directPath, thumbnailDirectPath, thumbnailSha256 } = await options.upload(filePath, {
 			fileEncSha256B64: fileSha256B64,
 			mediaType: mediaType,
 			timeoutMs: options.mediaUploadTimeoutMs,
@@ -195,10 +195,9 @@ export const prepareWAMessageMedia = async (
 		const obj = WAProto.Message.fromObject({
 			// todo: add more support here
 			[`${mediaType}Message`]: (MessageTypeProto as any)[mediaType].fromObject({
-				url: mediaUrl,
+				// url intentionally omitted — newsletters use directPath only
 				directPath,
 				fileSha256,
-				fileEncSha256: fileSha256,
 				fileLength,
 				thumbnailDirectPath,
 				thumbnailSha256: thumbnailSha256 ? Buffer.from(thumbnailSha256, 'base64') : undefined,

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -186,7 +186,8 @@ export const prepareWAMessageMedia = async (
 		const { mediaUrl, directPath } = await options.upload(filePath, {
 			fileEncSha256B64: fileSha256B64,
 			mediaType: mediaType,
-			timeoutMs: options.mediaUploadTimeoutMs
+			timeoutMs: options.mediaUploadTimeoutMs,
+			newsletter: true
 		})
 
 		await fs.unlink(filePath)

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -183,14 +183,20 @@ export const prepareWAMessageMedia = async (
 		)
 
 		const fileSha256B64 = fileSha256.toString('base64')
-		const { directPath, thumbnailDirectPath, thumbnailSha256 } = await options.upload(filePath, {
-			fileEncSha256B64: fileSha256B64,
-			mediaType: mediaType,
-			timeoutMs: options.mediaUploadTimeoutMs,
-			newsletter: true
-		})
-
-		await fs.unlink(filePath)
+		let directPath: string | undefined
+		let thumbnailDirectPath: string | undefined
+		let thumbnailSha256: string | undefined
+		try {
+			;({ directPath, thumbnailDirectPath, thumbnailSha256 } = await options.upload(filePath, {
+				fileEncSha256B64: fileSha256B64,
+				mediaType: mediaType,
+				timeoutMs: options.mediaUploadTimeoutMs,
+				newsletter: true
+			}))
+		} finally {
+			// Cleanup the temp file whether upload succeeded or threw.
+			await fs.unlink(filePath).catch(() => {})
+		}
 
 		const obj = WAProto.Message.fromObject({
 			// todo: add more support here


### PR DESCRIPTION
## Problem

`newsletterCreate(name, description?)` consistently throws
`TypeError: Cannot read properties of null (reading 'id')` on every
successful create against the current WhatsApp server, against v7.0.0-rc10
of this library.

The channel **is** created server-side — it shows up immediately in the
WhatsApp client — but the parser crashes on the response, so the caller
gets the misleading error and never sees the new `NewsletterMetadata`.

## Root cause

A freshly-created newsletter has no picture set yet. WhatsApp returns
`thread_metadata.picture: null` in that case. The current parser unconditionally reads `thread.picture.id` and `thread.picture.direct_path`,
which dereferences `null`.

```js
picture: {
    id: thread.picture.id,            // <- null.id throws
    directPath: thread.picture.direct_path
},
```

## Fix

`src/Socket/newsletter.ts`:

- Guard against a null/undefined top-level response (mirrors the
  defensive style of `parseNewsletterMetadata` above).
- Use optional chaining on all `thread.*` and `viewer.*` reads so partial
  responses (which the server has been returning) don't crash.
- Make `picture` `undefined` when `thread.picture` is null.

The shape of `NewsletterMetadata.picture` is already optional in the
public types, so this doesn't change the contract.

## How to reproduce

```ts
import makeWASocket from '@whiskeysockets/baileys'
const sock = makeWASocket({ auth: ... })
// (pair / connect)
const meta = await sock.newsletterCreate('hello', 'world')
// Without this fix: TypeError: Cannot read properties of null (reading 'id')
// With this fix:    meta = { id: '12345@newsletter', name: 'hello', picture: undefined, ... }
```

## Verified end-to-end

Discovered while building a Baileys-backed WhatsApp gateway. Outbound
sends to the newly-created newsletter immediately succeed after this
fix, with the channel appearing in the WhatsApp client.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in `newsletterCreate` and makes newsletter media uploads work with channel endpoints. Also hardens uploads and prevents a WebSocket close deadlock.

- **Bug Fixes**
  - Handle null/partial `thread_metadata` and `viewer_metadata`; map `picture: null` to `undefined`; throw a Boom error on empty responses.
  - Use newsletter-specific upload paths and params (`server_thumb_gen=1`; `server_transcode=1` for `video`/`gif`/`ptv`).
  - Set `mediatype` on the plaintext node; rely on `directPath` only; omit `url`/`fileEncSha256` in the proto to match Web and avoid error 479; fall back `mediaUrl` to `directPath`.
  - Read `thumbnail_info` from uploads and set `thumbnailDirectPath` and `thumbnailSha256` in the message.
  - Fail fast with Boom when no upload path exists for a media type; always delete temp files via try/finally.
  - Avoid deadlock by skipping the `close` await if the underlying WebSocket is already closed.

<sup>Written for commit 7b4fee08df6621e8f4a2f262f2314867e11f0a93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Newsletter media enhancements: dedicated upload paths, server-side thumbnail generation/transcoding, and thumbnail fields returned with uploads.
  * API/type updates to support newsletter uploads and surface thumbnail fields.
  * Message payloads now include media-type attributes for newsletter messages.
  * Re-exported additional type definitions for broader type availability.

* **Bug Fixes**
  * Prevented crashes during newsletter creation by handling empty responses and nullable picture fields.
  * Fixed websocket close handling to avoid deadlocks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2549)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->