### PR TITLE
feat(messages): support lottieStickerMessage for animated .was stickers

### DIFF
--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -676,6 +676,24 @@ export const generateWAMessageContent = async (
 		}
 	}
 
+	// Lottie animated stickers (.was) must be sent via lottieStickerMessage,
+	// a FutureProofMessage wrapping the inner stickerMessage at proto field 74.
+	// Mobile WhatsApp clients silently drop Lottie payloads delivered inside a
+	// plain stickerMessage (field 26), even when isLottie is set; Web tolerates
+	// it. The wrap below makes mobile render correctly.
+	if (
+		m.stickerMessage &&
+		(m.stickerMessage.mimetype === 'application/was' || m.stickerMessage.isLottie)
+	) {
+		m.stickerMessage.isAnimated = true
+		m.stickerMessage.isLottie = true
+		const { stickerMessage, messageContextInfo } = m
+		m = { lottieStickerMessage: { message: { stickerMessage } } }
+		if (messageContextInfo) {
+			m.messageContextInfo = messageContextInfo
+		}
+	}
+
 	return WAProto.Message.create(m)
 }
 
@@ -812,7 +830,12 @@ export const normalizeMessageContent = (content: WAMessageContent | null | undef
 			message?.editedMessage ||
 			message?.associatedChildMessage ||
 			message?.groupStatusMessage ||
-			message?.groupStatusMessageV2
+			message?.groupStatusMessageV2 ||
+			// Lottie animated stickers (.was) arrive wrapped in lottieStickerMessage
+			// (FutureProofMessage at proto field 74). Unwrapping here lets the rest
+			// of the pipeline (downloadMediaMessage, assertMediaContent, etc.) treat
+			// it as a normal stickerMessage with isLottie:true.
+			message?.lottieStickerMessage
 		)
 	}
 }

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -681,10 +681,7 @@ export const generateWAMessageContent = async (
 	// Mobile WhatsApp clients silently drop Lottie payloads delivered inside a
 	// plain stickerMessage (field 26), even when isLottie is set; Web tolerates
 	// it. The wrap below makes mobile render correctly.
-	if (
-		m.stickerMessage &&
-		(m.stickerMessage.mimetype === 'application/was' || m.stickerMessage.isLottie)
-	) {
+	if (m.stickerMessage && (m.stickerMessage.mimetype === 'application/was' || m.stickerMessage.isLottie)) {
 		m.stickerMessage.isAnimated = true
 		m.stickerMessage.isLottie = true
 		const { stickerMessage, messageContextInfo } = m

--- a/src/__tests__/Utils/lottie-sticker-message.test.ts
+++ b/src/__tests__/Utils/lottie-sticker-message.test.ts
@@ -1,0 +1,73 @@
+import { proto } from '../../../WAProto/index.js'
+import { WAProto } from '../../Types'
+import { extractMessageContent, normalizeMessageContent } from '../../Utils/messages'
+
+describe('Lottie sticker message support', () => {
+	const innerSticker: proto.Message.IStickerMessage = {
+		url: 'https://mmg.whatsapp.net/o1/v/example',
+		directPath: '/o1/v/example',
+		mediaKey: Buffer.from('a'.repeat(32)),
+		fileSha256: Buffer.from('b'.repeat(32)),
+		fileEncSha256: Buffer.from('c'.repeat(32)),
+		fileLength: 19805,
+		mimetype: 'application/was',
+		width: 64,
+		height: 64,
+		isAnimated: true,
+		isLottie: true
+	}
+
+	describe('normalizeMessageContent', () => {
+		it('unwraps lottieStickerMessage to its inner stickerMessage', () => {
+			const wrapped: proto.IMessage = {
+				lottieStickerMessage: {
+					message: { stickerMessage: innerSticker }
+				}
+			}
+
+			const result = normalizeMessageContent(wrapped)
+
+			expect(result).toBeDefined()
+			expect(result?.stickerMessage).toBeDefined()
+			expect(result?.stickerMessage?.isLottie).toBe(true)
+			expect(result?.stickerMessage?.mimetype).toBe('application/was')
+			expect(result?.lottieStickerMessage).toBeUndefined()
+		})
+
+		it('returns the original message untouched when there is no Lottie wrapper', () => {
+			const plain: proto.IMessage = { stickerMessage: innerSticker }
+			const result = normalizeMessageContent(plain)
+			expect(result).toBe(plain)
+		})
+	})
+
+	describe('extractMessageContent', () => {
+		it('reaches the inner stickerMessage through a lottieStickerMessage wrapper', () => {
+			const wrapped: proto.IMessage = {
+				lottieStickerMessage: {
+					message: { stickerMessage: innerSticker }
+				}
+			}
+
+			const content = extractMessageContent(wrapped)
+			expect(content?.stickerMessage?.url).toBe(innerSticker.url)
+			expect(content?.stickerMessage?.isLottie).toBe(true)
+		})
+	})
+
+	describe('proto round-trip', () => {
+		it('encodes and decodes a lottieStickerMessage without losing the inner sticker', () => {
+			const msg = WAProto.Message.create({
+				lottieStickerMessage: {
+					message: { stickerMessage: innerSticker }
+				}
+			})
+
+			const encoded = WAProto.Message.encode(msg).finish()
+			const decoded = WAProto.Message.decode(encoded)
+
+			expect(decoded.lottieStickerMessage?.message?.stickerMessage?.mimetype).toBe('application/was')
+			expect(decoded.lottieStickerMessage?.message?.stickerMessage?.isLottie).toBe(true)
+		})
+	})
+})


### PR DESCRIPTION
## Problem

Lottie animated stickers (.was) are delivered by WhatsApp via `lottieStickerMessage` — a `FutureProofMessage` wrapping a `stickerMessage` at proto field 74. Both the send and receive paths in Baileys today silently fail on this format:

- **Send.** `sock.sendMessage(jid, { sticker: buf, mimetype: 'application/was' })` produces a plain `stickerMessage` (field 26). Mobile WhatsApp clients (Android/iOS) silently drop Lottie payloads delivered that way; Web tolerates them. The result: the sticker bubble is created on the server (status \"Read\"), but never renders on the recipient's phone. No exception, no log.

- **Receive.** When a `lottieStickerMessage` arrives, `downloadMediaMessage` throws `\"lottieStickerMessage\" message is not a media message`, because `normalizeMessageContent` never unwraps the FutureProof layer to expose the inner `stickerMessage`.

The proto schema already declares both pieces: field 74 (`lottieStickerMessage`) and `isLottie` / `isAnimated` flags on `StickerMessage`. The send/receive plumbing simply was never wired up.

This was investigated empirically by capturing a Lottie sticker forwarded to a self-chat, decoding it, and round-tripping it through Baileys. Issue #803 raised the question in May 2024 and was closed without a fix.

## Fix

Two surgical changes in `src/Utils/messages.ts`:

1. **Send-side wrap** (in `generateWAMessageContent`, after `contextInfo` / `mentions` / `messageContextInfo` are applied):
   ```ts
   if (
     m.stickerMessage &&
     (m.stickerMessage.mimetype === 'application/was' || m.stickerMessage.isLottie)
   ) {
     m.stickerMessage.isAnimated = true
     m.stickerMessage.isLottie = true
     const { stickerMessage, messageContextInfo } = m
     m = { lottieStickerMessage: { message: { stickerMessage } } }
     if (messageContextInfo) m.messageContextInfo = messageContextInfo
   }
   ```

2. **Receive-side unwrap** (one line added to `getFutureProofMessage` inside `normalizeMessageContent`):
   ```ts
   message?.lottieStickerMessage
   ```
   This makes `extractMessageContent` / `downloadMediaMessage` / `assertMediaContent` transparently see the inner `stickerMessage` with no further changes.

## Tests

`src/__tests__/Utils/lottie-sticker-message.test.ts` covers:
- `normalizeMessageContent` unwraps `lottieStickerMessage` to the inner `stickerMessage`.
- `normalizeMessageContent` leaves a plain `stickerMessage` untouched (no-op path).
- `extractMessageContent` reaches the inner sticker through the wrapper.
- Proto round-trip: `WAProto.Message.encode/decode` preserves the wrapped sticker (`mimetype`, `isLottie`).

Full Utils suite passes: **301/301**.

## Behaviour change

- Calling `sock.sendMessage(jid, { sticker: buf, mimetype: 'application/was' })` now produces a `lottieStickerMessage` instead of a `stickerMessage`. This is the change required for mobile to render — but it is a different proto field, so consumers that introspect `m.message.stickerMessage` after sending will need to look at `m.message.lottieStickerMessage.message.stickerMessage` (or call `normalizeMessageContent`, which already handles both after this PR).
- Plain WebP stickers (`image/webp`) and other media types are untouched.

## Closes

Closes #803.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full support for Lottie animated stickers (.was) by sending them as `lottieStickerMessage` and unwrapping them on receive. Fixes silent drops on mobile and enables `downloadMediaMessage` for incoming Lottie stickers.

- **Bug Fixes**
  - Send: `generateWAMessageContent` wraps `.was` or `isLottie` stickers in `lottieStickerMessage`, sets `isAnimated`/`isLottie`, and preserves `messageContextInfo`.
  - Receive: `normalizeMessageContent` unwraps `lottieStickerMessage` so `extractMessageContent` and `downloadMediaMessage` see the inner `stickerMessage`.

- **Migration**
  - Sending `.was` now produces `lottieStickerMessage`. Read `message.lottieStickerMessage.message.stickerMessage`, or call `normalizeMessageContent`.
  - Other sticker types and media are unchanged.

<sup>Written for commit eab865a5dbb95840ddf4e73bfec7385516737f5b. Summary will update on new commits. <a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2563?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection and handling of Lottie animated stickers in messages with enhanced payload transformation support.

* **Tests**
  * Added comprehensive test coverage for Lottie sticker message processing and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->