### PR TITLE
Stage 10 — close deferred audit items (tc-token, prekeys, partial-encrypt, per-chat mutex, per-collection app-state)

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -45,7 +45,7 @@ import {
 	newLTHashState,
 	processSyncAction
 } from '../Utils'
-import { makeMutex } from '../Utils/make-mutex'
+import { makeKeyedMutex, makeMutex } from '../Utils/make-mutex'
 import processMessage from '../Utils/process-message'
 import { buildTcTokenFromJid } from '../Utils/tc-token-utils'
 import {
@@ -104,11 +104,21 @@ export const makeChatsSocket = (config: SocketConfig) => {
 
 	let syncState: SyncState = SyncState.Connecting
 
-	/** this mutex ensures that messages are processed in order */
-	const messageMutex = makeMutex()
+	/**
+	 * Per-chat mutex around message decrypt + downstream side effects.
+	 * Stage 10: switched from a global `makeMutex()` to a keyed mutex
+	 * keyed on `remoteJid` so messages for different chats can decrypt
+	 * and project to events in parallel; same-chat messages stay
+	 * strictly serialized (the order-within-a-chat contract the original
+	 * mutex was protecting). Same-chat ordering is still required:
+	 * `messageRetryManager.addRecentMessage`, the per-chat history
+	 * append, and the downstream signal-layer side effects all assume
+	 * sequential application per chat.
+	 */
+	const messageMutex = makeKeyedMutex()
 
-	/** this mutex ensures that receipts are processed in order */
-	const receiptMutex = makeMutex()
+	/** Per-chat mutex around receipt processing. Same rationale as `messageMutex`. */
+	const receiptMutex = makeKeyedMutex()
 
 	/** this mutex ensures that app state patches are processed in order */
 	const appStatePatchMutex = makeMutex()

--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -120,8 +120,20 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	/** Per-chat mutex around receipt processing. Same rationale as `messageMutex`. */
 	const receiptMutex = makeKeyedMutex()
 
-	/** this mutex ensures that app state patches are processed in order */
-	const appStatePatchMutex = makeMutex()
+	/**
+	 * Per-`WAPatchName` app-state patch mutex (Stage 10 — closes the
+	 * deferred per-collection finding). Was a single global
+	 * `makeMutex()` that serialized every `appPatch` call across every
+	 * collection (`critical_block`, `regular`, `regular_low`,
+	 * `regular_high`, `critical_unblock_low`). Switched to a keyed
+	 * mutex on the patch name so two collections can apply patches in
+	 * parallel; same-collection patches still strictly serialize
+	 * because their LTHash version chain requires sequential
+	 * application (`encodeSyncdPatch` reserves the next version off
+	 * the read state and a concurrent patch on the same collection
+	 * must wait).
+	 */
+	const appStatePatchMutex = makeKeyedMutex()
 
 	/** this mutex ensures that notifications are processed in order */
 	const notificationMutex = makeMutex()
@@ -929,7 +941,7 @@ export const makeChatsSocket = (config: SocketConfig) => {
 		let initial: LTHashState
 		let encodeResult: { patch: proto.ISyncdPatch; state: LTHashState }
 
-		await appStatePatchMutex.mutex(async () => {
+		await appStatePatchMutex.mutex(name, async () => {
 			await authState.keys.transaction(async () => {
 				logger.debug({ patch: patchCreate }, 'applying app patch')
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1578,7 +1578,13 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 
 		try {
 			await Promise.all([
-				receiptMutex.mutex(async () => {
+				// Per-chat receipt serialization (Stage 10): keyed on `remoteJid`
+				// so receipts for different chats process in parallel; same-chat
+				// receipts still serialize to preserve per-chat ordering.
+				// `remoteJid ?? '__no-chat__'` falls back to a sentinel so a
+				// receipt without a chat id (rare; defensive) doesn't try to
+				// acquire an empty-string key bucket.
+				receiptMutex.mutex(remoteJid ?? '__no-chat__', async () => {
 					const status = getStatusFromReceiptType(attrs.type)
 					if (
 						typeof status !== 'undefined' &&
@@ -1727,7 +1733,13 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				})
 			}
 
-			await messageMutex.mutex(async () => {
+			// Per-chat decrypt + side-effect serialization (Stage 10): keyed
+			// on the message's remoteJid so two different chats' inbound
+			// messages decrypt in parallel. Same-chat messages still
+			// serialize so the per-chat history append, receipt projection,
+			// and signal-layer state stay consistent.
+			const messageChatKey = msg.key?.remoteJid ?? '__no-chat__'
+			await messageMutex.mutex(messageChatKey, async () => {
 				await decrypt()
 
 				if (msg.key?.remoteJid && msg.key?.id && msg.message && messageRetryManager) {

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -57,7 +57,7 @@ import { makeLockManager } from '../Utils/lock-manager'
 import { makeOfflineNodeProcessor, type MessageType } from '../Utils/offline-node-processor'
 import { buildAckStanza } from '../Utils/stanza-ack'
 import {
-	buildMergedTcTokenIndexWrite,
+	commitTcTokenWithIndex,
 	isTcTokenExpired,
 	readTcTokenIndex,
 	resolveIssuanceJid,
@@ -1323,10 +1323,11 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 			tcTokenIndexTimer = undefined
 		}
 
-		// Merge with whatever is already persisted so we don't clobber writes from other
-		// paths (history sync, concurrent sessions on the same store).
-		const write = await buildMergedTcTokenIndexWrite(authState.keys, tcTokenKnownJids)
-		return authState.keys.set({ tctoken: write })
+		// Stage 10 (closure of deferred tc-token item): the read+write is
+		// wrapped in `transactWith` on the index record so a concurrent
+		// `commitTcTokenWithIndex` on the send path can't observe the same
+		// pre-merge state and clobber the merged additions.
+		await commitTcTokenWithIndex(authState.keys, tcTokenKnownJids)
 	}
 
 	function scheduleTcTokenIndexSave() {

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -588,6 +588,13 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		const meLid = authState.creds.me?.lid
 		const meLidUser = meLid ? jidDecode(meLid)?.user : null
 
+		// Per-recipient failures are accumulated rather than masked: the
+		// final result tells the caller exactly which recipients didn't
+		// get the message and why, so they can decide between
+		// "best-effort, log and move on" (the existing behavior) and
+		// "fail the whole send" (a stricter caller-side policy).
+		const failures: Array<{ jid: string; cause: unknown }> = []
+
 		const encryptionPromises = (patchedMessages as any).map(
 			async ({ recipientJid: jid, message: patchedMessage }: any) => {
 				try {
@@ -634,6 +641,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 
 					return node
 				} catch (err) {
+					failures.push({ jid, cause: err })
 					logger.error({ jid, err }, 'Failed to encrypt for recipient')
 					return null
 				}
@@ -643,10 +651,36 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		const nodes = (await Promise.all(encryptionPromises)).filter(node => node !== null) as BinaryNode[]
 
 		if (recipientJids.length > 0 && nodes.length === 0) {
-			throw new Boom('All encryptions failed', { statusCode: 500 })
+			// All recipients failed — attach the per-recipient causes via
+			// `data` so the caller's log shows which underlying errors
+			// (key-store failure, session corruption, etc.) caused the
+			// total failure instead of just the generic "All encryptions
+			// failed" string. `data.firstCause` is the most likely
+			// repeated root cause for quick diagnosis.
+			throw new Boom('All encryptions failed', {
+				statusCode: 500,
+				data: {
+					failed: failures.map(f => ({ jid: f.jid, error: String(f.cause) })),
+					firstCause: failures[0]?.cause ? String(failures[0]!.cause) : undefined
+				}
+			})
 		}
 
-		return { nodes, shouldIncludeDeviceIdentity }
+		if (failures.length > 0) {
+			// Partial failure: some recipients didn't get the message.
+			// Log structured so operators can grep / alert on this without
+			// trawling individual "Failed to encrypt for recipient" lines.
+			logger.warn(
+				{
+					succeededCount: nodes.length,
+					failedCount: failures.length,
+					failed: failures.map(f => ({ jid: f.jid, error: String(f.cause) }))
+				},
+				'createParticipantNodes: partial encryption failure'
+			)
+		}
+
+		return { nodes, shouldIncludeDeviceIdentity, failures }
 	}
 
 	const relayMessage = async (

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -40,7 +40,7 @@ import { getUrlInfo } from '../Utils/link-preview'
 import { makeKeyedMutex, makeMutex } from '../Utils/make-mutex'
 import { getMessageReportingToken, shouldIncludeReportingToken } from '../Utils/reporting-utils'
 import {
-	buildMergedTcTokenIndexWrite,
+	commitTcTokenWithIndex,
 	isTcTokenExpired,
 	resolveIssuanceJid,
 	resolveTcTokenJid,
@@ -1158,15 +1158,15 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 
 						const currentData = await authState.keys.get('tctoken', [tcTokenJid])
 						const currentEntry = currentData[tcTokenJid]
-						const indexWrite = await buildMergedTcTokenIndexWrite(authState.keys, [tcTokenJid])
-						await authState.keys.set({
-							tctoken: {
-								[tcTokenJid]: {
-									token: Buffer.alloc(0),
-									...currentEntry,
-									senderTimestamp: issueTimestamp
-								},
-								...indexWrite
+						// Stage 10 (closure of deferred tc-token item): atomic
+						// read-merge-write through `commitTcTokenWithIndex` so a
+						// concurrent `flushTcTokenIndex` on the recv path can't
+						// race the index update.
+						await commitTcTokenWithIndex(authState.keys, [tcTokenJid], {
+							[tcTokenJid]: {
+								token: Buffer.alloc(0),
+								...currentEntry,
+								senderTimestamp: issueTimestamp
 							}
 						})
 					})

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -1483,10 +1483,21 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 					// rejection becomes a structured `error` log instead of an
 					// `unhandledRejection`.
 					process.nextTick(() =>
-						runDetached(() => messageMutex.mutex(() => upsertMessage(fullMsg, 'append')), logger, {
-							op: 'emitOwnEvents.upsertMessage',
-							msgId: fullMsg.key.id
-						})
+						runDetached(
+							() =>
+								// Stage 10: keyed-mutex variant. The upsert is a
+								// per-chat operation (appends to that chat's
+								// history projection), so we acquire under the
+								// outgoing chat's remoteJid — same key the
+								// inbound receive path uses, ensuring upsertMessage
+								// ordering stays consistent with any concurrent
+								// inbound message for the same chat.
+								messageMutex.mutex(fullMsg.key.remoteJid ?? '__no-chat__', () =>
+									upsertMessage(fullMsg, 'append')
+								),
+							logger,
+							{ op: 'emitOwnEvents.upsertMessage', msgId: fullMsg.key.id }
+						)
 					)
 				}
 

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -661,7 +661,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				statusCode: 500,
 				data: {
 					failed: failures.map(f => ({ jid: f.jid, error: String(f.cause) })),
-					firstCause: failures[0]?.cause ? String(failures[0]!.cause) : undefined
+					firstCause: failures[0]?.cause ? String(failures[0].cause) : undefined
 				}
 			})
 		}
@@ -1492,9 +1492,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 								// inbound receive path uses, ensuring upsertMessage
 								// ordering stays consistent with any concurrent
 								// inbound message for the same chat.
-								messageMutex.mutex(fullMsg.key.remoteJid ?? '__no-chat__', () =>
-									upsertMessage(fullMsg, 'append')
-								),
+								messageMutex.mutex(fullMsg.key.remoteJid ?? '__no-chat__', () => upsertMessage(fullMsg, 'append')),
 							logger,
 							{ op: 'emitOwnEvents.upsertMessage', msgId: fullMsg.key.id }
 						)

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -14,6 +14,7 @@ import {
 	UPLOAD_TIMEOUT
 } from '../Defaults'
 import {
+	type AuthenticationCreds,
 	type LIDMapping,
 	type NewChatMessageCapInfo,
 	QueryIds,
@@ -529,26 +530,54 @@ export const makeSocket = (config: SocketConfig) => {
 			return
 		}
 
+		// Generate ONCE (outside the retry loop): pre-keys are persisted to
+		// the store, and `nextPreKeyId` advances so a parallel call doesn't
+		// reuse the id range. `firstUnuploadedPreKeyId` is HELD BACK in
+		// `commitUpdate` and only emitted after the server confirms — so a
+		// permanent upload failure leaves the local store carrying the
+		// generated keys ready for the next attempt (instead of marking
+		// them as "uploaded" prematurely and orphaning them).
+		let pendingNode: BinaryNode | undefined
+		let pendingCommit: Partial<AuthenticationCreds> | undefined
+
 		const uploadLogic = async (retryCount: number): Promise<void> => {
 			logger.info({ count, retryCount }, 'uploading pre-keys')
 
-			// Generate and save pre-keys atomically (prevents ID collisions on retry)
-			const node = await keys.transaction(async () => {
-				logger.debug({ requestedCount: count }, 'generating pre-keys with requested count')
-				const { update, node } = await getNextPreKeysNode({ creds, keys }, count)
-				// Update credentials immediately to prevent duplicate IDs on retry
-				ev.emit('creds.update', update)
-				return node
-			}, creds?.me?.id || 'upload-pre-keys')
+			if (!pendingNode) {
+				const generated = await keys.transaction(async () => {
+					logger.debug({ requestedCount: count }, 'generating pre-keys with requested count')
+					const { allocUpdate, commitUpdate, node } = await getNextPreKeysNode({ creds, keys }, count)
+					// Allocation half: commit immediately so parallel generation
+					// never collides on the same id range.
+					ev.emit('creds.update', allocUpdate)
+					return { node, commitUpdate }
+				}, creds?.me?.id || 'upload-pre-keys')
+				pendingNode = generated.node
+				pendingCommit = generated.commitUpdate
+			}
 
-			// Upload to server (outside transaction, can fail without affecting local keys)
+			// Bail out before the network call if the socket is gone — the
+			// next reconnect will run uploadPreKeysToServerIfRequired and
+			// retry naturally.
+			if (!ws.isOpen) {
+				throw new Boom('socket closed mid-upload, deferring to reconnect', {
+					statusCode: DisconnectReason.connectionClosed
+				})
+			}
+
 			try {
-				await query(node)
+				await query(pendingNode)
 				logger.info({ count }, 'uploaded pre-keys successfully')
+				// Commit half: advance firstUnuploadedPreKeyId NOW that the
+				// server has the keys.
+				if (pendingCommit) ev.emit('creds.update', pendingCommit)
 			} catch (uploadError) {
 				logger.error({ uploadError: (uploadError as Error).toString(), count }, 'Failed to upload pre-keys to server')
 
 				// Recurse into uploadLogic; calling uploadPreKeys would await its own in-flight promise.
+				// `pendingNode` + `pendingCommit` are preserved so the retry
+				// uses the SAME node (same key range) — the keys are already
+				// in the store; the server just hasn't acknowledged them.
 				if (retryCount < 3) {
 					const backoffDelay = Math.min(1000 * Math.pow(2, retryCount), 10000)
 					logger.info(`Retrying pre-key upload in ${backoffDelay}ms`)
@@ -556,6 +585,9 @@ export const makeSocket = (config: SocketConfig) => {
 					return uploadLogic(retryCount + 1)
 				}
 
+				// Permanent failure: leave `firstUnuploadedPreKeyId` UNCHANGED so
+				// the next uploadPreKeysToServerIfRequired call re-attempts
+				// these same keys instead of skipping past them.
 				throw uploadError
 			}
 		}

--- a/src/Utils/signal.ts
+++ b/src/Utils/signal.ts
@@ -237,9 +237,26 @@ export const getNextPreKeys = async ({ creds, keys }: AuthenticationState, count
 	return { update, preKeys }
 }
 
+/**
+ * Build the IQ node for a pre-key upload and split the creds update into
+ * two halves: an "allocation" update that's safe to commit immediately
+ * (advances `nextPreKeyId` so a parallel generation never reuses the
+ * same id range), and a "commit" update that should only be committed
+ * AFTER the server confirms the upload (advances `firstUnuploadedPreKeyId`
+ * — applying it before the server actually has the keys means a later
+ * upload-failure would leave generated-but-never-uploaded keys orphaned
+ * in the local store, since subsequent upload calls would skip past them).
+ *
+ * Stage 10 (M2 closure): the previous single `update` collapsed both
+ * fields and was emitted before the upload completed, so a permanent
+ * upload failure permanently lost the generated keys.
+ */
 export const getNextPreKeysNode = async (state: AuthenticationState, count: number) => {
 	const { creds } = state
 	const { update, preKeys } = await getNextPreKeys(state, count)
+
+	const allocUpdate: Partial<AuthenticationCreds> = { nextPreKeyId: update.nextPreKeyId }
+	const commitUpdate: Partial<AuthenticationCreds> = { firstUnuploadedPreKeyId: update.firstUnuploadedPreKeyId }
 
 	const node: BinaryNode = {
 		tag: 'iq',
@@ -257,5 +274,5 @@ export const getNextPreKeysNode = async (state: AuthenticationState, count: numb
 		]
 	}
 
-	return { update, node }
+	return { allocUpdate, commitUpdate, node }
 }

--- a/src/Utils/tc-token-utils.ts
+++ b/src/Utils/tc-token-utils.ts
@@ -1,4 +1,4 @@
-import type { SignalKeyStoreWithTransaction } from '../Types'
+import type { SignalDataTypeMap, SignalKeyStoreWithRecordTransaction, SignalKeyStoreWithTransaction } from '../Types'
 import type { BinaryNode } from '../WABinary'
 import {
 	getBinaryNodeChild,
@@ -50,7 +50,14 @@ export async function readTcTokenIndex(keys: SignalKeyStoreWithTransaction): Pro
 	}
 }
 
-/** Build a SignalDataSet fragment that writes the merged index (persisted ∪ added) under the sentinel key. */
+/** Build a SignalDataSet fragment that writes the merged index (persisted ∪ added) under the sentinel key.
+ *
+ * @deprecated Prefer {@link commitTcTokenWithIndex}, which performs the read
+ * → merge → write atomically under a `transactWith` lock on the index
+ * record. This helper still works but the caller must arrange its own
+ * locking to avoid two concurrent invocations each reading the same
+ * pre-merge state and clobbering each other's additions on commit.
+ */
 export async function buildMergedTcTokenIndexWrite(
 	keys: SignalKeyStoreWithTransaction,
 	addedJids: Iterable<string>
@@ -64,6 +71,49 @@ export async function buildMergedTcTokenIndexWrite(
 	return {
 		[TC_TOKEN_INDEX_KEY]: { token: Buffer.from(JSON.stringify([...merged])) }
 	}
+}
+
+/**
+ * Atomically commit a tctoken index update (and any accompanying per-jid
+ * token writes) under a `transactWith` lock on the index record.
+ *
+ * Stage 10 closure of the audit's deferred tc-token item: two concurrent
+ * callers using {@link buildMergedTcTokenIndexWrite} + a manual
+ * `keys.set` would each read the same pre-merge state and then commit
+ * their own merge, losing the other's additions. Wrapping the read +
+ * write in one transactWith on `{ type: 'tctoken', id: '__index' }`
+ * serializes them through the LockManager. Per-jid token writes can
+ * piggyback on the same transactWith by passing them in `extraWrites`
+ * — they're committed in the same atomic `state.set` as the index
+ * update, so a partial-commit window cannot exist.
+ *
+ * Records held: the index sentinel + every per-jid key in `extraWrites`.
+ * Concurrent callers touching disjoint jids and not the index proceed
+ * in parallel.
+ */
+export async function commitTcTokenWithIndex(
+	keys: SignalKeyStoreWithRecordTransaction,
+	addedJids: Iterable<string>,
+	extraWrites?: { [jid: string]: SignalDataTypeMap['tctoken'] | null }
+): Promise<void> {
+	const recordIds = [TC_TOKEN_INDEX_KEY, ...Object.keys(extraWrites ?? {})]
+	await keys.transactWith(
+		{ records: recordIds.map(id => ({ type: 'tctoken', id })) },
+		async () => {
+			const persisted = await readTcTokenIndex(keys)
+			const merged = new Set(persisted)
+			for (const jid of addedJids) {
+				if (jid && jid !== TC_TOKEN_INDEX_KEY) merged.add(jid)
+			}
+
+			await keys.set({
+				tctoken: {
+					...(extraWrites ?? {}),
+					[TC_TOKEN_INDEX_KEY]: { token: Buffer.from(JSON.stringify([...merged])) }
+				}
+			})
+		}
+	)
 }
 
 // WA Web has separate sender/receiver AB props for these but they're identical today

--- a/src/Utils/tc-token-utils.ts
+++ b/src/Utils/tc-token-utils.ts
@@ -97,23 +97,20 @@ export async function commitTcTokenWithIndex(
 	extraWrites?: { [jid: string]: SignalDataTypeMap['tctoken'] | null }
 ): Promise<void> {
 	const recordIds = [TC_TOKEN_INDEX_KEY, ...Object.keys(extraWrites ?? {})]
-	await keys.transactWith(
-		{ records: recordIds.map(id => ({ type: 'tctoken', id })) },
-		async () => {
-			const persisted = await readTcTokenIndex(keys)
-			const merged = new Set(persisted)
-			for (const jid of addedJids) {
-				if (jid && jid !== TC_TOKEN_INDEX_KEY) merged.add(jid)
-			}
-
-			await keys.set({
-				tctoken: {
-					...(extraWrites ?? {}),
-					[TC_TOKEN_INDEX_KEY]: { token: Buffer.from(JSON.stringify([...merged])) }
-				}
-			})
+	await keys.transactWith({ records: recordIds.map(id => ({ type: 'tctoken', id })) }, async () => {
+		const persisted = await readTcTokenIndex(keys)
+		const merged = new Set(persisted)
+		for (const jid of addedJids) {
+			if (jid && jid !== TC_TOKEN_INDEX_KEY) merged.add(jid)
 		}
-	)
+
+		await keys.set({
+			tctoken: {
+				...(extraWrites ?? {}),
+				[TC_TOKEN_INDEX_KEY]: { token: Buffer.from(JSON.stringify([...merged])) }
+			}
+		})
+	})
 }
 
 // WA Web has separate sender/receiver AB props for these but they're identical today


### PR DESCRIPTION
Final closure of every M-level finding from the concurrency/transaction audit that earlier stages explicitly deferred. Five separate commits, each independently revertable; ordering chosen so each builds on the same baseline (no inter-commit dependencies).

## Findings closed

| Commit | Finding | Impact |
|---|---|---|
| `691cb7b93a` | tc-token index transactWith | Two concurrent token writes could each read the same pre-merge index and clobber each other's additions. Now atomic under `transactWith({records:[{type:'tctoken', id:'__index'}, ...per-jid]})`. |
| `76a99d0880` | M2: cancellable uploadPreKeys | `firstUnuploadedPreKeyId` was advanced before server confirmation. A permanent upload failure left generated keys orphaned (the local store had them; the next upload skipped past). Split into `allocUpdate` (immediate, advances `nextPreKeyId` so parallel callers don't reuse the id range) + `commitUpdate` (only after server confirms). Pre-network `ws.isOpen` check bails out on closed socket. |
| `6f85c74ed6` | Partial-encrypt aggregation | Per-recipient encrypt failures were silently logged and the partial node list returned with no indicator. Now accumulates `{ jid, cause }[]` failures: all-fail throws a Boom with `data.failed` + `data.firstCause`; partial-fail emits a structured warn with counts + full list; the function return value includes the `failures` array so programmatic callers can opt into stricter policies. |
| `4913352a53` | Per-chat keyed `messageMutex` / `receiptMutex` | The two largest receive-path mutexes were global, serializing every inbound stanza across every chat. Switched to `makeKeyedMutex()` keyed on `remoteJid`. Cross-chat parallelism unlocked; within-chat ordering preserved. Send-side `upsertMessage` also keyed by `fullMsg.key.remoteJid` so outgoing and incoming side effects for the same chat still serialize. |
| `0ef42a91fe` | Per-`WAPatchName` `appStatePatchMutex` | Was a single global mutex serializing patches across `critical_block`, `regular`, `regular_low`, `regular_high`, etc. Now keyed on the patch name; same-collection still serializes (LTHashState version chain requires it). |

## Net audit status

Every H-finding (H0–H10) closed in Stages 1–7. Every M-finding (M1–M12) closed across Stages 5–9 and this stage. The 5 deferred items called out in earlier PR descriptions are now closed; no remaining audit items.

## Verification

- 50 test suites pass / 486 + 5 todo
- 0 lint errors
- Types clean
- Each commit individually verified (each ran the full suite + lint after applying)

## Risk profile

The riskiest commit is `4913352a53` (per-chat mutex). Within-chat ordering invariants verified:

- `messageRetryManager.addRecentMessage(remoteJid, ...)` — chat-scoped, OK.
- Per-chat history append in `processMessage` — chat-scoped, OK.
- Signal-layer mutations — already scoped by per-record locks (Stage 2/3), independent of these mutexes.

Cross-chat ordering was not relied on:

- `APP_STATE_SYNC_KEY_SHARE` is processed through `notificationMutex` (still global), so key-share landing for one chat unblocking decoding for another is unaffected.
- History-sync notifications also go through the notification path, not `messageMutex`.

A `'__no-chat__'` sentinel handles the rare defensive case of a stanza missing `remoteJid` — would otherwise collapse all such stanzas into one bucket (same as the pre-change empty-key behavior).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized concurrency handling to enable parallel message processing across different chats while maintaining sequential ordering within each chat.

* **Bug Fixes**
  * Enhanced error reporting for encryption failures with detailed per-recipient diagnostics.
  * Improved reliability of credential and authentication token updates through more atomic operations.
  * Added faster socket connectivity detection during authentication key uploads for quicker reconnection handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->