### PR TITLE
fix: guard fetch dispatcher option

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -777,9 +777,11 @@ const uploadWithFetch = async ({
 	// Convert Node.js Readable to Web ReadableStream
 	const nodeStream = createReadStream(filePath)
 	const webStream = Readable.toWeb(nodeStream) as ReadableStream
+	// Native fetch only accepts Undici-style dispatchers, not generic https Agents.
+	const dispatcher = typeof (agent as { dispatch?: unknown } | undefined)?.dispatch === 'function' ? agent : undefined
 
 	const response = await fetch(url, {
-		dispatcher: agent,
+		...(dispatcher ? { dispatcher } : {}),
 		method: 'POST',
 		body: webStream,
 		headers,

--- a/src/__tests__/Utils/messages-media.test.ts
+++ b/src/__tests__/Utils/messages-media.test.ts
@@ -1,9 +1,12 @@
 import * as fs from 'fs'
 import * as http from 'http'
+import { Agent } from 'https'
 import * as os from 'os'
 import * as path from 'path'
 import { Readable } from 'stream'
-import { encryptedStream, type UploadParams, uploadWithNodeHttp } from '../../Utils/messages-media'
+import type { MediaConnInfo, SocketConfig } from '../../Types'
+import type { ILogger } from '../../Utils/logger'
+import { encryptedStream, getWAUploadToServer, type UploadParams, uploadWithNodeHttp } from '../../Utils/messages-media'
 
 const createTempFile = async (content: string): Promise<string> => {
 	const filePath = path.join(os.tmpdir(), `test-upload-${Date.now()}.txt`)
@@ -15,6 +18,19 @@ const cleanupTempFile = async (filePath: string): Promise<void> => {
 	try {
 		await fs.promises.unlink(filePath)
 	} catch {}
+}
+
+const createLogger = (): ILogger => {
+	const logger: ILogger = {
+		level: 'silent',
+		child: () => logger,
+		trace: () => {},
+		debug: () => {},
+		info: () => {},
+		warn: () => {},
+		error: () => {}
+	}
+	return logger
 }
 
 describe('uploadWithNodeHttp', () => {
@@ -282,6 +298,73 @@ describe('uploadWithNodeHttp', () => {
 
 		expect(result).toEqual(expectedResponse)
 		expect(finalReceivedBody).toBe(testFileContent)
+	})
+})
+
+describe('getWAUploadToServer', () => {
+	let tempFilePath: string
+	let originalFetch: typeof globalThis.fetch
+	let originalBunDescriptor: PropertyDescriptor | undefined
+
+	beforeAll(async () => {
+		tempFilePath = await createTempFile('fetch upload content')
+	})
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch
+		originalBunDescriptor = Object.getOwnPropertyDescriptor(process.versions, 'bun')
+		Object.defineProperty(process.versions, 'bun', {
+			value: 'test-runtime',
+			configurable: true
+		})
+	})
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch
+		if (originalBunDescriptor) {
+			Object.defineProperty(process.versions, 'bun', originalBunDescriptor)
+		} else {
+			delete (process.versions as { bun?: string }).bun
+		}
+	})
+
+	afterAll(async () => {
+		await cleanupTempFile(tempFilePath)
+	})
+
+	it('does not pass a generic https Agent as a fetch dispatcher', async () => {
+		let fetchInit: RequestInit | undefined
+		globalThis.fetch = (async (_input, init) => {
+			fetchInit = init
+			return new Response(JSON.stringify({ url: 'https://example.com/media', direct_path: '/media' }), {
+				headers: { 'Content-Type': 'application/json' }
+			})
+		}) as typeof fetch
+
+		const mediaConn: MediaConnInfo = {
+			auth: 'auth-token',
+			ttl: 60,
+			hosts: [{ hostname: 'upload.example.com', maxContentLengthBytes: 1024 }],
+			fetchDate: new Date()
+		}
+		const upload = getWAUploadToServer(
+			{
+				customUploadHosts: [],
+				fetchAgent: new Agent(),
+				logger: createLogger(),
+				options: {}
+			} as Partial<SocketConfig> as SocketConfig,
+			async () => mediaConn
+		)
+
+		await expect(upload(tempFilePath, { fileEncSha256B64: 'abc123', mediaType: 'image' })).resolves.toEqual({
+			mediaUrl: 'https://example.com/media',
+			directPath: '/media',
+			meta_hmac: undefined,
+			fbid: undefined,
+			ts: undefined
+		})
+		expect((fetchInit as (RequestInit & { dispatcher?: unknown }) | undefined)?.dispatcher).toBeUndefined()
 	})
 })
 


### PR DESCRIPTION
## Summary

This PR makes the media upload fetch path only pass `dispatcher` when the configured upload agent actually implements an Undici-style `dispatch` method.

It also adds a regression test through `getWAUploadToServer` that forces the fetch upload path and verifies a plain Node `https.Agent` is not forwarded as `RequestInit.dispatcher`.

## Why

Baileys' `SocketConfig.fetchAgent` is typed as Node's `https.Agent`, which is valid for the Node HTTP upload path. The fetch path, however, uses the non-standard Undici `dispatcher` option. Native fetch/Undici expects that object to be Dispatcher-compatible, and a generic Node agent does not satisfy that contract.

Downstream, OpenClaw currently carries this as a pnpm patch against `baileys@7.0.0-rc11` to avoid media upload failures when the fetch path sees a generic agent. Upstreaming it lets downstream users drop that local patch.

## Validation

- `yarn prettier --write src/Utils/messages-media.ts src/__tests__/Utils/messages-media.test.ts`
- `yarn lint` passes with existing warnings only
- `yarn build`
- `yarn node --experimental-vm-modules ./node_modules/.bin/jest src/__tests__/Utils/messages-media.test.ts --runInBand --globals '{"ts-jest":{"diagnostics":false}}'`

Note: the normal focused Jest command currently fails before running tests because ts-jest cannot resolve the ambient `Long` type in `src/Utils/generics.ts`. The same source typecheck passes through `yarn lint`, so I used the diagnostics-off invocation above to execute the regression test.

AI-assisted: drafted with Codex, reviewed and tested locally before submission.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix media uploads over fetch by only setting `dispatcher` when the agent implements `dispatch`. Prevents failures when `SocketConfig.fetchAgent` is a Node `https.Agent` and keeps behavior compatible with native fetch/Undici.

- **Bug Fixes**
  - In `uploadWithFetch`, conditionally include `dispatcher` only for Undici-compatible agents.
  - Added a regression test via `getWAUploadToServer` that forces the fetch path and ensures a plain `https.Agent` is not forwarded as `dispatcher`.

<sup>Written for commit a39339403db3fada90b5f4b4fd3b3bd8e3c226a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved file upload handling to correctly detect and configure network compatibility. File uploads now work properly with both standard and alternative network configurations without unnecessary dispatcher configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2557)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->