### PR TITLE
fix: harden pairing code request flow

### DIFF
--- a/Example/example.ts
+++ b/Example/example.ts
@@ -78,6 +78,7 @@ const startSock = async() => {
 				if(connection === 'close') {
 					// reconnect if not logged out
 					if((lastDisconnect?.error as Boom)?.output?.statusCode !== DisconnectReason.loggedOut) {
+						// A 515 restartRequired close after first pairing is expected; reconnect with saved creds.
 						startSock()
 					} else {
 						logger.fatal('Connection closed. You are logged out.')
@@ -85,11 +86,15 @@ const startSock = async() => {
 				}
 
 				if (qr) {
-					// Pairing code for Web clients
+					// Pairing code for Web clients. requestPairingCode also queues until this pair-device readiness point.
 					if (usePairingCode && !sock.authState.creds.registered) {
 						const phoneNumber = await question('Please enter your phone number:\n')
-						const code = await sock.requestPairingCode(phoneNumber)
-						console.log(`Pairing code: ${code}`)
+						try {
+							const code = await sock.requestPairingCode(phoneNumber)
+							console.log(`Pairing code: ${code}`)
+						} catch (err) {
+							logger.error({ err }, 'pairing code request failed')
+						}
 					}
 				}
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ if (!sock.authState.creds.registered) {
 }
 ```
 
+You can call `requestPairingCode()` after the first `connection.update` with `qr`, or call it earlier and Baileys will wait until WhatsApp sends the `pair-device` readiness stanza. After a successful first pair, WhatsApp normally closes the socket with `515 restartRequired`; reconnect with the saved creds instead of treating that as a failed pair.
+
+If you use a custom `browser[0]` label, Baileys keeps that label for the linked-device registration, but normalizes the pairing-code `companion_platform_display` to a WhatsApp-accepted browser/OS pair such as `Chrome (Mac OS)` or `Chrome (Ubuntu)`.
+
 ### Receive Full History
 
 1. Set `syncFullHistory` as `true`

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -35,9 +35,9 @@ import {
 	generateMdTagPrefix,
 	generateRegistrationNode,
 	getCodeFromWSError,
-	getCompanionPlatformId,
 	getErrorCodeFromStreamError,
 	getNextPreKeysNode,
+	getPairingCodePlatform,
 	makeEventBuffer,
 	makeNoiseHandler,
 	promiseTimeout,
@@ -385,6 +385,10 @@ export const makeSocket = (config: SocketConfig) => {
 	let keepAliveReq: NodeJS.Timeout
 	let qrTimer: NodeJS.Timeout
 	let closed = false
+	let pairingReady = false
+	let pairingInProgress = false
+	let pendingPairingResolve: (() => void) | undefined
+	let pendingPairingReject: ((err: Error) => void) | undefined
 
 	const socketEndHandlers: Array<(error: Error | undefined) => void | Promise<void>> = []
 
@@ -630,6 +634,14 @@ export const makeSocket = (config: SocketConfig) => {
 		clearInterval(keepAliveReq)
 		clearTimeout(qrTimer)
 
+		pairingReady = false
+		pairingInProgress = false
+		pendingPairingReject?.(
+			error || new Boom('Connection closed before pairing completed', { statusCode: DisconnectReason.connectionClosed })
+		)
+		pendingPairingResolve = undefined
+		pendingPairingReject = undefined
+
 		ws.removeAllListeners('close')
 		ws.removeAllListeners('open')
 		ws.removeAllListeners('message')
@@ -755,7 +767,7 @@ export const makeSocket = (config: SocketConfig) => {
 		void end(new Boom(msg || 'Intentional Logout', { statusCode: DisconnectReason.loggedOut }))
 	}
 
-	const requestPairingCode = async (phoneNumber: string, customPairingCode?: string): Promise<string> => {
+	const sendPairingCodeRequest = async (phoneNumber: string, customPairingCode?: string): Promise<string> => {
 		const pairingCode = customPairingCode ?? bytesToCrockford(randomBytes(5))
 
 		if (customPairingCode && customPairingCode?.length !== 8) {
@@ -764,59 +776,106 @@ export const makeSocket = (config: SocketConfig) => {
 
 		authState.creds.pairingCode = pairingCode
 
-		authState.creds.me = {
-			id: jidEncode(phoneNumber, 's.whatsapp.net'),
-			name: '~'
-		}
-		ev.emit('creds.update', authState.creds)
-		await sendNode({
-			tag: 'iq',
-			attrs: {
-				to: S_WHATSAPP_NET,
-				type: 'set',
-				id: generateMessageTag(),
-				xmlns: 'md'
-			},
-			content: [
-				{
-					tag: 'link_code_companion_reg',
-					attrs: {
-						jid: authState.creds.me.id,
-						stage: 'companion_hello',
+		const jid = jidEncode(phoneNumber, 's.whatsapp.net')
+		const pairingPlatform = getPairingCodePlatform(browser)
 
-						should_show_push_notification: 'true'
-					},
-					content: [
-						{
-							tag: 'link_code_pairing_wrapped_companion_ephemeral_pub',
-							attrs: {},
-							content: await generatePairingKey()
+		try {
+			const result = await query({
+				tag: 'iq',
+				attrs: {
+					to: S_WHATSAPP_NET,
+					type: 'set',
+					xmlns: 'md'
+				},
+				content: [
+					{
+						tag: 'link_code_companion_reg',
+						attrs: {
+							jid,
+							stage: 'companion_hello',
+							should_show_push_notification: 'true'
 						},
-						{
-							tag: 'companion_server_auth_key_pub',
-							attrs: {},
-							content: authState.creds.noiseKey.public
-						},
-						{
-							tag: 'companion_platform_id',
-							attrs: {},
-							content: getCompanionPlatformId(browser)
-						},
-						{
-							tag: 'companion_platform_display',
-							attrs: {},
-							content: `${browser[1]} (${browser[0]})`
-						},
-						{
-							tag: 'link_code_pairing_nonce',
-							attrs: {},
-							content: '0'
-						}
-					]
-				}
-			]
-		})
-		return authState.creds.pairingCode
+						content: [
+							{
+								tag: 'link_code_pairing_wrapped_companion_ephemeral_pub',
+								attrs: {},
+								content: await generatePairingKey()
+							},
+							{
+								tag: 'companion_server_auth_key_pub',
+								attrs: {},
+								content: authState.creds.noiseKey.public
+							},
+							{
+								tag: 'companion_platform_id',
+								attrs: {},
+								content: pairingPlatform.id
+							},
+							{
+								tag: 'companion_platform_display',
+								attrs: {},
+								content: pairingPlatform.display
+							},
+							{
+								tag: 'link_code_pairing_nonce',
+								attrs: {},
+								content: '0'
+							}
+						]
+					}
+				]
+			})
+
+			if (!result) {
+				throw new Boom('Timed out waiting for pairing code response', { statusCode: DisconnectReason.timedOut })
+			}
+		} catch (error) {
+			if (authState.creds.pairingCode === pairingCode) {
+				authState.creds.pairingCode = undefined
+			}
+
+			throw error
+		}
+
+		authState.creds.me = { id: jid, name: '~' }
+		ev.emit('creds.update', authState.creds)
+
+		return pairingCode
+	}
+
+	const requestPairingCode = async (phoneNumber: string, customPairingCode?: string): Promise<string> => {
+		if (customPairingCode && customPairingCode.length !== 8) {
+			throw new Error('Custom pairing code must be exactly 8 chars')
+		}
+
+		if (pairingInProgress) {
+			throw new Boom('A pairing request is already in progress', { statusCode: 400 })
+		}
+
+		pairingInProgress = true
+
+		try {
+			if (!pairingReady) {
+				logger.debug('pairing not ready yet, queuing request until pair-device is received')
+				await new Promise<void>((resolve, reject) => {
+					pendingPairingResolve = () => {
+						pendingPairingResolve = undefined
+						pendingPairingReject = undefined
+						resolve()
+					}
+
+					pendingPairingReject = (err: Error) => {
+						pendingPairingResolve = undefined
+						pendingPairingReject = undefined
+						reject(err)
+					}
+				})
+			}
+
+			return await sendPairingCodeRequest(phoneNumber, customPairingCode)
+		} finally {
+			pairingInProgress = false
+		}
 	}
 
 	async function generatePairingKey() {
@@ -873,6 +932,9 @@ export const makeSocket = (config: SocketConfig) => {
 			}
 		}
 		await sendNode(iq)
+
+		pairingReady = true
+		pendingPairingResolve?.()
 
 		const pairDeviceNode = getBinaryNodeChild(stanza, 'pair-device')
 		const refNodes = getBinaryNodeChildren(pairDeviceNode, 'ref')

--- a/src/Utils/companion-reg-client-utils.ts
+++ b/src/Utils/companion-reg-client-utils.ts
@@ -22,6 +22,24 @@ const BROWSER_TO_COMPANION_WEB_CLIENT: Record<string, CompanionWebClientType> = 
 	Safari: CompanionWebClientType.SAFARI
 }
 
+const DEFAULT_PAIRING_CODE_BROWSER_PLATFORM = { id: '1', displayName: 'Chrome' }
+
+const PAIRING_CODE_BROWSER_PLATFORM: Record<string, { id: string; displayName: string }> = {
+	Chrome: DEFAULT_PAIRING_CODE_BROWSER_PLATFORM,
+	Firefox: { id: '2', displayName: 'Firefox' },
+	IE: { id: '3', displayName: 'IE' },
+	Opera: { id: '4', displayName: 'Opera' },
+	Safari: { id: '5', displayName: 'Safari' },
+	Edge: { id: '6', displayName: 'Edge' }
+}
+
+const PAIRING_CODE_OS_DISPLAY = new Set(['Mac OS', 'Windows', 'Ubuntu'])
+
+export type PairingCodePlatform = {
+	id: string
+	display: string
+}
+
 export const getCompanionWebClientType = ([os, browserName]: WABrowserDescription): CompanionWebClientType => {
 	if (browserName === 'Desktop') {
 		return os === 'Windows' ? CompanionWebClientType.UWP : CompanionWebClientType.ELECTRON
@@ -32,6 +50,16 @@ export const getCompanionWebClientType = ([os, browserName]: WABrowserDescriptio
 
 export const getCompanionPlatformId = (browser: WABrowserDescription): string => {
 	return getCompanionWebClientType(browser).toString()
+}
+
+export const getPairingCodePlatform = ([os, browserName]: WABrowserDescription): PairingCodePlatform => {
+	const browser = PAIRING_CODE_BROWSER_PLATFORM[browserName] || DEFAULT_PAIRING_CODE_BROWSER_PLATFORM
+	const osDisplay = PAIRING_CODE_OS_DISPLAY.has(os) ? os : 'Mac OS'
+
+	return {
+		id: browser.id,
+		display: `${browser.displayName} (${osDisplay})`
+	}
 }
 
 export const buildPairingQRData = (

--- a/src/__tests__/Socket/pairing-code.test.ts
+++ b/src/__tests__/Socket/pairing-code.test.ts
@@ -1,0 +1,243 @@
+import { jest } from '@jest/globals'
+import { EventEmitter } from 'events'
+import { DEFAULT_CONNECTION_CONFIG } from '../../Defaults'
+import type { AuthenticationState, SignalDataTypeMap, SocketConfig } from '../../Types'
+import { initAuthCreds } from '../../Utils/auth-utils'
+import type { ILogger } from '../../Utils/logger'
+import type { BinaryNode } from '../../WABinary'
+
+class MockWebSocketClient extends EventEmitter {
+	public sent: Array<string | Uint8Array> = []
+	private closed = false
+	private closing = false
+
+	constructor(
+		public url: URL,
+		public config: SocketConfig
+	) {
+		super()
+	}
+
+	get isOpen() {
+		return !this.closed && !this.closing
+	}
+
+	get isClosed() {
+		return this.closed
+	}
+
+	get isClosing() {
+		return this.closing
+	}
+
+	get isConnecting() {
+		return false
+	}
+
+	connect() {}
+
+	async close() {
+		if (this.closed) {
+			return
+		}
+
+		this.closing = true
+		this.closed = true
+		this.closing = false
+		this.emit('close')
+	}
+
+	send(data: string | Uint8Array, cb?: (err?: Error) => void) {
+		this.sent.push(data)
+		cb?.()
+		return true
+	}
+}
+
+const mockSockets: MockWebSocketClient[] = []
+const createWebSocketClient = (url: URL, config: SocketConfig) => {
+	const socket = new MockWebSocketClient(url, config)
+	mockSockets.push(socket)
+	return socket
+}
+
+jest.unstable_mockModule('../../Socket/Client/websocket', () => ({
+	WebSocketClient: jest.fn<typeof createWebSocketClient>(createWebSocketClient)
+}))
+
+const { default: makeWASocket } = await import('../../Socket')
+
+const makeAuthState = (): AuthenticationState => ({
+	creds: initAuthCreds(),
+	keys: {
+		get: async <T extends keyof SignalDataTypeMap>(type: T, ids: string[]) => {
+			void type
+			void ids
+			return {} as { [id: string]: SignalDataTypeMap[T] }
+		},
+		set: async data => {
+			void data
+		}
+	}
+})
+
+type TestLogger = ILogger & {
+	child: jest.MockedFunction<ILogger['child']>
+	trace: jest.MockedFunction<ILogger['trace']>
+	debug: jest.MockedFunction<ILogger['debug']>
+	info: jest.MockedFunction<ILogger['info']>
+	warn: jest.MockedFunction<ILogger['warn']>
+	error: jest.MockedFunction<ILogger['error']>
+}
+
+const makeLogger = (): TestLogger => {
+	const logger: TestLogger = {
+		level: 'trace',
+		child: jest.fn<ILogger['child']>(),
+		trace: jest.fn<ILogger['trace']>(),
+		debug: jest.fn<ILogger['debug']>(),
+		info: jest.fn<ILogger['info']>(),
+		warn: jest.fn<ILogger['warn']>(),
+		error: jest.fn<ILogger['error']>()
+	}
+
+	logger.child.mockReturnValue(logger)
+
+	return logger
+}
+
+const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0))
+
+const pairDeviceStanza = (): BinaryNode => ({
+	tag: 'iq',
+	attrs: {
+		from: '@s.whatsapp.net',
+		id: 'pair-device-1',
+		type: 'set',
+		xmlns: 'md'
+	},
+	content: [
+		{
+			tag: 'pair-device',
+			attrs: {},
+			content: [{ tag: 'ref', attrs: {}, content: Buffer.from('pair-ref') }]
+		}
+	]
+})
+
+const getPairingRequestXml = async (logger: ReturnType<typeof makeLogger>) => {
+	for (let i = 0; i < 200; i++) {
+		const entries = logger.trace.mock.calls.map(([entry]) => entry)
+		for (let index = entries.length - 1; index >= 0; index--) {
+			const entry = entries[index]
+			if (
+				typeof entry === 'object' &&
+				entry !== null &&
+				'xml' in entry &&
+				typeof entry.xml === 'string' &&
+				entry.xml.includes('link_code_companion_reg')
+			) {
+				return entry.xml
+			}
+		}
+
+		await flushPromises()
+	}
+
+	throw new Error('pairing request XML was not sent')
+}
+
+const getStanzaId = (xml: string) => {
+	const id = /<iq[^>]* id='([^']+)'/.exec(xml)?.[1]
+	if (!id) {
+		throw new Error(`could not find stanza id in XML: ${xml}`)
+	}
+
+	return id
+}
+
+const makeSocket = (auth: AuthenticationState, logger: ILogger) =>
+	makeWASocket({
+		...DEFAULT_CONNECTION_CONFIG,
+		auth,
+		logger,
+		defaultQueryTimeoutMs: 1_000,
+		browser: ['Aidy Staging', 'Chrome', '20.0.04']
+	})
+
+describe('requestPairingCode', () => {
+	beforeEach(() => {
+		mockSockets.length = 0
+		jest.clearAllMocks()
+	})
+
+	it('queues requests until pair-device is received', async () => {
+		const auth = makeAuthState()
+		const logger = makeLogger()
+		const sock = makeSocket(auth, logger)
+		const ws = mockSockets[0]!
+
+		const codePromise = sock.requestPairingCode('1234567890')
+		await flushPromises()
+
+		expect(logger.trace.mock.calls.some(([entry]) => JSON.stringify(entry).includes('link_code_companion_reg'))).toBe(
+			false
+		)
+
+		ws.emit('CB:iq,type:set,pair-device', pairDeviceStanza())
+		const xml = await getPairingRequestXml(logger)
+		expect(xml).toContain('companion_platform_display')
+		expect(xml).toContain('Chrome (Mac OS)')
+
+		ws.emit(`TAG:${getStanzaId(xml)}`, {
+			tag: 'iq',
+			attrs: { from: '@s.whatsapp.net', id: getStanzaId(xml), type: 'result' }
+		} satisfies BinaryNode)
+
+		const code = await codePromise
+		expect(code).toHaveLength(8)
+		expect(auth.creds.me?.id).toBe('1234567890@s.whatsapp.net')
+
+		await sock.end(new Error('test complete'))
+	})
+
+	it('rejects server companion_hello errors without persisting creds.me', async () => {
+		const auth = makeAuthState()
+		const logger = makeLogger()
+		const sock = makeSocket(auth, logger)
+		const ws = mockSockets[0]!
+
+		ws.emit('CB:iq,type:set,pair-device', pairDeviceStanza())
+		const codePromise = sock.requestPairingCode('1234567890')
+		const xml = await getPairingRequestXml(logger)
+		const id = getStanzaId(xml)
+
+		ws.emit(`TAG:${id}`, {
+			tag: 'iq',
+			attrs: { from: '@s.whatsapp.net', id, type: 'error' },
+			content: [{ tag: 'error', attrs: { code: '400', text: 'bad-request' } }]
+		} satisfies BinaryNode)
+
+		await expect(codePromise).rejects.toThrow('bad-request')
+		expect(auth.creds.me).toBeUndefined()
+		expect(auth.creds.pairingCode).toBeUndefined()
+
+		await sock.end(new Error('test complete'))
+	})
+
+	it('rejects concurrent pairing requests', async () => {
+		const auth = makeAuthState()
+		const logger = makeLogger()
+		const sock = makeSocket(auth, logger)
+
+		const firstRequest = sock.requestPairingCode('1234567890')
+		firstRequest.catch(() => undefined)
+
+		await expect(sock.requestPairingCode('1234567890')).rejects.toMatchObject({
+			output: { statusCode: 400 }
+		})
+
+		await sock.end(new Error('test complete'))
+		await expect(firstRequest).rejects.toThrow('test complete')
+	})
+})

--- a/src/__tests__/Utils/companion-reg-client-utils.test.ts
+++ b/src/__tests__/Utils/companion-reg-client-utils.test.ts
@@ -1,0 +1,37 @@
+import { Browsers } from '../../Utils/browser-utils'
+import { getPairingCodePlatform } from '../../Utils/companion-reg-client-utils'
+
+describe('getPairingCodePlatform', () => {
+	it('normalizes a custom OS label to a canonical pairing display', () => {
+		expect(getPairingCodePlatform(['Aidy Staging', 'Chrome', '20.0.04'])).toEqual({
+			id: '1',
+			display: 'Chrome (Mac OS)'
+		})
+	})
+
+	it('preserves Ubuntu as a canonical pairing display OS', () => {
+		expect(getPairingCodePlatform(Browsers.ubuntu('Chrome'))).toEqual({
+			id: '1',
+			display: 'Chrome (Ubuntu)'
+		})
+	})
+
+	it('uses the Safari pairing platform id', () => {
+		expect(getPairingCodePlatform(Browsers.macOS('Safari'))).toEqual({
+			id: '5',
+			display: 'Safari (Mac OS)'
+		})
+	})
+
+	it('falls back to Chrome for non-browser platform names', () => {
+		expect(getPairingCodePlatform(Browsers.macOS('Desktop'))).toEqual({
+			id: '1',
+			display: 'Chrome (Mac OS)'
+		})
+
+		expect(getPairingCodePlatform(Browsers.macOS('Unknown Browser'))).toEqual({
+			id: '1',
+			display: 'Chrome (Mac OS)'
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Fixes #2560.

Harden the pairing-code registration path so callers get a real success/failure result from WhatsApp instead of an optimistic local code.

This fixes a live failure mode where a custom `browser[0]` label is accepted during the normal registration node but rejected by WhatsApp's stricter `companion_hello` validator. For example, a socket configured with:

```ts
browser: ['Custom Label', 'Chrome', '20.0.04']
```

currently sends `companion_platform_display='Chrome (Custom Label)'` in the pairing-code IQ and can receive `<iq type='error'><error code='400' text='bad-request'/></iq>` after Baileys has already returned an 8-character code to the caller.

## Changes

- Add an internal pairing-code platform helper that keeps the public `browser` tuple unchanged for registration, but normalizes `companion_platform_display` to canonical browser/OS values for the strict pairing-code IQ.
- Send `companion_hello` through `query()` instead of fire-and-forget `sendNode()`, so server IQ errors reject `requestPairingCode()`.
- Defer `creds.me` and `creds.update` until `companion_hello` succeeds, and clear transient pairing-code state on failure.
- Queue `requestPairingCode()` until the server sends the initial `pair-device` stanza, and reject concurrent pairing requests with Boom 400.
- Document the expected post-pair `515 restartRequired` reconnect behavior.

## Validation

Validated against a downstream staging deployment using a non-canonical browser label. Before this patch, the server rejected stage-1 pairing with `400 bad-request` for `Chrome (Custom Label)`. With this patch, the same config sent `Chrome (Mac OS)`, the server accepted `companion_hello`, `primary_hello` arrived, `companion_finish` was acknowledged, `pair-success` was received, and the socket reconnected authenticated.

No phone numbers, auth state, raw keys, or cryptographic payloads are included here; the validation summary above is intentionally sanitized.

## Testing

- `yarn lint`
- `yarn test`
- `yarn build` on the downstream package branch containing this commit

Related: #2488, #2494, #2512

Drafted with Codex; live protocol validation was performed on a downstream staging deployment before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced pairing code request flow with improved error handling, automatic platform detection, and better state management during device pairing
  
* **Documentation**
  * Clarified pairing code timing guidance relative to connection events and improved browser/platform identification procedures

* **Tests**
  * Added comprehensive test coverage for pairing code functionality, platform detection, and error scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->