### PR TITLE
feat: implement decryption for secret encrypted message edits

### DIFF
--- a/WAProto/WAProto.proto
+++ b/WAProto/WAProto.proto
@@ -3426,6 +3426,9 @@ message Message {
             UNKNOWN = 0;
             EVENT_EDIT = 1;
             MESSAGE_EDIT = 2;
+            MESSAGE_SCHEDULE = 3;
+            POLL_EDIT = 4;
+            POLL_ADD_OPTION = 5;
         }
     }
 

--- a/WAProto/index.d.ts
+++ b/WAProto/index.d.ts
@@ -8837,7 +8837,10 @@ export namespace proto {
             enum SecretEncType {
                 UNKNOWN = 0,
                 EVENT_EDIT = 1,
-                MESSAGE_EDIT = 2
+                MESSAGE_EDIT = 2,
+                MESSAGE_SCHEDULE = 3,
+                POLL_EDIT = 4,
+                POLL_ADD_OPTION = 5
             }
         }
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1775,12 +1775,12 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				cleanMessage(msg, authState.creds.me!.id, authState.creds.me!.lid!)
 				const content = normalizeMessageContent(msg.message)
 				const secretEncryptedMessage = content?.secretEncryptedMessage
-				if (secretEncryptedMessage?.secretEncType === proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT) {
+				if (secretEncryptedMessage) {
 					const targetMessageKey = secretEncryptedMessage.targetMessageKey as WAMessageKey | undefined
 					const originalMessage = targetMessageKey?.id
 						? (messageRetryManager?.getRecentMessageById(targetMessageKey.id)?.message ??
 							(await getMessage(targetMessageKey).catch(err => {
-								logger.warn({ err, targetMessageKey }, 'failed to load original message for encrypted edit')
+								logger.warn({ err, targetMessageKey }, 'failed to load original message for secret encrypted message')
 								return undefined
 							})))
 						: undefined
@@ -1795,7 +1795,10 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 							logger
 						)
 					} else {
-						logger.warn({ targetMessageKey }, 'missing original message secret for encrypted edit')
+						logger.warn(
+							{ secretEncType: secretEncryptedMessage.secretEncType, targetMessageKey },
+							'missing original message secret for secret encrypted message'
+						)
 					}
 				}
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1785,10 +1785,19 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 							})))
 						: undefined
 
-					msg.messageSecret = normalizeMessageContent(originalMessage)?.messageContextInfo?.messageSecret
-
-					await decryptSecretEncryptedMessage(msg, authState.creds.me!.id, authState.creds.me!.lid!, logger)
-				}
+						const messageSecret = normalizeMessageContent(originalMessage)?.messageContextInfo?.messageSecret
+						if (messageSecret?.length) {
+							await decryptSecretEncryptedMessage(
+								msg,
+								messageSecret,
+								authState.creds.me!.id,
+								authState.creds.me!.lid!,
+								logger
+							)
+						} else {
+							logger.warn({ targetMessageKey }, 'missing original message secret for encrypted edit')
+						}
+					}
 
 				await upsertMessage(msg, node.attrs.offline ? 'append' : 'notify')
 			})

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1785,19 +1785,19 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 							})))
 						: undefined
 
-						const messageSecret = normalizeMessageContent(originalMessage)?.messageContextInfo?.messageSecret
-						if (messageSecret?.length) {
-							await decryptSecretEncryptedMessage(
-								msg,
-								messageSecret,
-								authState.creds.me!.id,
-								authState.creds.me!.lid!,
-								logger
-							)
-						} else {
-							logger.warn({ targetMessageKey }, 'missing original message secret for encrypted edit')
-						}
+					const messageSecret = normalizeMessageContent(originalMessage)?.messageContextInfo?.messageSecret
+					if (messageSecret?.length) {
+						await decryptSecretEncryptedMessage(
+							msg,
+							messageSecret,
+							authState.creds.me!.id,
+							authState.creds.me!.lid!,
+							logger
+						)
+					} else {
+						logger.warn({ targetMessageKey }, 'missing original message secret for encrypted edit')
 					}
+				}
 
 				await upsertMessage(msg, node.attrs.offline ? 'append' : 'notify')
 			})

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -32,6 +32,7 @@ import {
 	decodeMediaRetryNode,
 	decodeMessageNode,
 	decryptMessageNode,
+	decryptSecretEncryptedMessage,
 	delay,
 	derivePairingCodeKey,
 	encodeBigEndian,
@@ -47,6 +48,7 @@ import {
 	MISSING_KEYS_ERROR_TEXT,
 	NACK_REASONS,
 	NO_MESSAGE_FOUND_ERROR_TEXT,
+	normalizeMessageContent,
 	SERVER_ERROR_CODES,
 	toNumber,
 	unixTimestampSeconds,
@@ -1771,6 +1773,22 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				}
 
 				cleanMessage(msg, authState.creds.me!.id, authState.creds.me!.lid!)
+				const content = normalizeMessageContent(msg.message)
+				const secretEncryptedMessage = content?.secretEncryptedMessage
+				if (secretEncryptedMessage?.secretEncType === proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT) {
+					const targetMessageKey = secretEncryptedMessage.targetMessageKey as WAMessageKey | undefined
+					const originalMessage = targetMessageKey?.id
+						? (messageRetryManager?.getRecentMessageById(targetMessageKey.id)?.message ??
+							(await getMessage(targetMessageKey).catch(err => {
+								logger.warn({ err, targetMessageKey }, 'failed to load original message for encrypted edit')
+								return undefined
+							})))
+						: undefined
+
+					msg.messageSecret = normalizeMessageContent(originalMessage)?.messageContextInfo?.messageSecret
+
+					await decryptSecretEncryptedMessage(msg, authState.creds.me!.id, authState.creds.me!.lid!, logger)
+				}
 
 				await upsertMessage(msg, node.attrs.offline ? 'append' : 'notify')
 			})

--- a/src/Utils/message-retry-manager.ts
+++ b/src/Utils/message-retry-manager.ts
@@ -135,6 +135,14 @@ export class MessageRetryManager {
 	}
 
 	/**
+	 * Get a recent message using only its message ID.
+	 */
+	getRecentMessageById(id: string): RecentMessage | undefined {
+		const keyStr = this.messageKeyIndex.get(id)
+		return keyStr ? this.recentMessagesMap.get(keyStr) : undefined
+	}
+
+	/**
 	 * Check if a session should be recreated based on retry count, history, and error code.
 	 * MAC errors (codes 4 and 7) trigger immediate session recreation regardless of timeout.
 	 */

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -180,6 +180,7 @@ export const cleanMessage = (message: WAMessage, meId: string, meLid: string) =>
 
 export const decryptSecretEncryptedMessage = async (
 	message: WAMessage,
+	messageSecret: Uint8Array,
 	meId: string,
 	meLid: string,
 	logger?: ILogger
@@ -212,17 +213,11 @@ export const decryptSecretEncryptedMessage = async (
 		return
 	}
 
-	const messageSecret = message.messageSecret
 	const ownSender = message.key.addressingMode === 'lid' && meLid ? meLid : meId
 	const originalSender = targetMessageKey.fromMe
 		? ownSender
 		: targetMessageKey.participant || targetMessageKey.remoteJid
 	const modificationSender = message.key.fromMe ? ownSender : message.key.participant || message.key.remoteJid
-
-	if (!messageSecret?.length) {
-		logger?.warn({ targetMessageKey }, 'missing original message secret for encrypted edit')
-		return
-	}
 
 	if (!originalSender || !modificationSender) {
 		logger?.warn({ targetMessageKey, messageKey: message.key }, 'missing sender for secret encrypted message')

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -57,7 +57,30 @@ const REAL_MSG_STUB_TYPES = new Set([
 ])
 
 const REAL_MSG_REQ_ME_STUB_TYPES = new Set([WAMessageStubType.GROUP_PARTICIPANT_ADD])
+const ENC_SECRET_EVENT_EDIT = 'Event Edit'
 const ENC_SECRET_MESSAGE_EDIT = 'Message Edit'
+const ENC_SECRET_MESSAGE_SCHEDULE = 'Message Schedule'
+const ENC_SECRET_POLL_EDIT = 'Poll Edit'
+const ENC_SECRET_POLL_ADD_OPTION = 'Poll Add Option'
+
+type SecretEncType = proto.Message.SecretEncryptedMessage.SecretEncType
+
+const getSecretEncTypeScopes = (secretEncType: SecretEncType | null | undefined) => {
+	switch (secretEncType) {
+		case proto.Message.SecretEncryptedMessage.SecretEncType.EVENT_EDIT:
+			return [ENC_SECRET_EVENT_EDIT]
+		case proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT:
+			return [ENC_SECRET_MESSAGE_EDIT]
+		case proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_SCHEDULE:
+			return [ENC_SECRET_MESSAGE_SCHEDULE]
+		case proto.Message.SecretEncryptedMessage.SecretEncType.POLL_EDIT:
+			return [ENC_SECRET_POLL_EDIT]
+		case proto.Message.SecretEncryptedMessage.SecretEncType.POLL_ADD_OPTION:
+			return [ENC_SECRET_POLL_ADD_OPTION, ENC_SECRET_POLL_EDIT]
+		default:
+			return undefined
+	}
+}
 
 async function storeTcTokensFromHistorySync(
 	chats: Chat[],
@@ -192,12 +215,10 @@ export const decryptSecretEncryptedMessage = async (
 	}
 
 	const targetMessageKey = secretEncryptedMessage.targetMessageKey as WAMessageKey | undefined
-	let editedMessage: proto.IMessage | undefined
+	let decryptedMessage: proto.IMessage | undefined
+	const secretEncTypeScopes = getSecretEncTypeScopes(secretEncryptedMessage.secretEncType)
 
-	if (
-		secretEncryptedMessage.secretEncType !== proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT ||
-		!targetMessageKey?.id
-	) {
+	if (!secretEncTypeScopes) {
 		logger?.warn(
 			{
 				secretEncType: secretEncryptedMessage.secretEncType,
@@ -208,41 +229,60 @@ export const decryptSecretEncryptedMessage = async (
 		return
 	}
 
-	if (!secretEncryptedMessage.encPayload?.length || !secretEncryptedMessage.encIv?.length) {
-		logger?.warn({ targetMessageKey }, 'missing encrypted edit payload')
+	if (!targetMessageKey?.id) {
+		logger?.warn(
+			{ targetMessageKey: secretEncryptedMessage.targetMessageKey },
+			'missing secret encrypted message target'
+		)
 		return
 	}
 
-	const ownSender = message.key.addressingMode === 'lid' && meLid ? meLid : meId
+	if (!secretEncryptedMessage.encPayload?.length || !secretEncryptedMessage.encIv?.length) {
+		logger?.warn({ targetMessageKey }, 'missing secret encrypted message payload')
+		return
+	}
+
+	const ownSender = jidNormalizedUser(message.key.addressingMode === 'lid' && meLid ? meLid : meId)
 	const originalSender = targetMessageKey.fromMe
 		? ownSender
-		: targetMessageKey.participant || targetMessageKey.remoteJid
-	const modificationSender = message.key.fromMe ? ownSender : message.key.participant || message.key.remoteJid
+		: jidNormalizedUser(targetMessageKey.participant || targetMessageKey.remoteJid || undefined)
+	const modificationSender = message.key.fromMe
+		? ownSender
+		: jidNormalizedUser(message.key.participant || message.key.remoteJid || undefined)
 
 	if (!originalSender || !modificationSender) {
 		logger?.warn({ targetMessageKey, messageKey: message.key }, 'missing sender for secret encrypted message')
 		return
 	}
 
-	try {
-		const decryptKey = generateMsgSecretKey(
-			ENC_SECRET_MESSAGE_EDIT,
-			targetMessageKey.id,
-			originalSender,
-			modificationSender,
-			messageSecret
-		)
-		const decrypted = aesDecryptGCM(
-			secretEncryptedMessage.encPayload,
-			decryptKey,
-			secretEncryptedMessage.encIv,
-			Buffer.alloc(0)
-		)
-		editedMessage = proto.Message.decode(decrypted)
-	} catch (err) {
+	let decryptErr: unknown
+	for (const secretEncTypeScope of secretEncTypeScopes) {
+		try {
+			const decryptKey = generateMsgSecretKey(
+				secretEncTypeScope,
+				targetMessageKey.id,
+				originalSender,
+				modificationSender,
+				messageSecret
+			)
+			const decrypted = aesDecryptGCM(
+				secretEncryptedMessage.encPayload,
+				decryptKey,
+				secretEncryptedMessage.encIv,
+				Buffer.alloc(0)
+			)
+			decryptedMessage = proto.Message.decode(decrypted)
+			break
+		} catch (err) {
+			decryptErr = err
+		}
+	}
+
+	if (!decryptedMessage) {
 		logger?.warn(
 			{
-				err,
+				err: decryptErr,
+				secretEncType: secretEncryptedMessage.secretEncType,
 				targetMessageKey,
 				messageKey: message.key,
 				originalSender,
@@ -250,21 +290,24 @@ export const decryptSecretEncryptedMessage = async (
 			},
 			'failed to decrypt secret encrypted message'
 		)
+		return
 	}
 
-	if (editedMessage) {
-		if (message.message?.messageContextInfo && !editedMessage.messageContextInfo) {
-			editedMessage.messageContextInfo = message.message.messageContextInfo
-		}
+	if (message.message?.messageContextInfo && !decryptedMessage.messageContextInfo) {
+		decryptedMessage.messageContextInfo = message.message.messageContextInfo
+	}
 
+	if (secretEncryptedMessage.secretEncType === proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT) {
 		message.message = {
 			protocolMessage: {
 				key: targetMessageKey,
 				type: proto.Message.ProtocolMessage.Type.MESSAGE_EDIT,
-				editedMessage,
+				editedMessage: decryptedMessage,
 				timestampMs: toNumber(message.messageTimestamp) * 1000
 			}
 		}
+	} else {
+		message.message = decryptedMessage
 	}
 }
 

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -34,6 +34,7 @@ import { aesDecryptGCM, hmacSign } from './crypto'
 import { getKeyAuthor, toNumber } from './generics'
 import { downloadAndProcessHistorySyncNotification } from './history'
 import type { ILogger } from './logger'
+import { generateMsgSecretKey } from './reporting-utils'
 import { buildMergedTcTokenIndexWrite, resolveTcTokenJid } from './tc-token-utils'
 
 type ProcessMessageContext = {
@@ -56,6 +57,7 @@ const REAL_MSG_STUB_TYPES = new Set([
 ])
 
 const REAL_MSG_REQ_ME_STUB_TYPES = new Set([WAMessageStubType.GROUP_PARTICIPANT_ADD])
+const ENC_SECRET_MESSAGE_EDIT = 'Message Edit'
 
 async function storeTcTokensFromHistorySync(
 	chats: Chat[],
@@ -146,6 +148,15 @@ export const cleanMessage = (message: WAMessage, meId: string, meLid: string) =>
 		normaliseKey(content.pollUpdateMessage.pollCreationMessageKey!)
 	}
 
+	if (content?.secretEncryptedMessage?.targetMessageKey) {
+		const targetMessageKey = content.secretEncryptedMessage.targetMessageKey as WAMessageKey
+		normaliseKey(targetMessageKey)
+		if (!message.key.fromMe) {
+			targetMessageKey.remoteJidAlt = message.key.remoteJidAlt
+			targetMessageKey.participantAlt = targetMessageKey.participantAlt || message.key.participantAlt
+		}
+	}
+
 	function normaliseKey(msgKey: WAMessageKey) {
 		// if the reaction is from another user
 		// we've to correctly map the key to this user's perspective
@@ -167,6 +178,101 @@ export const cleanMessage = (message: WAMessage, meId: string, meLid: string) =>
 	}
 }
 
+export const decryptSecretEncryptedMessage = async (
+	message: WAMessage,
+	meId: string,
+	meLid: string,
+	logger?: ILogger
+) => {
+	const content = normalizeMessageContent(message.message)
+	const secretEncryptedMessage = content?.secretEncryptedMessage
+	if (!secretEncryptedMessage) {
+		return
+	}
+
+	const targetMessageKey = secretEncryptedMessage.targetMessageKey as WAMessageKey | undefined
+	let editedMessage: proto.IMessage | undefined
+
+	if (
+		secretEncryptedMessage.secretEncType !== proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT ||
+		!targetMessageKey?.id
+	) {
+		logger?.warn(
+			{
+				secretEncType: secretEncryptedMessage.secretEncType,
+				targetMessageKey: secretEncryptedMessage.targetMessageKey
+			},
+			'unsupported secret encrypted message type'
+		)
+		return
+	}
+
+	if (!secretEncryptedMessage.encPayload?.length || !secretEncryptedMessage.encIv?.length) {
+		logger?.warn({ targetMessageKey }, 'missing encrypted edit payload')
+		return
+	}
+
+	const messageSecret = message.messageSecret
+	const ownSender = message.key.addressingMode === 'lid' && meLid ? meLid : meId
+	const originalSender = targetMessageKey.fromMe
+		? ownSender
+		: targetMessageKey.participant || targetMessageKey.remoteJid
+	const modificationSender = message.key.fromMe ? ownSender : message.key.participant || message.key.remoteJid
+
+	if (!messageSecret?.length) {
+		logger?.warn({ targetMessageKey }, 'missing original message secret for encrypted edit')
+		return
+	}
+
+	if (!originalSender || !modificationSender) {
+		logger?.warn({ targetMessageKey, messageKey: message.key }, 'missing sender for secret encrypted message')
+		return
+	}
+
+	try {
+		const decryptKey = generateMsgSecretKey(
+			ENC_SECRET_MESSAGE_EDIT,
+			targetMessageKey.id,
+			originalSender,
+			modificationSender,
+			messageSecret
+		)
+		const decrypted = aesDecryptGCM(
+			secretEncryptedMessage.encPayload,
+			decryptKey,
+			secretEncryptedMessage.encIv,
+			Buffer.alloc(0)
+		)
+		editedMessage = proto.Message.decode(decrypted)
+	} catch (err) {
+		logger?.warn(
+			{
+				err,
+				targetMessageKey,
+				messageKey: message.key,
+				originalSender,
+				modificationSender
+			},
+			'failed to decrypt secret encrypted message'
+		)
+	}
+
+	if (editedMessage) {
+		if (message.message?.messageContextInfo && !editedMessage.messageContextInfo) {
+			editedMessage.messageContextInfo = message.message.messageContextInfo
+		}
+
+		message.message = {
+			protocolMessage: {
+				key: targetMessageKey,
+				type: proto.Message.ProtocolMessage.Type.MESSAGE_EDIT,
+				editedMessage,
+				timestampMs: toNumber(message.messageTimestamp) * 1000
+			}
+		}
+	}
+}
+
 // TODO: target:audit AUDIT THIS FUNCTION AGAIN
 export const isRealMessage = (message: WAMessage) => {
 	const normalizedContent = normalizeMessageContent(message.message)
@@ -177,6 +283,7 @@ export const isRealMessage = (message: WAMessage) => {
 			REAL_MSG_REQ_ME_STUB_TYPES.has(message.messageStubType!)) &&
 		hasSomeContent &&
 		!normalizedContent?.protocolMessage &&
+		!normalizedContent?.secretEncryptedMessage &&
 		!normalizedContent?.reactionMessage &&
 		!normalizedContent?.pollUpdateMessage
 	)

--- a/src/Utils/reporting-utils.ts
+++ b/src/Utils/reporting-utils.ts
@@ -102,7 +102,7 @@ export const shouldIncludeReportingToken = (message: proto.IMessage): boolean =>
 	!message.encEventResponseMessage &&
 	!message.pollUpdateMessage
 
-const generateMsgSecretKey = (
+export const generateMsgSecretKey = (
 	modificationType: string,
 	origMsgId: string,
 	origMsgSender: string,


### PR DESCRIPTION
This adds support for decrypting `secretEncryptedMessage` edit payloads (`MESSAGE_EDIT`).

WhatsApp now sends message edits as encrypted edit envelopes instead of a plain `protocolMessage.editedMessage`. These envelopes are not self-contained: decrypting them requires the original message’s `messageContextInfo.messageSecret`.

The receive path first tries Baileys’ recent message cache to find the original message by id. If the original message is no longer in that cache, Baileys falls back to the socket `getMessage` config.

Because of that, consistent edit decryption for older messages requires `getMessage` to be properly configured against the application’s persistent message store. Without it, Baileys can only decrypt edits for messages still present in the recent in-memory cache.

This also means the example/docs should recommend configuring `getMessage` for production use, especially now that WhatsApp relies on original-message secrets for encrypted edit payloads.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds decryption for WhatsApp `secretEncryptedMessage` envelopes so edited, scheduled, and poll-update messages render correctly. Looks up the original message via recent cache or `getMessage`; configure `getMessage` against your store for older updates.

- **New Features**
  - Added `decryptSecretEncryptedMessage` to decrypt envelopes using the original message’s `messageContextInfo.messageSecret`; supports `MESSAGE_EDIT`, `MESSAGE_SCHEDULE`, `POLL_EDIT`, `POLL_ADD_OPTION`; resolves originals via `getRecentMessageById` with fallback to `getMessage`; normalizes `targetMessageKey` (incl. alt fields); excludes `secretEncryptedMessage` in `isRealMessage`; exports `generateMsgSecretKey`; updated WAProto enums/types.

- **Bug Fixes**
  - Passed the correct `messageSecret` to `decryptSecretEncryptedMessage`.

<sup>Written for commit fe21ca34a4a627ff553d4bbc10c26beeada6e888. Summary will update on new commits. <a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2554?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Receive and decrypt secret-encrypted message edits and other secret-encrypted actions so decoded content displays correctly.
  * Better resolution of referenced messages by checking recent-message cache before fallback retrieval.
  * Support for additional secret-encryption action types.

* **Bug Fixes**
  * Secret-encrypted payloads are excluded from normal message flow to avoid stub/display issues; missing or undecryptable secrets now log warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->