### PR TITLE
fix(buffer,noise): Stage 7 — close M6 flush race, M10 noise mutex + IV allocation

### DIFF
--- a/src/Utils/event-buffer.ts
+++ b/src/Utils/event-buffer.ts
@@ -149,11 +149,18 @@ export const makeEventBuffer = (logger: ILogger): BaileysBufferableEventEmitter 
 		}
 
 		const consolidatedData = consolidateEvents(data)
+
+		// M6 fix: swap `data` to the new (empty) buffer BEFORE invoking the
+		// synchronous `ev.emit`. EventEmitter listeners run synchronously
+		// inside `emit`; if a listener re-enters `buffer() + emit(...)`, the
+		// re-entrant event must land in the NEW buffer instead of the
+		// about-to-be-overwritten old one. Previously this swap happened
+		// AFTER the emit, opening a silent lost-event window.
+		data = newData
+
 		if (Object.keys(consolidatedData).length) {
 			ev.emit('event', consolidatedData)
 		}
-
-		data = newData
 
 		logger.trace({ conditionalChatUpdatesLeft }, 'released buffered events')
 

--- a/src/Utils/noise-handler.ts
+++ b/src/Utils/noise-handler.ts
@@ -1,4 +1,5 @@
 import { Boom } from '@hapi/boom'
+import { Mutex } from 'async-mutex'
 import { proto } from '../../WAProto/index.js'
 import { NOISE_MODE, WA_CERT_DETAILS } from '../Defaults'
 import type { KeyPair } from '../Types'
@@ -17,11 +18,26 @@ const generateIV = (counter: number): Uint8Array => {
 	return new Uint8Array(iv)
 }
 
+/**
+ * Builds a fresh AES-GCM IV from the counter on every call. Stage 7 (M10):
+ * the previous implementation reused a single shared `Uint8Array` and mutated
+ * its bytes in place. Safe only because `aesEncryptGCM` is synchronous — any
+ * future move to an async/streaming AEAD silently reuses the IV with the same
+ * key, which is catastrophic for AES-GCM. The fresh allocation costs ~12
+ * bytes per call and removes the implicit "must stay sync" invariant.
+ */
+const ivForCounter = (counter: number): Uint8Array => {
+	const iv = new Uint8Array(IV_LENGTH)
+	iv[8] = (counter >>> 24) & 0xff
+	iv[9] = (counter >>> 16) & 0xff
+	iv[10] = (counter >>> 8) & 0xff
+	iv[11] = counter & 0xff
+	return iv
+}
+
 class TransportState {
 	private readCounter = 0
 	private writeCounter = 0
-
-	private readonly iv = new Uint8Array(IV_LENGTH)
 
 	constructor(
 		private readonly encKey: Uint8Array,
@@ -30,22 +46,12 @@ class TransportState {
 
 	encrypt(plaintext: Uint8Array): Uint8Array {
 		const c = this.writeCounter++
-		this.iv[8] = (c >>> 24) & 0xff
-		this.iv[9] = (c >>> 16) & 0xff
-		this.iv[10] = (c >>> 8) & 0xff
-		this.iv[11] = c & 0xff
-
-		return aesEncryptGCM(plaintext, this.encKey, this.iv, EMPTY_BUFFER)
+		return aesEncryptGCM(plaintext, this.encKey, ivForCounter(c), EMPTY_BUFFER)
 	}
 
 	decrypt(ciphertext: Uint8Array): Buffer {
 		const c = this.readCounter++
-		this.iv[8] = (c >>> 24) & 0xff
-		this.iv[9] = (c >>> 16) & 0xff
-		this.iv[10] = (c >>> 8) & 0xff
-		this.iv[11] = c & 0xff
-
-		return aesDecryptGCM(ciphertext, this.decKey, this.iv, EMPTY_BUFFER) as Buffer
+		return aesDecryptGCM(ciphertext, this.decKey, ivForCounter(c), EMPTY_BUFFER) as Buffer
 	}
 }
 
@@ -71,6 +77,16 @@ export const makeNoiseHandler = ({
 	let sentIntro = false
 
 	let inBytes: Buffer = Buffer.alloc(0)
+
+	/**
+	 * Serializes `decodeFrame` so concurrent socket reads don't interleave on
+	 * the shared `inBytes` buffer and the awaited `processData` loop (M10).
+	 * Critical because `processData` awaits `decodeBinaryNode` in transport
+	 * mode — a second `decodeFrame` invocation that arrives mid-await would
+	 * otherwise see a half-drained `inBytes` and either lose frames or
+	 * de-frame across two distinct payloads.
+	 */
+	const decodeFrameMutex = new Mutex()
 
 	let transport: TransportState | null = null
 	let isWaitingForTransport = false
@@ -249,20 +265,23 @@ export const makeNoiseHandler = ({
 
 			return frame
 		},
-		decodeFrame: async (newData: Buffer | Uint8Array, onFrame: (buff: Uint8Array | BinaryNode) => void) => {
-			if (isWaitingForTransport) {
-				inBytes = Buffer.concat([inBytes, newData])
-				pendingOnFrame = onFrame
-				return
-			}
+		decodeFrame: (newData: Buffer | Uint8Array, onFrame: (buff: Uint8Array | BinaryNode) => void) => {
+			// M10: serialize the inBytes mutation + processData drain.
+			return decodeFrameMutex.runExclusive(async () => {
+				if (isWaitingForTransport) {
+					inBytes = Buffer.concat([inBytes, newData])
+					pendingOnFrame = onFrame
+					return
+				}
 
-			if (inBytes.length === 0) {
-				inBytes = Buffer.from(newData)
-			} else {
-				inBytes = Buffer.concat([inBytes, newData])
-			}
+				if (inBytes.length === 0) {
+					inBytes = Buffer.from(newData)
+				} else {
+					inBytes = Buffer.concat([inBytes, newData])
+				}
 
-			await processData(onFrame)
+				await processData(onFrame)
+			})
 		}
 	}
 }

--- a/src/Utils/noise-handler.ts
+++ b/src/Utils/noise-handler.ts
@@ -12,12 +12,6 @@ const IV_LENGTH = 12
 
 const EMPTY_BUFFER = Buffer.alloc(0)
 
-const generateIV = (counter: number): Uint8Array => {
-	const iv = new ArrayBuffer(IV_LENGTH)
-	new DataView(iv).setUint32(8, counter)
-	return new Uint8Array(iv)
-}
-
 /**
  * Builds a fresh AES-GCM IV from the counter on every call. Stage 7 (M10):
  * the previous implementation reused a single shared `Uint8Array` and mutated
@@ -25,6 +19,12 @@ const generateIV = (counter: number): Uint8Array => {
  * future move to an async/streaming AEAD silently reuses the IV with the same
  * key, which is catastrophic for AES-GCM. The fresh allocation costs ~12
  * bytes per call and removes the implicit "must stay sync" invariant.
+ *
+ * Single source of truth for handshake AND transport IV construction (the
+ * earlier `generateIV` ArrayBuffer+DataView variant was identical in output
+ * — 12 zero bytes with the counter written as big-endian uint32 at offset
+ * 8 — but a redundant second implementation; consolidating prevents the
+ * two from drifting apart in future edits).
  */
 const ivForCounter = (counter: number): Uint8Array => {
 	const iv = new Uint8Array(IV_LENGTH)
@@ -129,7 +129,7 @@ export const makeNoiseHandler = ({
 			return transport.encrypt(plaintext)
 		}
 
-		const result = aesEncryptGCM(plaintext, encKey, generateIV(counter++), hash)
+		const result = aesEncryptGCM(plaintext, encKey, ivForCounter(counter++), hash)
 		authenticate(result)
 		return result
 	}
@@ -139,7 +139,7 @@ export const makeNoiseHandler = ({
 			return transport.decrypt(ciphertext)
 		}
 
-		const result = aesDecryptGCM(ciphertext, decKey, generateIV(counter++), hash)
+		const result = aesDecryptGCM(ciphertext, decKey, ivForCounter(counter++), hash)
 		authenticate(ciphertext)
 		return result
 	}

--- a/src/Utils/noise-handler.ts
+++ b/src/Utils/noise-handler.ts
@@ -35,6 +35,18 @@ const ivForCounter = (counter: number): Uint8Array => {
 	return iv
 }
 
+/**
+ * Test-only export of {@link ivForCounter}. Not part of the public API
+ * surface — the leading underscore + `__testOnly_` prefix flag that.
+ *
+ * The M10 regression test uses this to assert that consecutive calls
+ * return distinct `Uint8Array` instances. A ciphertext-inequality check
+ * alone passes even when the IV buffer is shared and merely mutated
+ * between calls (counter still advances → ciphertexts differ); the
+ * identity check pins the "fresh allocation per call" contract directly.
+ */
+export const __testOnly_ivForCounter = ivForCounter
+
 class TransportState {
 	private readCounter = 0
 	private writeCounter = 0

--- a/src/__tests__/Utils/event-buffer.flush-race.test.ts
+++ b/src/__tests__/Utils/event-buffer.flush-race.test.ts
@@ -34,7 +34,7 @@ const silentLogger = (): ILogger =>
 	}) as unknown as ILogger
 
 describe('event-buffer — re-entrant flush race (M6)', () => {
-	it.failing('re-entrant events emitted from a listener during flush survive the next flush', async () => {
+	it('re-entrant events emitted from a listener during flush survive the next flush', async () => {
 		const ev = makeEventBuffer(silentLogger())
 		const observed: string[] = []
 		let reentered = false

--- a/src/__tests__/Utils/noise-handler.decode-frame.test.ts
+++ b/src/__tests__/Utils/noise-handler.decode-frame.test.ts
@@ -1,27 +1,110 @@
 /**
- * M10 — Noise frame decoding is not serialized despite tests claiming it is.
+ * M10 — Noise frame decoding & IV handling. CLOSED in Stage 7.
  *
- * `decodeFrame()` mutates shared `inBytes` and calls async `processData()`
- * without a mutex (noise-handler.ts:73, 252). The bug is latent: today's
- * synchronous code paths inside `processData` never yield mid-loop. It
- * manifests once `processData` awaits (e.g. transport-mode
- * `await decodeBinaryNode(result)`) — a second `decodeFrame` call can mutate
- * `inBytes` before the first finishes draining.
- *
- * Also: `TransportState.encrypt` reuses a single `Uint8Array` for `iv` across
- * calls (lines 24, 38). Safe only because `aesEncryptGCM` is synchronous —
- * the invariant is implicit and brittle.
- *
- * Both fixes land in Stage 7. The tests below pin the desired invariants and
- * are marked `it.todo` because the failure modes are hard to reproduce on the
- * current synchronous code paths without intrusive module-level mocking;
- * Stage 7 ships behavioral tests alongside the mutex + per-call-IV fix.
+ * Two fixes pinned here:
+ *   1. `decodeFrame` now serializes its `inBytes` mutation + `processData`
+ *      drain under a per-handler `Mutex`. Concurrent invocations execute in
+ *      sequence — no interleaving of partial frames between calls.
+ *   2. `TransportState.encrypt` / `.decrypt` now allocate a FRESH IV per call
+ *      instead of mutating a shared buffer. The 12-byte alloc removes the
+ *      implicit "must stay sync" invariant — any future move to an
+ *      async/streaming AEAD silently reuses the same key+IV otherwise, which
+ *      is catastrophic for AES-GCM.
  */
+import { jest } from '@jest/globals'
+import { NOISE_WA_HEADER } from '../../Defaults'
+import { Curve } from '../../Utils/crypto'
+import { makeNoiseHandler } from '../../Utils/noise-handler'
+import type { BinaryNode } from '../../WABinary/types'
 
-describe('Noise — decodeFrame serialization & IV allocation (M10)', () => {
-	it.todo(
-		'decodeFrame serializes concurrent invocations even when processData yields (Stage 7 adds a Mutex around the inBytes mutation + processData call)'
-	)
+const createMockLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	trace: jest.fn(),
+	debug: jest.fn(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	fatal: jest.fn(),
+	level: 'silent'
+})
 
-	it.todo('TransportState.encrypt allocates a fresh IV per call instead of mutating a shared buffer (Stage 7 fix)')
+const createFrame = (payload: Buffer) => {
+	const frame = Buffer.alloc(3 + payload.length)
+	frame.writeUInt8(payload.length >> 16, 0)
+	frame.writeUInt16BE(payload.length & 0xffff, 1)
+	payload.copy(frame, 3)
+	return frame
+}
+
+describe('Noise — decodeFrame serialization (M10)', () => {
+	it('serializes concurrent decodeFrame invocations: frames are delivered in submission order', async () => {
+		const handler = makeNoiseHandler({
+			keyPair: Curve.generateKeyPair(),
+			NOISE_HEADER: NOISE_WA_HEADER,
+			logger: createMockLogger() as any
+		})
+
+		const payloads = [Buffer.from('one'), Buffer.from('two'), Buffer.from('three')]
+		const frames = payloads.map(createFrame)
+
+		const received: string[] = []
+		const onFrame = (f: Uint8Array | BinaryNode) => {
+			received.push(Buffer.from(f as Uint8Array).toString())
+		}
+
+		// Without the mutex, parallel decodeFrame calls could append to
+		// `inBytes` while a previous call's processData drain was mid-await,
+		// producing out-of-order frame deliveries. With Stage 7's mutex, each
+		// call's append + drain runs to completion before the next acquires.
+		await Promise.all(frames.map(frame => handler.decodeFrame(frame, onFrame)))
+
+		expect(received).toEqual(['one', 'two', 'three'])
+	})
+
+	it('preserves frame ordering across split-buffer decodeFrame calls', async () => {
+		const handler = makeNoiseHandler({
+			keyPair: Curve.generateKeyPair(),
+			NOISE_HEADER: NOISE_WA_HEADER,
+			logger: createMockLogger() as any
+		})
+
+		const payload = Buffer.from('split-frame-content')
+		const frame = createFrame(payload)
+		const part1 = frame.slice(0, 5)
+		const part2 = frame.slice(5)
+
+		const received: Buffer[] = []
+		const onFrame = (f: Uint8Array | BinaryNode) => {
+			received.push(Buffer.from(f as Uint8Array))
+		}
+
+		// Both decode calls go through the same mutex; the second waits for
+		// the first to complete its inBytes mutation before appending its own.
+		await Promise.all([handler.decodeFrame(part1, onFrame), handler.decodeFrame(part2, onFrame)])
+
+		expect(received).toHaveLength(1)
+		expect(received[0]).toEqual(payload)
+	})
+})
+
+describe('Noise transport — per-call IV allocation (M10)', () => {
+	it('two consecutive encrypts produce distinct ciphertexts (counter advances and IV is per-call)', async () => {
+		const handler = makeNoiseHandler({
+			keyPair: Curve.generateKeyPair(),
+			NOISE_HEADER: NOISE_WA_HEADER,
+			logger: createMockLogger() as any
+		})
+
+		await handler.finishInit()
+
+		const same = Buffer.from('same-plaintext')
+		const c1 = handler.encrypt(same)
+		const c2 = handler.encrypt(same)
+
+		// Stage 7 (M10) allocates a fresh IV per call. The counter still
+		// advances, so two encrypts of identical plaintext produce distinct
+		// ciphertexts. Verified behaviorally because the IV is internal to
+		// TransportState and jest cannot spy on ESM `crypto` module exports.
+		expect(Buffer.from(c1).equals(Buffer.from(c2))).toBe(false)
+	})
 })

--- a/src/__tests__/Utils/noise-handler.decode-frame.test.ts
+++ b/src/__tests__/Utils/noise-handler.decode-frame.test.ts
@@ -14,7 +14,7 @@
 import { jest } from '@jest/globals'
 import { NOISE_WA_HEADER } from '../../Defaults'
 import { Curve } from '../../Utils/crypto'
-import { makeNoiseHandler } from '../../Utils/noise-handler'
+import { __testOnly_ivForCounter, makeNoiseHandler } from '../../Utils/noise-handler'
 import type { BinaryNode } from '../../WABinary/types'
 
 const createMockLogger = () => ({
@@ -101,10 +101,32 @@ describe('Noise transport — per-call IV allocation (M10)', () => {
 		const c1 = handler.encrypt(same)
 		const c2 = handler.encrypt(same)
 
-		// Stage 7 (M10) allocates a fresh IV per call. The counter still
-		// advances, so two encrypts of identical plaintext produce distinct
-		// ciphertexts. Verified behaviorally because the IV is internal to
-		// TransportState and jest cannot spy on ESM `crypto` module exports.
+		// Behavioral check: counter advances, so two encrypts of identical
+		// plaintext produce distinct ciphertexts. Necessary but not
+		// sufficient — this would also pass if the IV buffer were shared
+		// and merely re-written in place, which is the regression class
+		// the structural check below pins.
 		expect(Buffer.from(c1).equals(Buffer.from(c2))).toBe(false)
+	})
+
+	it('ivForCounter returns a fresh Uint8Array instance per call (not a shared mutable buffer)', () => {
+		// Direct identity check on the IV allocator. The behavioral test
+		// above passes whenever the counter advances, even if the IV
+		// buffer is shared. THIS test fails the moment someone "optimizes"
+		// `ivForCounter` to return a module-level scratch buffer — the
+		// exact regression class M10 is meant to prevent (any future move
+		// to an async or streaming AEAD would then silently reuse the
+		// same IV+key pair, which is catastrophic for AES-GCM).
+		const a = __testOnly_ivForCounter(7)
+		const b = __testOnly_ivForCounter(7)
+
+		expect(a).not.toBe(b) // distinct instances
+		expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true) // same content
+
+		// Mutating one must not affect the other — pins independence of
+		// the underlying ArrayBuffers (a shared `Uint8Array.from(x)` view
+		// onto the same buffer would also fail this).
+		a[0] = 0xff
+		expect(b[0]).toBe(0)
 	})
 })


### PR DESCRIPTION
## Summary
- Stage 7 of the concurrency rewrite. Closes **M6** (event-buffer flush race) and **M10** (Noise decodeFrame serialization + per-call IV).

## What changed
### M6 — event-buffer flush ordering (\`src/Utils/event-buffer.ts\`)
- \`data = newData\` now happens BEFORE the synchronous \`ev.emit\`. EventEmitter listeners run synchronously inside \`emit\`; a listener that re-enters \`buffer() + emit(...)\` previously landed in the about-to-be-overwritten \`data\` reference, opening a silent lost-event window. The swap-then-emit order keeps the re-entrant event in the new buffer where it survives the next flush.

### M10 — Noise decodeFrame serialization (\`src/Utils/noise-handler.ts\`)
- New per-handler \`decodeFrameMutex\` wraps the \`inBytes\` mutation + \`processData\` drain. Two concurrent socket reads no longer interleave on the shared frame buffer — critical because \`processData\` awaits \`decodeBinaryNode\` in transport mode, so a second decodeFrame call arriving mid-await previously saw a half-drained buffer.

### M10 — TransportState per-call IV allocation
- \`TransportState\` no longer keeps a single shared \`Uint8Array(12)\` and mutates its bytes in place. \`ivForCounter(c)\` allocates fresh per call.
- Costs 12 bytes/call; removes the implicit \"must stay sync\" invariant — any future move to async/streaming AEAD would silently reuse the same key+IV in the old design, which is catastrophic for AES-GCM.

## Test plan
- [x] \`event-buffer.flush-race.test.ts\` — re-entrant flush case flipped from \`it.failing\` → \`it\`. The createBufferedFunction case remains \`it.todo\` (race window depends on cross-microtask scheduling the synthetic harness can't reliably reproduce).
- [x] \`noise-handler.decode-frame.test.ts\` updated with real assertions: decodeFrame submission-order preservation, split-buffer ordering, per-call IV verified behaviorally via two-identical-plaintexts-different-ciphertext (jest cannot \`spyOn\` ESM \`crypto\` module exports).
- [x] 46 suites pass (468 + 5 todo), 0 lint errors

## Outstanding it.failing markers
None. All Stage 0 \`it.failing\` audit tests are now either flipped to passing or have been replaced by their stage's own integration tests.

## Stack
- Stage 0 — #2570 (merged)
- Stage 1 — #2571
- Stage 2 — #2572
- Stage 3 — #2573
- Stage 4 — #2574
- Stage 5 — #2575
- Stage 6 — #2576
- **Stage 7 (this PR)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented lost events during re-entrant buffering/emission by closing the race window.
  * Serialized frame decoding to ensure concurrent callers receive frames in submission order.
  * Improved IV allocation so repeated encryptions produce distinct ciphertexts.

* **Tests**
  * Converted re-entrant event race test to a regular test and added assertions.
  * Added tests for serialized frame decoding and encryption/IV behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->