### PR TITLE
fix: make inbound acks fire-and-forget

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -564,16 +564,16 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 	}
 
-	const sendMessageAck = (node: BinaryNode, errorCode?: number) => {
+	const sendMessageAck = (node: BinaryNode, errorCode?: number): Promise<void> => {
 		if (!ws.isOpen) {
 			logger.debug({ recv: node.attrs }, 'dropping ack because socket closed')
-			return
+			return Promise.resolve()
 		}
 
 		const stanza = buildAckStanza(node, errorCode, authState.creds.me!.id)
 
-		void sendNode(stanza).catch(err => {
-			if (isConnectionClosedError(err)) {
+		return sendNode(stanza).catch(err => {
+			if (!ws.isOpen || isConnectionClosedError(err)) {
 				logger.debug({ recv: node.attrs, ack: stanza.attrs }, 'dropping ack because socket closed')
 				return
 			}
@@ -1578,7 +1578,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				})
 			])
 		} finally {
-			sendMessageAck(node)
+			void sendMessageAck(node)
 		}
 	}
 
@@ -1611,7 +1611,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				})
 			])
 		} finally {
-			sendMessageAck(node)
+			void sendMessageAck(node)
 		}
 	}
 
@@ -1620,7 +1620,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		// TODO: temporary fix for crashes and issues resulting of failed msmsg decryption
 		if (encNode?.attrs.type === 'msmsg') {
 			logger.debug({ key: node.attrs.key }, 'ignored msmsg')
-			sendMessageAck(node, NACK_REASONS.MissingMessageSecret)
+			void sendMessageAck(node, NACK_REASONS.MissingMessageSecret)
 			return
 		}
 
@@ -1661,7 +1661,8 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				if (msg.messageStubType === proto.WebMessageInfo.StubType.CIPHERTEXT && msg.category !== 'peer') {
 					if (msg?.messageStubParameters?.[0] === MISSING_KEYS_ERROR_TEXT) {
 						acked = true
-						return sendMessageAck(node, NACK_REASONS.ParsingError)
+						void sendMessageAck(node, NACK_REASONS.ParsingError)
+						return
 					}
 
 					if (msg.messageStubParameters?.[0] === NO_MESSAGE_FOUND_ERROR_TEXT) {
@@ -1679,14 +1680,16 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 								'skipping placeholder resend for excluded unavailable type'
 							)
 							acked = true
-							return sendMessageAck(node)
+							void sendMessageAck(node)
+							return
 						}
 
 						const messageAge = unixTimestampSeconds() - toNumber(msg.messageTimestamp)
 						if (messageAge > PLACEHOLDER_MAX_AGE_SECONDS) {
 							logger.debug({ msgId: msg.key.id, messageAge }, 'skipping placeholder resend for old message')
 							acked = true
-							return sendMessageAck(node)
+							void sendMessageAck(node)
+							return
 						}
 
 						// Request the real content from the phone via placeholder resend PDO.
@@ -1724,7 +1727,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 								logger.warn({ err, msgId: msg.key.id }, 'failed to request placeholder resend for unavailable message')
 							})
 						acked = true
-						sendMessageAck(node)
+						void sendMessageAck(node)
 						// Don't return — fall through to upsertMessage so the stub is emitted
 					} else {
 						// Skip retry for expired status messages (>24h old)
@@ -1736,7 +1739,8 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 									'skipping retry for expired status message'
 								)
 								acked = true
-								return sendMessageAck(node)
+								void sendMessageAck(node)
+								return
 							}
 						}
 
@@ -1760,7 +1764,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 							}
 
 							acked = true
-							sendMessageAck(node, NACK_REASONS.UnhandledError)
+							void sendMessageAck(node, NACK_REASONS.UnhandledError)
 						})
 					}
 				} else {
@@ -1798,7 +1802,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 						}
 					} else {
 						acked = true
-						sendMessageAck(node)
+						void sendMessageAck(node)
 						logger.debug({ key: msg.key }, 'processed newsletter message without receipts')
 					}
 				}
@@ -1810,7 +1814,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		} catch (error) {
 			logger.error({ error, node: binaryNodeToString(node) }, 'error in handling message')
 			if (!acked) {
-				sendMessageAck(node, NACK_REASONS.UnhandledError)
+				void sendMessageAck(node, NACK_REASONS.UnhandledError)
 			}
 		}
 	}
@@ -1872,7 +1876,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		} catch (error) {
 			logger.error({ error, node: binaryNodeToString(node) }, 'error in handling call')
 		} finally {
-			sendMessageAck(node)
+			void sendMessageAck(node)
 		}
 	}
 
@@ -2013,7 +2017,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 
 		if (ignoreJid && ignoreJid !== S_WHATSAPP_NET && shouldIgnoreJid(ignoreJid)) {
-			sendMessageAck(node, type === 'message' ? NACK_REASONS.UnhandledError : undefined)
+			void sendMessageAck(node, type === 'message' ? NACK_REASONS.UnhandledError : undefined)
 			return
 		}
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -22,7 +22,7 @@ import type {
 	WAMessageKey,
 	WAPatchName
 } from '../Types'
-import { DisconnectReason, ReachoutTimelockEnforcementType, WAMessageStatus, WAMessageStubType } from '../Types'
+import { ReachoutTimelockEnforcementType, WAMessageStatus, WAMessageStubType } from '../Types'
 import {
 	ACCOUNT_RESTRICTED_TEXT,
 	aesDecryptCTR,
@@ -44,6 +44,7 @@ import {
 	getStatusFromReceiptType,
 	handleIdentityChange,
 	hkdf,
+	isConnectionClosedError,
 	MISSING_KEYS_ERROR_TEXT,
 	NACK_REASONS,
 	NO_MESSAGE_FOUND_ERROR_TEXT,
@@ -101,31 +102,10 @@ type ReachoutTimelockNotificationPayload = {
 	time_enforcement_ends?: string
 }
 
-type SocketWriteError = {
-	code?: unknown
-	output?: {
-		statusCode?: unknown
-	}
-}
-
 const ENFORCEMENT_TYPE_VALUES = new Set<string>(Object.values(ReachoutTimelockEnforcementType))
 
 function isValidEnforcementType(value: string | undefined): value is ReachoutTimelockEnforcementType {
 	return typeof value === 'string' && ENFORCEMENT_TYPE_VALUES.has(value)
-}
-
-function isConnectionClosedError(error: unknown) {
-	if (!error || typeof error !== 'object') {
-		return false
-	}
-
-	const err = error as SocketWriteError
-	return (
-		err.output?.statusCode === DisconnectReason.connectionClosed ||
-		err.code === 'ECONNRESET' ||
-		err.code === 'EPIPE' ||
-		err.code === 'ECONNABORTED'
-	)
 }
 
 export const makeMessagesRecvSocket = (config: SocketConfig) => {

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -564,17 +564,15 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 	}
 
-	const sendMessageAck = (node: BinaryNode, errorCode?: number): Promise<void> => {
-		if (!ws.isOpen) {
-			logger.debug({ recv: node.attrs }, 'dropping ack because socket closed')
-			return Promise.resolve()
-		}
-
+	const sendMessageAck = async (node: BinaryNode, errorCode?: number): Promise<void> => {
 		const stanza = buildAckStanza(node, errorCode, authState.creds.me!.id)
+		await sendNode(stanza)
+	}
 
-		return sendNode(stanza).catch(err => {
+	const sendMessageAckFireAndForget = (node: BinaryNode, errorCode?: number) => {
+		void sendMessageAck(node, errorCode).catch(err => {
 			if (!ws.isOpen || isConnectionClosedError(err)) {
-				logger.debug({ recv: node.attrs, ack: stanza.attrs }, 'dropping ack because socket closed')
+				logger.debug({ recv: node.attrs }, 'dropping ack because socket closed')
 				return
 			}
 
@@ -1578,7 +1576,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				})
 			])
 		} finally {
-			void sendMessageAck(node)
+			sendMessageAckFireAndForget(node)
 		}
 	}
 
@@ -1611,7 +1609,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				})
 			])
 		} finally {
-			void sendMessageAck(node)
+			sendMessageAckFireAndForget(node)
 		}
 	}
 
@@ -1620,7 +1618,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		// TODO: temporary fix for crashes and issues resulting of failed msmsg decryption
 		if (encNode?.attrs.type === 'msmsg') {
 			logger.debug({ key: node.attrs.key }, 'ignored msmsg')
-			void sendMessageAck(node, NACK_REASONS.MissingMessageSecret)
+			sendMessageAckFireAndForget(node, NACK_REASONS.MissingMessageSecret)
 			return
 		}
 
@@ -1661,7 +1659,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				if (msg.messageStubType === proto.WebMessageInfo.StubType.CIPHERTEXT && msg.category !== 'peer') {
 					if (msg?.messageStubParameters?.[0] === MISSING_KEYS_ERROR_TEXT) {
 						acked = true
-						void sendMessageAck(node, NACK_REASONS.ParsingError)
+						sendMessageAckFireAndForget(node, NACK_REASONS.ParsingError)
 						return
 					}
 
@@ -1680,7 +1678,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 								'skipping placeholder resend for excluded unavailable type'
 							)
 							acked = true
-							void sendMessageAck(node)
+							sendMessageAckFireAndForget(node)
 							return
 						}
 
@@ -1688,7 +1686,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 						if (messageAge > PLACEHOLDER_MAX_AGE_SECONDS) {
 							logger.debug({ msgId: msg.key.id, messageAge }, 'skipping placeholder resend for old message')
 							acked = true
-							void sendMessageAck(node)
+							sendMessageAckFireAndForget(node)
 							return
 						}
 
@@ -1727,7 +1725,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 								logger.warn({ err, msgId: msg.key.id }, 'failed to request placeholder resend for unavailable message')
 							})
 						acked = true
-						void sendMessageAck(node)
+						sendMessageAckFireAndForget(node)
 						// Don't return — fall through to upsertMessage so the stub is emitted
 					} else {
 						// Skip retry for expired status messages (>24h old)
@@ -1739,7 +1737,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 									'skipping retry for expired status message'
 								)
 								acked = true
-								void sendMessageAck(node)
+								sendMessageAckFireAndForget(node)
 								return
 							}
 						}
@@ -1764,7 +1762,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 							}
 
 							acked = true
-							void sendMessageAck(node, NACK_REASONS.UnhandledError)
+							sendMessageAckFireAndForget(node, NACK_REASONS.UnhandledError)
 						})
 					}
 				} else {
@@ -1802,7 +1800,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 						}
 					} else {
 						acked = true
-						void sendMessageAck(node)
+						sendMessageAckFireAndForget(node)
 						logger.debug({ key: msg.key }, 'processed newsletter message without receipts')
 					}
 				}
@@ -1814,7 +1812,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		} catch (error) {
 			logger.error({ error, node: binaryNodeToString(node) }, 'error in handling message')
 			if (!acked) {
-				void sendMessageAck(node, NACK_REASONS.UnhandledError)
+				sendMessageAckFireAndForget(node, NACK_REASONS.UnhandledError)
 			}
 		}
 	}
@@ -1876,7 +1874,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		} catch (error) {
 			logger.error({ error, node: binaryNodeToString(node) }, 'error in handling call')
 		} finally {
-			void sendMessageAck(node)
+			sendMessageAckFireAndForget(node)
 		}
 	}
 
@@ -2017,7 +2015,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 
 		if (ignoreJid && ignoreJid !== S_WHATSAPP_NET && shouldIgnoreJid(ignoreJid)) {
-			void sendMessageAck(node, type === 'message' ? NACK_REASONS.UnhandledError : undefined)
+			sendMessageAckFireAndForget(node, type === 'message' ? NACK_REASONS.UnhandledError : undefined)
 			return
 		}
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -22,7 +22,7 @@ import type {
 	WAMessageKey,
 	WAPatchName
 } from '../Types'
-import { ReachoutTimelockEnforcementType, WAMessageStatus, WAMessageStubType } from '../Types'
+import { DisconnectReason, ReachoutTimelockEnforcementType, WAMessageStatus, WAMessageStubType } from '../Types'
 import {
 	ACCOUNT_RESTRICTED_TEXT,
 	aesDecryptCTR,
@@ -101,10 +101,31 @@ type ReachoutTimelockNotificationPayload = {
 	time_enforcement_ends?: string
 }
 
+type SocketWriteError = {
+	code?: unknown
+	output?: {
+		statusCode?: unknown
+	}
+}
+
 const ENFORCEMENT_TYPE_VALUES = new Set<string>(Object.values(ReachoutTimelockEnforcementType))
 
 function isValidEnforcementType(value: string | undefined): value is ReachoutTimelockEnforcementType {
 	return typeof value === 'string' && ENFORCEMENT_TYPE_VALUES.has(value)
+}
+
+function isConnectionClosedError(error: unknown) {
+	if (!error || typeof error !== 'object') {
+		return false
+	}
+
+	const err = error as SocketWriteError
+	return (
+		err.output?.statusCode === DisconnectReason.connectionClosed ||
+		err.code === 'ECONNRESET' ||
+		err.code === 'EPIPE' ||
+		err.code === 'ECONNABORTED'
+	)
 }
 
 export const makeMessagesRecvSocket = (config: SocketConfig) => {
@@ -543,10 +564,22 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 	}
 
-	const sendMessageAck = async (node: BinaryNode, errorCode?: number) => {
+	const sendMessageAck = (node: BinaryNode, errorCode?: number) => {
+		if (!ws.isOpen) {
+			logger.debug({ recv: node.attrs }, 'dropping ack because socket closed')
+			return
+		}
+
 		const stanza = buildAckStanza(node, errorCode, authState.creds.me!.id)
-		logger.debug({ recv: { tag: node.tag, attrs: node.attrs }, sent: stanza.attrs }, 'sent ack')
-		await sendNode(stanza)
+
+		void sendNode(stanza).catch(err => {
+			if (isConnectionClosedError(err)) {
+				logger.debug({ recv: node.attrs, ack: stanza.attrs }, 'dropping ack because socket closed')
+				return
+			}
+
+			onUnexpectedError(err, 'send ack')
+		})
 	}
 
 	const rejectCall = async (callId: string, callFrom: string) => {
@@ -1545,7 +1578,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				})
 			])
 		} finally {
-			await sendMessageAck(node).catch(ackErr => logger.error({ ackErr }, 'failed to ack receipt'))
+			sendMessageAck(node)
 		}
 	}
 
@@ -1578,7 +1611,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				})
 			])
 		} finally {
-			await sendMessageAck(node).catch(ackErr => logger.error({ ackErr }, 'failed to ack notification'))
+			sendMessageAck(node)
 		}
 	}
 
@@ -1587,7 +1620,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		// TODO: temporary fix for crashes and issues resulting of failed msmsg decryption
 		if (encNode?.attrs.type === 'msmsg') {
 			logger.debug({ key: node.attrs.key }, 'ignored msmsg')
-			await sendMessageAck(node, NACK_REASONS.MissingMessageSecret)
+			sendMessageAck(node, NACK_REASONS.MissingMessageSecret)
 			return
 		}
 
@@ -1691,7 +1724,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 								logger.warn({ err, msgId: msg.key.id }, 'failed to request placeholder resend for unavailable message')
 							})
 						acked = true
-						await sendMessageAck(node)
+						sendMessageAck(node)
 						// Don't return — fall through to upsertMessage so the stub is emitted
 					} else {
 						// Skip retry for expired status messages (>24h old)
@@ -1727,7 +1760,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 							}
 
 							acked = true
-							await sendMessageAck(node, NACK_REASONS.UnhandledError)
+							sendMessageAck(node, NACK_REASONS.UnhandledError)
 						})
 					}
 				} else {
@@ -1765,7 +1798,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 						}
 					} else {
 						acked = true
-						await sendMessageAck(node)
+						sendMessageAck(node)
 						logger.debug({ key: msg.key }, 'processed newsletter message without receipts')
 					}
 				}
@@ -1777,9 +1810,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		} catch (error) {
 			logger.error({ error, node: binaryNodeToString(node) }, 'error in handling message')
 			if (!acked) {
-				await sendMessageAck(node, NACK_REASONS.UnhandledError).catch(ackErr =>
-					logger.error({ ackErr }, 'failed to ack message after error')
-				)
+				sendMessageAck(node, NACK_REASONS.UnhandledError)
 			}
 		}
 	}
@@ -1841,7 +1872,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		} catch (error) {
 			logger.error({ error, node: binaryNodeToString(node) }, 'error in handling call')
 		} finally {
-			await sendMessageAck(node).catch(ackErr => logger.error({ ackErr }, 'failed to ack call'))
+			sendMessageAck(node)
 		}
 	}
 
@@ -1982,7 +2013,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 
 		if (ignoreJid && ignoreJid !== S_WHATSAPP_NET && shouldIgnoreJid(ignoreJid)) {
-			await sendMessageAck(node, type === 'message' ? NACK_REASONS.UnhandledError : undefined)
+			sendMessageAck(node, type === 'message' ? NACK_REASONS.UnhandledError : undefined)
 			return
 		}
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -564,8 +564,9 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 	}
 
-	const sendMessageAck = async (node: BinaryNode, errorCode?: number): Promise<void> => {
+	const sendMessageAck = async (node: BinaryNode, errorCode?: number) => {
 		const stanza = buildAckStanza(node, errorCode, authState.creds.me!.id)
+		logger.debug({ recv: { tag: node.tag, attrs: node.attrs }, sent: stanza.attrs }, 'sent ack')
 		await sendNode(stanza)
 	}
 

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -231,6 +231,26 @@ export function bindWaitForEvent<T extends keyof BaileysEventMap>(ev: BaileysEve
 
 export const bindWaitForConnectionUpdate = (ev: BaileysEventEmitter) => bindWaitForEvent(ev, 'connection.update')
 
+export function isConnectionClosedError(error: unknown) {
+	if (!error || typeof error !== 'object') {
+		return false
+	}
+
+	const err = error as {
+		code?: unknown
+		output?: {
+			statusCode?: unknown
+		}
+	}
+
+	return (
+		err.output?.statusCode === DisconnectReason.connectionClosed ||
+		err.code === 'ECONNRESET' ||
+		err.code === 'EPIPE' ||
+		err.code === 'ECONNABORTED'
+	)
+}
+
 /**
  * utility that fetches latest baileys version from the master branch.
  * Use to ensure your WA connection is always on the latest version


### PR DESCRIPTION
This fixes a receive-path issue where sending an ACK/NACK for an inbound stanza could block or surface errors after the websocket was already closing.

Inbound message/receipt/notification/call ACKs are now sent fire-and-forget internally, matching WA Web`castStanza` behavior for returned handler ACKs. The exported `sendMessageAck` method remains awaitable and keeps its existing rejection behavior for callers.

SynchronousAck is false by default in whatsmeow too.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make inbound stanza ACK/NACK sending fire-and-forget to avoid blocking and noisy errors when the websocket is closing. The public `sendMessageAck` remains awaitable and keeps its existing rejection behavior.

- **Bug Fixes**
  - Send message/receipt/notification/call ACKs asynchronously in the receive path; do not await.
  - Add `isConnectionClosedError` and drop ACKs when the socket is closed (log at debug).
  - Align internal behavior with WA Web `castStanza` for handler ACKs.
  - Preserve API: exported `sendMessageAck` still returns a promise and rejects on failure.

<sup>Written for commit a49c67da5388d50729564fc8ad9209b11a8b64dd. Summary will update on new commits. <a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2568?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized message acknowledgment processing to prevent blocking the main processing flow, improving overall responsiveness.
  * Enhanced connection error detection to better identify and handle connection-closed scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->