### PR TITLE
fix: preserve context info for device-sent messages

### DIFF
--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -332,7 +332,9 @@ export const decryptMessageNode = (
 						let msg: proto.IMessage = proto.Message.decode(
 							e2eType !== 'plaintext' ? unpadRandomMax16(msgBuffer) : msgBuffer
 						)
+						const messageContextInfo = msg.messageContextInfo
 						msg = msg.deviceSentMessage?.message || msg
+						msg.messageContextInfo ||= messageContextInfo
 						if (msg.senderKeyDistributionMessage) {
 							//eslint-disable-next-line max-depth
 							try {

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -332,9 +332,11 @@ export const decryptMessageNode = (
 						let msg: proto.IMessage = proto.Message.decode(
 							e2eType !== 'plaintext' ? unpadRandomMax16(msgBuffer) : msgBuffer
 						)
-						const messageContextInfo = msg.messageContextInfo
-						msg = msg.deviceSentMessage?.message || msg
-						msg.messageContextInfo ||= messageContextInfo
+						if (msg.deviceSentMessage?.message) {
+							const inner = msg.deviceSentMessage.message
+							const { deviceSentMessage, ...outer } = msg
+							msg = { ...outer, ...inner }
+						}
 						if (msg.senderKeyDistributionMessage) {
 							//eslint-disable-next-line max-depth
 							try {


### PR DESCRIPTION
Preserves the outer `messageContextInfo` when unwrapping `deviceSentMessage` payloads.

WhatsApp can send linked-device messages as an outer `Message` that contains both the real message inside `deviceSentMessage.message` and useful context on the outer message.

Before this change, we unwrapped the inner message directly:

```ts
msg = msg.deviceSentMessage?.message || msg
```

That kept the visible message content, but dropped the outer `messageContextInfo`, including `messageContextInfo.messageSecret`.

This matters for encrypted edit handling in #2554. Apps that persist messages from `messages.upsert` need to store the original `messageSecret`, especially for `fromMe: true` messages sent from another linked device. Without it, later encrypted edit envelopes may fail to decrypt because `getMessage` can return the original message without the required secret.

This change keeps the existing unwrap behavior, but copies the outer `messageContextInfo` onto the unwrapped message when the inner message does not already have its own context info. That keeps normal behavior unchanged and avoids overwriting message-local context if WhatsApp provides both.

Manually tested with a linked-device `fromMe: true` message. Before this change, the upsert only included the message content. After this change, it also includes `messageContextInfo.messageSecret`, allowing apps to persist it and use it later for encrypted edit decryption.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves outer message fields when unwrapping `deviceSentMessage` so context and metadata (e.g., `messageContextInfo.messageSecret`) are retained. Fixes decryption of encrypted edits for linked-device `fromMe: true` messages.

- **Bug Fixes**
  - Merge inner message with outer (excluding `deviceSentMessage`) so outer fields persist unless overridden.
  - Ensures `messages.upsert` includes the original `messageSecret` for later edit decryption.

<sup>Written for commit cfb230422df40d1a8957bdefc2d21024dea96bcf. Summary will update on new commits. <a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2566?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve outer message metadata when using inner message content during decryption, ensuring messageContextInfo and related fields are retained.
  * Improves reliability of decrypted messages so metadata and content remain consistent for display and processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->