### PR TITLE
chore(ops): Stage 9 — runDetached helper, refreshMediaConn + placeholderResend single-flight

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1814,7 +1814,15 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 						await attemptRetryRequest(node)
 
 						acked = true
-						await sendMessageAck(node, NACK_REASONS.UnhandledError)
+						// Skip the ack if the socket is no longer open. Without
+						// this guard, `sendMessageAck` would throw a
+						// `Connection Closed` Boom inside the receive pipeline,
+						// surfacing as an unhandled rejection that interrupts
+						// downstream message handling. The server already moved
+						// on; missing an ack on a closed socket is benign.
+						if (ws.isOpen) {
+							await sendMessageAck(node, NACK_REASONS.UnhandledError)
+						}
 					}
 				} else {
 					if (messageRetryManager && msg.key.id) {

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -163,6 +163,15 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		namespace: 'msg-retry',
 		id: `${msgId}:${participant}`
 	})
+	/**
+	 * Single-flight guard for `requestPlaceholderResend` (Stage 9). The cache-
+	 * based dedupe (\`get → set\`) had a race window: two concurrent calls for
+	 * the same message id could both observe the cache as empty and both
+	 * issue the placeholder resend. The lock collapses the get + set into
+	 * one critical section per id.
+	 */
+	const placeholderResendLocks = makeLockManager()
+
 	const incrementRetryAndGet = async (msgId: string, participant: string): Promise<number> => {
 		return retryLocks.withLock(retryLockRef(msgId, participant), async () => {
 			const key = `${msgId}:${participant}`
@@ -241,14 +250,24 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			throw new Boom('Not authenticated')
 		}
 
-		if (await placeholderResendCache.get(messageKey?.id!)) {
-			logger.debug({ messageKey }, 'already requested resend')
-			return
-		} else {
-			// Store original message data so PDO response handler can preserve
-			// metadata (LID details, timestamps, etc.) that the phone may omit
-			await placeholderResendCache.set(messageKey?.id!, msgData || true)
-		}
+		// Stage 9: collapse the previous \`get → set\` cache-dedupe into one
+		// per-id critical section so two concurrent callers can't both
+		// observe an empty cache and both fire the resend.
+		const alreadyHandled = await placeholderResendLocks.withLock(
+			{ namespace: 'placeholder-resend', id: messageKey?.id ?? '' },
+			async () => {
+				if (await placeholderResendCache.get(messageKey?.id!)) {
+					logger.debug({ messageKey }, 'already requested resend')
+					return true
+				}
+
+				// Store original message data so PDO response handler can preserve
+				// metadata (LID details, timestamps, etc.) that the phone may omit
+				await placeholderResendCache.set(messageKey?.id!, msgData || true)
+				return false
+			}
+		)
+		if (alreadyHandled) return
 
 		await delay(2000)
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -250,20 +250,32 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			throw new Boom('Not authenticated')
 		}
 
-		// Stage 9: collapse the previous \`get → set\` cache-dedupe into one
+		// Guard against an undefined `messageKey.id`. Without this, the lock
+		// would acquire on the empty-string id (serializing every
+		// id-less caller through a single bucket) and the cache get/set
+		// would hit `undefined` as a key. Up the call stack `messageKey`
+		// is non-optional so the `id` check is the only real concern.
+		if (!messageKey.id) {
+			logger.warn({ messageKey }, 'requestPlaceholderResend called with undefined message id')
+			return
+		}
+
+		const resendId = messageKey.id
+
+		// Stage 9: collapse the previous `get → set` cache-dedupe into one
 		// per-id critical section so two concurrent callers can't both
 		// observe an empty cache and both fire the resend.
 		const alreadyHandled = await placeholderResendLocks.withLock(
-			{ namespace: 'placeholder-resend', id: messageKey?.id ?? '' },
+			{ namespace: 'placeholder-resend', id: resendId },
 			async () => {
-				if (await placeholderResendCache.get(messageKey?.id!)) {
+				if (await placeholderResendCache.get(resendId)) {
 					logger.debug({ messageKey }, 'already requested resend')
 					return true
 				}
 
 				// Store original message data so PDO response handler can preserve
 				// metadata (LID details, timestamps, etc.) that the phone may omit
-				await placeholderResendCache.set(messageKey?.id!, msgData || true)
+				await placeholderResendCache.set(resendId, msgData || true)
 				return false
 			}
 		)
@@ -271,7 +283,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 
 		await delay(2000)
 
-		if (!(await placeholderResendCache.get(messageKey?.id!))) {
+		if (!(await placeholderResendCache.get(resendId))) {
 			logger.debug({ messageKey }, 'message received while resend requested')
 			return 'RESOLVED'
 		}
@@ -286,9 +298,9 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 
 		setTimeout(async () => {
-			if (await placeholderResendCache.get(messageKey?.id!)) {
+			if (await placeholderResendCache.get(resendId)) {
 				logger.debug({ messageKey }, 'PDO message without response after 8 seconds. Phone possibly offline')
-				await placeholderResendCache.del(messageKey?.id!)
+				await placeholderResendCache.del(resendId)
 			}
 		}, 8_000)
 

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -33,6 +33,7 @@ import {
 	MessageRetryManager,
 	normalizeMessageContent,
 	parseAndInjectE2ESessions,
+	runDetached,
 	unixTimestampSeconds
 } from '../Utils'
 import { getUrlInfo } from '../Utils/link-preview'
@@ -123,9 +124,27 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	let mediaConn: Promise<MediaConnInfo> | undefined
 	/** Per-socket media host; updated whenever media_conn is fetched. Defaults to the public WhatsApp host. */
 	let mediaHost: string = DEF_MEDIA_HOST
+	/**
+	 * Single-flight guard for the media-conn fetch (Stage 9). Two concurrent
+	 * callers used to both observe `mediaConn` as expired and both reassign
+	 * the in-flight promise, leaking the first fetch's result. The mutex
+	 * ensures only one refresh runs at a time; subsequent callers await the
+	 * one in-flight or reuse the freshly-cached value.
+	 */
+	const mediaConnMutex = makeMutex()
 	const refreshMediaConn = async (forceGet = false): Promise<MediaConnInfo> => {
-		const media = await mediaConn
-		if (!media || forceGet || new Date().getTime() - media.fetchDate.getTime() > media.ttl * 1000) {
+		const cached = await mediaConn
+		if (cached && !forceGet && new Date().getTime() - cached.fetchDate.getTime() <= cached.ttl * 1000) {
+			return cached
+		}
+
+		return mediaConnMutex.mutex(async () => {
+			// Re-check inside the lock: another caller may have refreshed.
+			const after = await mediaConn
+			if (after && !forceGet && new Date().getTime() - after.fetchDate.getTime() <= after.ttl * 1000) {
+				return after
+			}
+
 			mediaConn = (async () => {
 				const result = await query({
 					tag: 'iq',
@@ -137,7 +156,6 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 					content: [{ tag: 'media_conn', attrs: {} }]
 				})
 				const mediaConnNode = getBinaryNodeChild(result, 'media_conn')!
-				// TODO: explore full length of data that whatsapp provides
 				const node: MediaConnInfo = {
 					hosts: getBinaryNodeChildren(mediaConnNode, 'host').map(({ attrs }) => ({
 						hostname: attrs.hostname!,
@@ -154,9 +172,9 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 
 				return node
 			})()
-		}
 
-		return mediaConn!
+			return mediaConn
+		})
 	}
 
 	/**
@@ -1407,9 +1425,17 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 					additionalNodes
 				})
 				if (config.emitOwnEvents) {
-					process.nextTick(async () => {
-						await messageMutex.mutex(() => upsertMessage(fullMsg, 'append'))
-					})
+					// Detached on purpose — `relayMessage` already returned. The
+					// upsert is a best-effort projection into the local event
+					// stream. Stage 9: route through `runDetached` so a
+					// rejection becomes a structured `error` log instead of an
+					// `unhandledRejection`.
+					process.nextTick(() =>
+						runDetached(() => messageMutex.mutex(() => upsertMessage(fullMsg, 'append')), logger, {
+							op: 'emitOwnEvents.upsertMessage',
+							msgId: fullMsg.key.id
+						})
+					)
 				}
 
 				return fullMsg

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -132,15 +132,33 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	 * one in-flight or reuse the freshly-cached value.
 	 */
 	const mediaConnMutex = makeMutex()
+	/**
+	 * Safely await the cached `mediaConn` promise. If a previous fetch
+	 * stored a REJECTED promise, awaiting it again would just rethrow
+	 * forever and poison every subsequent caller with the stale failure
+	 * — there'd be no way to retry. Clear the cache slot on rejection so
+	 * the next caller falls through to a fresh `media_conn` query.
+	 */
+	const safeAwaitMediaConn = async (): Promise<MediaConnInfo | undefined> => {
+		if (!mediaConn) return undefined
+		try {
+			return await mediaConn
+		} catch (err) {
+			logger.warn?.({ err }, 'previous media_conn fetch failed, will retry')
+			mediaConn = undefined
+			return undefined
+		}
+	}
+
 	const refreshMediaConn = async (forceGet = false): Promise<MediaConnInfo> => {
-		const cached = await mediaConn
+		const cached = await safeAwaitMediaConn()
 		if (cached && !forceGet && new Date().getTime() - cached.fetchDate.getTime() <= cached.ttl * 1000) {
 			return cached
 		}
 
 		return mediaConnMutex.mutex(async () => {
 			// Re-check inside the lock: another caller may have refreshed.
-			const after = await mediaConn
+			const after = await safeAwaitMediaConn()
 			if (after && !forceGet && new Date().getTime() - after.fetchDate.getTime() <= after.ttl * 1000) {
 				return after
 			}

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -482,3 +482,39 @@ export function bytesToCrockford(buffer: Buffer): string {
 export function encodeNewsletterMessage(message: proto.IMessage): Uint8Array {
 	return proto.Message.encode(message).finish()
 }
+
+/**
+ * Schedule an async function to run without blocking the caller (`fire and
+ * forget`) — but always log rejections at `warn`/`error` instead of letting
+ * them become silent `unhandledRejection`.
+ *
+ * Used throughout the socket layer to replace ad-hoc patterns like
+ * `void (async () => { ... })()` and `process.nextTick(async () => { ... })`
+ * whose rejections previously only debug-logged (or never surfaced at all).
+ *
+ * @param work the async work to run detached
+ * @param logger child logger to use for error reporting
+ * @param context structured context attached to the log entry (operation
+ *                name, ids, etc.) so operators can correlate the failure
+ *                with the call site
+ */
+export function runDetached(
+	work: () => Promise<unknown>,
+	logger: { warn?: (obj: unknown, msg?: string) => void; error?: (obj: unknown, msg?: string) => void },
+	context: Record<string, unknown> = {}
+): void {
+	let result: Promise<unknown> | undefined
+	try {
+		result = work()
+	} catch (err) {
+		// Synchronous throw from `work` itself (rare — `async` functions wrap in Promise.reject).
+		logger.error?.({ err, ...context }, 'runDetached: detached work threw synchronously')
+		return
+	}
+
+	if (result !== undefined && result !== null) {
+		Promise.resolve(result).catch((err: unknown) => {
+			logger.error?.({ err, ...context }, 'runDetached: detached work rejected')
+		})
+	}
+}

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -508,13 +508,16 @@ export function runDetached(
 		result = work()
 	} catch (err) {
 		// Synchronous throw from `work` itself (rare — `async` functions wrap in Promise.reject).
-		logger.error?.({ err, ...context }, 'runDetached: detached work threw synchronously')
+		// `err` goes LAST so a `context.err` key (e.g. caller passing
+		// `{ err: previousFailure }`) can't overwrite the actual exception
+		// in the structured log.
+		logger.error?.({ ...context, err }, 'runDetached: detached work threw synchronously')
 		return
 	}
 
 	if (result !== undefined && result !== null) {
 		Promise.resolve(result).catch((err: unknown) => {
-			logger.error?.({ err, ...context }, 'runDetached: detached work rejected')
+			logger.error?.({ ...context, err }, 'runDetached: detached work rejected')
 		})
 	}
 }

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -503,21 +503,24 @@ export function runDetached(
 	logger: { warn?: (obj: unknown, msg?: string) => void; error?: (obj: unknown, msg?: string) => void },
 	context: Record<string, unknown> = {}
 ): void {
-	let result: Promise<unknown> | undefined
-	try {
-		result = work()
-	} catch (err) {
-		// Synchronous throw from `work` itself (rare — `async` functions wrap in Promise.reject).
-		// `err` goes LAST so a `context.err` key (e.g. caller passing
-		// `{ err: previousFailure }`) can't overwrite the actual exception
-		// in the structured log.
-		logger.error?.({ ...context, err }, 'runDetached: detached work threw synchronously')
-		return
-	}
-
-	if (result !== undefined && result !== null) {
-		Promise.resolve(result).catch((err: unknown) => {
+	// Schedule `work()` on a microtask rather than calling it inline. An
+	// `async` function still runs its synchronous prologue (variable
+	// initialization, the first chunk before any await) in the caller's
+	// tick when invoked directly, which defeats the "detached" name: a
+	// caller firing many runDetached calls in a hot loop would still feel
+	// the prologue cost on its own clock. Scheduling via
+	// `Promise.resolve().then(work)` defers the entire body — sync
+	// prologue included — to the microtask queue, and additionally folds
+	// synchronous throws from `work` into the same rejection-handling
+	// path as async rejections (the `.catch` below handles both
+	// uniformly, so the previous try/catch around the synchronous call
+	// is no longer needed).
+	//
+	// `err` goes LAST in the log spread so a caller-supplied `context.err`
+	// can't shadow the actual exception in the structured log.
+	Promise.resolve()
+		.then(work)
+		.catch((err: unknown) => {
 			logger.error?.({ ...context, err }, 'runDetached: detached work rejected')
 		})
-	}
 }

--- a/src/__tests__/Utils/generics.test.ts
+++ b/src/__tests__/Utils/generics.test.ts
@@ -83,14 +83,11 @@ describe('runDetached', () => {
 		const order: string[] = []
 		const logger = { error: () => {} }
 
-		runDetached(
-			async () => {
-				order.push('work-prologue')
-				await delay(0)
-				order.push('work-after-await')
-			},
-			logger
-		)
+		runDetached(async () => {
+			order.push('work-prologue')
+			await delay(0)
+			order.push('work-after-await')
+		}, logger)
 
 		// Synchronous: runs immediately after `runDetached` returns. Must
 		// land in `order` BEFORE the work's prologue (which is now

--- a/src/__tests__/Utils/generics.test.ts
+++ b/src/__tests__/Utils/generics.test.ts
@@ -1,4 +1,4 @@
-import { BufferJSON } from '../../Utils/generics'
+import { BufferJSON, runDetached } from '../../Utils/generics'
 
 describe('BufferJSON', () => {
 	const originalObject = {
@@ -66,5 +66,37 @@ describe('BufferJSON', () => {
 	it('should correctly handle an empty object', () => {
 		const revived = JSON.parse('{}', BufferJSON.reviver)
 		expect(revived).toEqual({})
+	})
+})
+
+describe('runDetached', () => {
+	const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
+
+	it('logs the actual rejection even when context carries a colliding `err` key', async () => {
+		// Stage 9 round 2 fix: the logger payload spreads `context` BEFORE
+		// `err` so a caller-supplied `context.err` (e.g. a previous failure
+		// they're carrying through) can't shadow the actual exception that
+		// just fired. Pre-fix the order was `{ err, ...context }` which
+		// would let `context.err` overwrite the real one in the log.
+		const errorCalls: Array<{ obj: unknown; msg?: string }> = []
+		const logger = { error: (obj: unknown, msg?: string) => errorCalls.push({ obj, msg }) }
+
+		runDetached(
+			async () => {
+				throw new Error('actual-detached-failure')
+			},
+			logger,
+			{ op: 'unit-test', err: 'caller-supplied-misleading-value' }
+		)
+
+		// Detached rejection lands on a microtask later.
+		await delay(10)
+
+		expect(errorCalls).toHaveLength(1)
+		const payload = errorCalls[0]!.obj as { op: string; err: unknown }
+		expect(payload.op).toBe('unit-test')
+		// The REAL Error must win — not the caller's misleading string.
+		expect(payload.err).toBeInstanceOf(Error)
+		expect((payload.err as Error).message).toBe('actual-detached-failure')
 	})
 })

--- a/src/__tests__/Utils/generics.test.ts
+++ b/src/__tests__/Utils/generics.test.ts
@@ -72,6 +72,38 @@ describe('BufferJSON', () => {
 describe('runDetached', () => {
 	const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
 
+	it('schedules work on a microtask so the caller tick is not blocked', async () => {
+		// Pre-fix `runDetached` called `work()` inline, so even an `async`
+		// work function ran its synchronous prologue in the caller's tick.
+		// Post-fix it goes through `Promise.resolve().then(work)`, which
+		// defers ALL of `work` (including the sync prologue) to a
+		// microtask. The marker below records observation order: the
+		// caller's "after runDetached" line must observe its own
+		// synchronous statement BEFORE work's prologue runs.
+		const order: string[] = []
+		const logger = { error: () => {} }
+
+		runDetached(
+			async () => {
+				order.push('work-prologue')
+				await delay(0)
+				order.push('work-after-await')
+			},
+			logger
+		)
+
+		// Synchronous: runs immediately after `runDetached` returns. Must
+		// land in `order` BEFORE the work's prologue (which is now
+		// microtask-scheduled).
+		order.push('caller-sync')
+
+		await delay(20)
+
+		expect(order[0]).toBe('caller-sync')
+		expect(order).toContain('work-prologue')
+		expect(order).toContain('work-after-await')
+	})
+
 	it('logs the actual rejection even when context carries a colliding `err` key', async () => {
 		// Stage 9 round 2 fix: the logger payload spreads `context` BEFORE
 		// `err` so a caller-supplied `context.err` (e.g. a previous failure


### PR DESCRIPTION
## Summary
- Stage 9 of the concurrency rewrite. Operational hygiene cleanup — the last batch of audit findings.

## What changed
### \`runDetached\` helper (\`src/Utils/generics.ts\`)
- New utility for fire-and-forget patterns. Wraps an async function so rejections always surface via \`logger.error\` with structured context, instead of becoming silent \`unhandledRejection\` events.
- Replaces ad-hoc \`void (async () => { ... })()\` and \`process.nextTick(async () => { ... })\` patterns where rejections previously had no observable signal.
- Applied at \`messages-send.ts:1410\` — the \`emitOwnEvents.upsertMessage\` fire-and-forget projection now logs its rejection with \`{ op, msgId }\` context.

### Single-flight \`refreshMediaConn\` (\`src/Socket/messages-send.ts\`)
- New \`mediaConnMutex\` wraps the \`mediaConn\` cache refresh. Two concurrent callers used to both observe the cache as expired and both reassign the in-flight promise, leaking the first fetch's result. The mutex ensures only one refresh runs at a time; subsequent callers await the in-flight or reuse the fresh cache.
- Hit path (cache fresh) skips the lock entirely — only the refresh-path enters the critical section.

### Single-flight \`requestPlaceholderResend\` (\`src/Socket/messages-recv.ts\`)
- New per-id \`placeholderResendLocks: LockManager\` collapses the former \`get → set\` cache dedupe into one critical section.
- Two concurrent callers for the same message id could both observe an empty cache and both fire the placeholder resend; the lock makes the check-then-mark atomic per id.

## Test plan
- [x] \`yarn install --immutable\` passes (lockfile fix from Stage 5 propagated)
- [x] 47 suites pass (472 + 5 todo), 0 lint errors

## Stack
- Stage 0 — #2570 (merged)
- Stage 1 — #2571
- Stage 2 — #2572
- Stage 3 — #2573
- Stage 4 — #2574
- Stage 5 — #2575
- Stage 6 — #2576
- Stage 7 — #2577
- Stage 8 — #2578
- **Stage 9 (this PR)**

This completes the audit cleanup. Every H finding is closed; every M finding except a few explicitly deferred items (per-chat granularity of messageMutex/receiptMutex as a perf change, partial-encrypt errors, cancellable uploadPreKeys, tc-token transactWith) is closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate resend requests for the same message and avoided using invalid resend keys.
  * Skipped acknowledging messages when the socket is closed to reduce errors.
  * Serialized media-connection refreshes to avoid refresh races.
  * Made local message-upsert timing more predictable when emitting local events.

* **Tests**
  * Added tests to validate error logging and execution order for detached asynchronous work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->