### PR TITLE
Remove unused Long import from messages-recv.ts

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1,7 +1,6 @@
 import NodeCache from '@cacheable/node-cache'
 import { Boom } from '@hapi/boom'
 import { randomBytes } from 'crypto'
-import Long from 'long'
 import { proto } from '../../WAProto/index.js'
 import {
 	DEFAULT_CACHE_TTLS,


### PR DESCRIPTION
fix: remove unused Long import causing missing dependency issues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an unused `long` import from `src/Socket/messages-recv.ts` to prevent missing dependency errors and clean up the build. No runtime changes.

<sup>Written for commit a8a900277d0447b38be948657dec56fa143e41ca. Summary will update on new commits. <a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2567?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->