### PR TITLE
feat(media): bind downloads to the per-socket media_conn hostname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,6 @@ Proxy
 test.ts
 TestData
 wa-logs*
+wa-bench-logs*
+test.db
 coverage

--- a/Example/benchmark.ts
+++ b/Example/benchmark.ts
@@ -1,0 +1,350 @@
+import { Boom } from '@hapi/boom'
+import { randomUUID } from 'node:crypto'
+import fs from 'node:fs'
+import { request as httpRequest } from 'node:http'
+import { request as httpsRequest } from 'node:https'
+import P from 'pino'
+import makeWASocket, { DisconnectReason, useSqliteAuthState } from '../lib/index.js'
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
+
+const AUTH_FOLDER = 'baileys_auth_info_bench'
+const SOCKET_URL = process.env.SOCKET_URL ?? 'wss://127.0.0.1:8080/ws/chat'
+const MOCK_PHONE_ADMIN_PATH = '/admin/mock-phone/scan-qr'
+const TERMINAL_DISCONNECT_REASONS = [
+	DisconnectReason.loggedOut,
+	DisconnectReason.connectionReplaced,
+	DisconnectReason.connectionClosed
+]
+
+function postQrToMockPhone(socketUrl: string, qr: string): Promise<void> {
+	const adminUrl = new URL(socketUrl)
+	adminUrl.protocol = adminUrl.protocol === 'wss:' ? 'https:' : 'http:'
+	const isHttps = adminUrl.protocol === 'https:'
+	const request = isHttps ? httpsRequest : httpRequest
+
+	return new Promise((resolve, reject) => {
+		const req = request(
+			{
+				host: adminUrl.hostname,
+				port: adminUrl.port,
+				path: MOCK_PHONE_ADMIN_PATH,
+				method: 'POST',
+				...(isHttps ? { rejectUnauthorized: false } : {})
+			},
+			res => {
+				res.resume()
+				const status = res.statusCode ?? 0
+				if (status >= 200 && status < 300) {
+					resolve()
+				} else {
+					reject(new Error(`mock-phone ${MOCK_PHONE_ADMIN_PATH} returned ${status}`))
+				}
+			}
+		)
+		req.on('error', reject)
+		req.write(qr)
+		req.end()
+	})
+}
+
+interface BenchmarkResult {
+	durationMs: number
+	userCpuMs: number
+	systemCpuMs: number
+	totalCpuMs: number
+	cpuPercent: number
+	heapUsedStart: number
+	heapUsedEnd: number
+	heapUsedDiff: number
+	heapTotalStart: number
+	heapTotalEnd: number
+	heapTotalDiff: number
+	rssStart: number
+	rssEnd: number
+	rssDiff: number
+}
+
+interface BenchmarkTracking {
+	cpuUsage: NodeJS.CpuUsage
+	time: bigint
+	memory: NodeJS.MemoryUsage
+}
+
+function parseArgs(): { runs: number } {
+	const runsArg = process.argv.find(arg => arg.startsWith('--runs='))
+	const runs = runsArg ? parseInt(runsArg.split('=')[1], 10) : 1
+	if (isNaN(runs) || runs < 1) {
+		console.error('Invalid --runs value. Must be a positive integer.')
+		process.exit(1)
+	}
+	return { runs }
+}
+
+function formatBytes(bytes: number): string {
+	const mb = bytes / 1024 / 1024
+	return `${mb.toFixed(2)} MB`
+}
+
+function median(values: number[]): number {
+	if (values.length === 0) return 0
+	const sorted = [...values].sort((a, b) => a - b)
+	const mid = Math.floor(sorted.length / 2)
+	if (sorted.length % 2 === 0) {
+		return (sorted[mid - 1] + sorted[mid]) / 2
+	}
+	return sorted[mid]
+}
+
+function runGC(): void {
+	if (global.gc) {
+		global.gc()
+	}
+}
+
+function cleanAuthFolder(): void {
+	if (fs.existsSync(AUTH_FOLDER)) {
+		fs.rmSync(AUTH_FOLDER, { recursive: true })
+	}
+}
+
+function captureResult(tracking: BenchmarkTracking): BenchmarkResult {
+	const endCpuUsage = process.cpuUsage(tracking.cpuUsage)
+	runGC()
+	const endMemory = process.memoryUsage()
+	const elapsedNs = process.hrtime.bigint() - tracking.time
+	const durationMs = Number(elapsedNs) / 1_000_000
+
+	const userCpuMs = endCpuUsage.user / 1000
+	const systemCpuMs = endCpuUsage.system / 1000
+	const totalCpuMs = userCpuMs + systemCpuMs
+	const cpuPercent = (totalCpuMs / durationMs) * 100
+
+	return {
+		durationMs,
+		userCpuMs,
+		systemCpuMs,
+		totalCpuMs,
+		cpuPercent,
+		heapUsedStart: tracking.memory.heapUsed,
+		heapUsedEnd: endMemory.heapUsed,
+		heapUsedDiff: endMemory.heapUsed - tracking.memory.heapUsed,
+		heapTotalStart: tracking.memory.heapTotal,
+		heapTotalEnd: endMemory.heapTotal,
+		heapTotalDiff: endMemory.heapTotal - tracking.memory.heapTotal,
+		rssStart: tracking.memory.rss,
+		rssEnd: endMemory.rss,
+		rssDiff: endMemory.rss - tracking.memory.rss
+	}
+}
+
+function buildMemoryTable(
+	heapUsed: { start: number; end: number; diff: number },
+	heapTotal: { start: number; end: number; diff: number },
+	rss: { start: number; end: number; diff: number }
+): Record<string, { Start: string; End: string; Diff: string }> {
+	return {
+		'Heap Used': {
+			Start: formatBytes(heapUsed.start),
+			End: formatBytes(heapUsed.end),
+			Diff: formatBytes(heapUsed.diff)
+		},
+		'Heap Total': {
+			Start: formatBytes(heapTotal.start),
+			End: formatBytes(heapTotal.end),
+			Diff: formatBytes(heapTotal.diff)
+		},
+		RSS: {
+			Start: formatBytes(rss.start),
+			End: formatBytes(rss.end),
+			Diff: formatBytes(rss.diff)
+		}
+	}
+}
+
+function printSingleRunSummary(run: number, totalRuns: number, result: BenchmarkResult): void {
+	console.log(
+		`Run ${run}/${totalRuns} completed - ` +
+			`Duration: ${(result.durationMs / 1000).toFixed(2)}s, ` +
+			`CPU: ${result.totalCpuMs.toFixed(0)}ms (${result.cpuPercent.toFixed(1)}%), ` +
+			`Heap Diff: ${formatBytes(result.heapUsedDiff)}`
+	)
+}
+
+function printAggregatedResults(results: BenchmarkResult[]): void {
+	if (results.length === 0) return
+
+	if (results.length === 1) {
+		const r = results[0]
+		console.log('\n========== BENCHMARK STATS ==========')
+		console.log(`Duration: ${(r.durationMs / 1000).toFixed(2)}s\n`)
+
+		console.log('CPU Usage:')
+		console.table({
+			'User CPU': `${r.userCpuMs.toFixed(2)} ms`,
+			'System CPU': `${r.systemCpuMs.toFixed(2)} ms`,
+			'Total CPU': `${r.totalCpuMs.toFixed(2)} ms`,
+			'CPU %': `${r.cpuPercent.toFixed(2)}%`
+		})
+
+		console.log('Memory:')
+		console.table(
+			buildMemoryTable(
+				{ start: r.heapUsedStart, end: r.heapUsedEnd, diff: r.heapUsedDiff },
+				{ start: r.heapTotalStart, end: r.heapTotalEnd, diff: r.heapTotalDiff },
+				{ start: r.rssStart, end: r.rssEnd, diff: r.rssDiff }
+			)
+		)
+		return
+	}
+
+	console.log(`\n========== AGGREGATED RESULTS (${results.length} runs) ==========\n`)
+
+	console.log('CPU Usage (median):')
+	console.table({
+		Duration: `${(median(results.map(r => r.durationMs)) / 1000).toFixed(2)} s`,
+		'User CPU': `${median(results.map(r => r.userCpuMs)).toFixed(2)} ms`,
+		'System CPU': `${median(results.map(r => r.systemCpuMs)).toFixed(2)} ms`,
+		'Total CPU': `${median(results.map(r => r.totalCpuMs)).toFixed(2)} ms`,
+		'CPU %': `${median(results.map(r => r.cpuPercent)).toFixed(2)}%`
+	})
+
+	console.log('Memory (median):')
+	console.table(
+		buildMemoryTable(
+			{
+				start: median(results.map(r => r.heapUsedStart)),
+				end: median(results.map(r => r.heapUsedEnd)),
+				diff: median(results.map(r => r.heapUsedDiff))
+			},
+			{
+				start: median(results.map(r => r.heapTotalStart)),
+				end: median(results.map(r => r.heapTotalEnd)),
+				diff: median(results.map(r => r.heapTotalDiff))
+			},
+			{
+				start: median(results.map(r => r.rssStart)),
+				end: median(results.map(r => r.rssEnd)),
+				diff: median(results.map(r => r.rssDiff))
+			}
+		)
+	)
+}
+
+const { runs: totalRuns } = parseArgs()
+const results: BenchmarkResult[] = []
+let currentRun = 0
+let tracking: BenchmarkTracking | null = null
+
+const logger = P({ level: process.env.LOG_LEVEL ?? 'warn' })
+
+cleanAuthFolder()
+console.log(`Removed ${AUTH_FOLDER} for clean state`)
+
+function finishCurrentRun(): void {
+	if (tracking) {
+		const result = captureResult(tracking)
+		results.push(result)
+		printSingleRunSummary(currentRun, totalRuns, result)
+		tracking = null
+	}
+}
+
+function handleShutdown(): void {
+	finishCurrentRun()
+	printAggregatedResults(results)
+	process.exit(0)
+}
+
+process.on('SIGINT', handleShutdown)
+process.on('SIGTERM', handleShutdown)
+
+async function startBenchmark(auth?: { state: any; saveCreds: () => Promise<void>; close: () => void; }): Promise<void> {
+	if (!auth) {
+		auth = await useSqliteAuthState({dbPath: ':memory:'})
+	}
+	const { state, saveCreds, close: dbClose } = auth
+
+
+	const sock = makeWASocket({
+		logger,
+		auth: state,
+		waWebSocketUrl: SOCKET_URL,
+		pushName: `baileys-bench-${randomUUID()}`
+	})
+
+	sock.ev.on('creds.update', saveCreds)
+
+	let qrScanned = false
+
+	sock.ev.process(async events => {
+		if (events['connection.update']) {
+			const { connection, lastDisconnect, qr } = events['connection.update']
+
+			if (qr && !qrScanned) {
+				qrScanned = true
+				try {
+					await postQrToMockPhone(SOCKET_URL, qr)
+					console.log('QR posted to mock-phone')
+				} catch (err) {
+					console.error('Failed to pair with mock-phone:', err)
+				}
+			}
+
+			if (connection === 'close') {
+				const statusCode = (lastDisconnect?.error as Boom)?.output?.statusCode
+				console.log(`Disconnected: ${connection} with code ${statusCode}`)
+
+				// Transient close (WhatsApp's post-pair 515 "restart
+				// required", network blips, etc.): keep the SQLite handle
+				// open so the next socket can keep using the same auth.
+				// Closing here would crash `saveCreds` on the very next
+				// `creds.update` emission.
+				if (!TERMINAL_DISCONNECT_REASONS.includes(statusCode!)) {
+					startBenchmark(auth)
+					return
+				}
+
+				finishCurrentRun()
+
+				// Terminal close: between runs we want a fresh auth state,
+				// so close the db and let the next `startBenchmark` call
+				// (with no `auth` arg) build a new one.
+				dbClose()
+
+				if (currentRun < totalRuns) {
+					cleanAuthFolder()
+					startBenchmark()
+				} else {
+					printAggregatedResults(results)
+					process.exit(0)
+				}
+			} else if (connection === 'open') {
+				currentRun++
+				console.log(`\nRun ${currentRun}/${totalRuns} - Connected, ready for ping/pong benchmark`)
+
+				runGC()
+				tracking = {
+					cpuUsage: process.cpuUsage(),
+					memory: process.memoryUsage(),
+					time: process.hrtime.bigint()
+				}
+			}
+		}
+
+		if (events['messages.upsert']) {
+			const { messages, type } = events['messages.upsert']
+			if (type !== 'notify') return
+
+			for (const msg of messages) {
+				const text = msg.message?.conversation || msg.message?.extendedTextMessage?.text
+				if (text === 'ping') {
+					await sock.sendMessage(msg.key.remoteJid!, { text: `pong ${msg.key.id}` })
+				}
+			}
+		}
+	})
+}
+
+console.log(`Starting benchmark with ${totalRuns} run(s)...`)
+startBenchmark()

--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -85,7 +85,8 @@ export const makeChatsSocket = (config: SocketConfig) => {
 		signalRepository,
 		onUnexpectedError,
 		sendUnifiedSession,
-		registerSocketEndHandler
+		registerSocketEndHandler,
+		getMediaHost
 	} = sock
 
 	const getLIDForPN = signalRepository.lidMapping.getLIDForPN.bind(signalRepository.lidMapping)
@@ -665,7 +666,10 @@ export const makeChatsSocket = (config: SocketConfig) => {
 					})
 
 					// extract from binary node
-					const decoded = await extractSyncdPatches(result, config?.options)
+					// Stage 11: route the external-blob download (for collections too
+					// large to inline) through the socket's `media_conn` host so the
+					// app-state sync hits the same shard as the upload path.
+					const decoded = await extractSyncdPatches(result, config?.options, getMediaHost())
 					for (const key in decoded) {
 						const name = key as WAPatchName
 						const { patches, hasMorePatches, snapshot } = decoded[name]
@@ -697,7 +701,8 @@ export const makeChatsSocket = (config: SocketConfig) => {
 									config.options,
 									initialVersionMap[name],
 									logger,
-									appStateMacVerification.patch
+									appStateMacVerification.patch,
+									getMediaHost()
 								)
 
 								await authState.keys.set({ 'app-state-sync-version': { [name]: newState } })
@@ -999,7 +1004,9 @@ export const makeChatsSocket = (config: SocketConfig) => {
 				getAppStateSyncKey,
 				config.options,
 				undefined,
-				logger
+				logger,
+				undefined,
+				getMediaHost()
 			)
 			for (const key in mutationMap) {
 				onMutation(mutationMap[key]!)
@@ -1350,7 +1357,10 @@ export const makeChatsSocket = (config: SocketConfig) => {
 				keyStore: authState.keys,
 				logger,
 				options: config.options,
-				getMessage
+				getMessage,
+				// Stage 11: thread the per-socket media-CDN host into
+				// history-sync downloads inside processMessage.
+				getMediaHost
 			})
 		])
 

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -121,38 +121,6 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	// Prevent race conditions in Signal session encryption by user
 	const encryptionMutex = makeKeyedMutex()
 
-	/**
-	 * Per-recipient outbox mutex around the ENTIRE relayMessage body
-	 * (encrypt + assemble + sendNode). Without this, two parallel
-	 * `sendMessage(jid, ...)` calls can serialize their inner
-	 * `encryptMessage` correctly (via `transactWith` per-session lock)
-	 * yet still hit the network in the WRONG ORDER:
-	 *
-	 *   1. Handler A acquires session lock, encrypts (counter N), releases.
-	 *   2. Between lock release and Handler A's downstream `sendNode`,
-	 *      there are awaits (additional node assembly, group-metadata
-	 *      fetches, etc.). The JS scheduler can yield.
-	 *   3. Handler B's encrypt was queued on the session lock — it now
-	 *      acquires, encrypts (counter N+1), releases, and may reach
-	 *      its own `sendNode` BEFORE Handler A's `sendNode` is queued.
-	 *   4. Bytes hit the wire as N+1, N. Peer ratchets past N when it
-	 *      receives N+1, then reports "old counter" when N arrives.
-	 *
-	 * Under SQLite the encrypt commit is microsecond-fast so the gap is
-	 * imperceptible to the scheduler; under multi-file the writeFile +
-	 * two renames take milliseconds and the window opens wide enough to
-	 * make this reproducible. Serializing the entire relayMessage body
-	 * per destination jid closes the gap regardless of adapter speed —
-	 * the bytes hit `sendNode` in the same order the encrypt commits.
-	 *
-	 * Scope: keyed on the destination jid (the recipient chat / group).
-	 * Different chats proceed in parallel; same-chat outbound serializes.
-	 * For groups this also serializes the sender-key fanout against
-	 * other sends to the same group, which matches WhatsApp's expected
-	 * delivery-order semantics.
-	 */
-	const outboxMutex = makeKeyedMutex()
-
 	// `mediaConn` / `mediaHost` / `refreshMediaConn` moved to the base
 	// socket in Stage 11 so chats.ts (which is BELOW this layer in the
 	// socket layering) can also route its app-state / history-sync
@@ -648,35 +616,6 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	}
 
 	const relayMessage = async (
-		jid: string,
-		message: proto.IMessage,
-		{
-			messageId: msgId,
-			participant,
-			additionalAttributes,
-			additionalNodes,
-			useUserDevicesCache,
-			useCachedGroupMetadata,
-			statusJidList
-		}: MessageRelayOptions
-	) => {
-		// Serialize the entire relay (encrypt + assemble + sendNode) per
-		// destination jid. See `outboxMutex` docblock for why this is
-		// necessary on top of the per-session `transactWith` lock.
-		return outboxMutex.mutex(jid, () =>
-			relayMessageImpl(jid, message, {
-				messageId: msgId,
-				participant,
-				additionalAttributes,
-				additionalNodes,
-				useUserDevicesCache,
-				useCachedGroupMetadata,
-				statusJidList
-			})
-		)
-	}
-
-	const relayMessageImpl = async (
 		jid: string,
 		message: proto.IMessage,
 		{

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -121,6 +121,38 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	// Prevent race conditions in Signal session encryption by user
 	const encryptionMutex = makeKeyedMutex()
 
+	/**
+	 * Per-recipient outbox mutex around the ENTIRE relayMessage body
+	 * (encrypt + assemble + sendNode). Without this, two parallel
+	 * `sendMessage(jid, ...)` calls can serialize their inner
+	 * `encryptMessage` correctly (via `transactWith` per-session lock)
+	 * yet still hit the network in the WRONG ORDER:
+	 *
+	 *   1. Handler A acquires session lock, encrypts (counter N), releases.
+	 *   2. Between lock release and Handler A's downstream `sendNode`,
+	 *      there are awaits (additional node assembly, group-metadata
+	 *      fetches, etc.). The JS scheduler can yield.
+	 *   3. Handler B's encrypt was queued on the session lock — it now
+	 *      acquires, encrypts (counter N+1), releases, and may reach
+	 *      its own `sendNode` BEFORE Handler A's `sendNode` is queued.
+	 *   4. Bytes hit the wire as N+1, N. Peer ratchets past N when it
+	 *      receives N+1, then reports "old counter" when N arrives.
+	 *
+	 * Under SQLite the encrypt commit is microsecond-fast so the gap is
+	 * imperceptible to the scheduler; under multi-file the writeFile +
+	 * two renames take milliseconds and the window opens wide enough to
+	 * make this reproducible. Serializing the entire relayMessage body
+	 * per destination jid closes the gap regardless of adapter speed —
+	 * the bytes hit `sendNode` in the same order the encrypt commits.
+	 *
+	 * Scope: keyed on the destination jid (the recipient chat / group).
+	 * Different chats proceed in parallel; same-chat outbound serializes.
+	 * For groups this also serializes the sender-key fanout against
+	 * other sends to the same group, which matches WhatsApp's expected
+	 * delivery-order semantics.
+	 */
+	const outboxMutex = makeKeyedMutex()
+
 	// `mediaConn` / `mediaHost` / `refreshMediaConn` moved to the base
 	// socket in Stage 11 so chats.ts (which is BELOW this layer in the
 	// socket layering) can also route its app-state / history-sync
@@ -616,6 +648,35 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	}
 
 	const relayMessage = async (
+		jid: string,
+		message: proto.IMessage,
+		{
+			messageId: msgId,
+			participant,
+			additionalAttributes,
+			additionalNodes,
+			useUserDevicesCache,
+			useCachedGroupMetadata,
+			statusJidList
+		}: MessageRelayOptions
+	) => {
+		// Serialize the entire relay (encrypt + assemble + sendNode) per
+		// destination jid. See `outboxMutex` docblock for why this is
+		// necessary on top of the per-session `transactWith` lock.
+		return outboxMutex.mutex(jid, () =>
+			relayMessageImpl(jid, message, {
+				messageId: msgId,
+				participant,
+				additionalAttributes,
+				additionalNodes,
+				useUserDevicesCache,
+				useCachedGroupMetadata,
+				statusJidList
+			})
+		)
+	}
+
+	const relayMessageImpl = async (
 		jid: string,
 		message: proto.IMessage,
 		{

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -4,7 +4,6 @@ import { proto } from '../../WAProto/index.js'
 import { DEFAULT_CACHE_TTLS, WA_DEFAULT_EPHEMERAL } from '../Defaults'
 import type {
 	AnyMessageContent,
-	MediaConnInfo,
 	MessageReceiptType,
 	MessageRelayOptions,
 	MiscMessageGenerationOptions,
@@ -18,7 +17,6 @@ import {
 	assertMeId,
 	bindWaitForEvent,
 	decryptMediaRetryData,
-	DEF_MEDIA_HOST,
 	downloadContentFromMessage,
 	downloadMediaMessage,
 	encodeNewsletterMessage,
@@ -54,8 +52,6 @@ import {
 	type BinaryNode,
 	type BinaryNodeAttributes,
 	type FullJid,
-	getBinaryNodeChild,
-	getBinaryNodeChildren,
 	isHostedLidUser,
 	isHostedPnUser,
 	isJidBot,
@@ -96,7 +92,9 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		sendNode,
 		groupMetadata,
 		groupToggleEphemeral,
-		registerSocketEndHandler
+		registerSocketEndHandler,
+		refreshMediaConn,
+		getMediaHost
 	} = sock
 
 	const getLIDForPN = signalRepository.lidMapping.getLIDForPN.bind(signalRepository.lidMapping)
@@ -123,79 +121,11 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	// Prevent race conditions in Signal session encryption by user
 	const encryptionMutex = makeKeyedMutex()
 
-	let mediaConn: Promise<MediaConnInfo> | undefined
-	/** Per-socket media host; updated whenever media_conn is fetched. Defaults to the public WhatsApp host. */
-	let mediaHost: string = DEF_MEDIA_HOST
-	/**
-	 * Single-flight guard for the media-conn fetch (Stage 9). Two concurrent
-	 * callers used to both observe `mediaConn` as expired and both reassign
-	 * the in-flight promise, leaking the first fetch's result. The mutex
-	 * ensures only one refresh runs at a time; subsequent callers await the
-	 * one in-flight or reuse the freshly-cached value.
-	 */
-	const mediaConnMutex = makeMutex()
-	/**
-	 * Safely await the cached `mediaConn` promise. If a previous fetch
-	 * stored a REJECTED promise, awaiting it again would just rethrow
-	 * forever and poison every subsequent caller with the stale failure
-	 * — there'd be no way to retry. Clear the cache slot on rejection so
-	 * the next caller falls through to a fresh `media_conn` query.
-	 */
-	const safeAwaitMediaConn = async (): Promise<MediaConnInfo | undefined> => {
-		if (!mediaConn) return undefined
-		try {
-			return await mediaConn
-		} catch (err) {
-			logger.warn?.({ err }, 'previous media_conn fetch failed, will retry')
-			mediaConn = undefined
-			return undefined
-		}
-	}
-
-	const refreshMediaConn = async (forceGet = false): Promise<MediaConnInfo> => {
-		const cached = await safeAwaitMediaConn()
-		if (cached && !forceGet && new Date().getTime() - cached.fetchDate.getTime() <= cached.ttl * 1000) {
-			return cached
-		}
-
-		return mediaConnMutex.mutex(async () => {
-			// Re-check inside the lock: another caller may have refreshed.
-			const after = await safeAwaitMediaConn()
-			if (after && !forceGet && new Date().getTime() - after.fetchDate.getTime() <= after.ttl * 1000) {
-				return after
-			}
-
-			mediaConn = (async () => {
-				const result = await query({
-					tag: 'iq',
-					attrs: {
-						type: 'set',
-						xmlns: 'w:m',
-						to: S_WHATSAPP_NET
-					},
-					content: [{ tag: 'media_conn', attrs: {} }]
-				})
-				const mediaConnNode = getBinaryNodeChild(result, 'media_conn')!
-				const node: MediaConnInfo = {
-					hosts: getBinaryNodeChildren(mediaConnNode, 'host').map(({ attrs }) => ({
-						hostname: attrs.hostname!,
-						maxContentLengthBytes: +attrs.maxContentLengthBytes!
-					})),
-					auth: mediaConnNode.attrs.auth!,
-					ttl: +mediaConnNode.attrs.ttl!,
-					fetchDate: new Date()
-				}
-				logger.debug('fetched media conn')
-				if (node.hosts[0]) {
-					mediaHost = node.hosts[0].hostname
-				}
-
-				return node
-			})()
-
-			return mediaConn
-		})
-	}
+	// `mediaConn` / `mediaHost` / `refreshMediaConn` moved to the base
+	// socket in Stage 11 so chats.ts (which is BELOW this layer in the
+	// socket layering) can also route its app-state / history-sync
+	// downloads through the correct CDN shard. We just pull the helpers
+	// out of `sock`.
 
 	/**
 	 * generic send receipt function
@@ -1324,7 +1254,9 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 			userDevicesCache.close()
 		}
 
-		mediaConn = undefined
+		// `mediaConn` clearing now lives in the base socket's own
+		// teardown — moved alongside the rest of the media-conn
+		// machinery in Stage 11.
 		if (messageRetryManager) {
 			messageRetryManager.clear()
 		}
@@ -1346,10 +1278,10 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	 */
 	const downloadMediaMessageWithHost = <Type extends 'buffer' | 'stream'>(
 		...[message, type, options, ctx]: Parameters<typeof downloadMediaMessage<Type>>
-	) => downloadMediaMessage<Type>(message, type, { host: mediaHost, ...options }, ctx)
+	) => downloadMediaMessage<Type>(message, type, { host: getMediaHost(), ...options }, ctx)
 
 	const downloadContentFromMessageWithHost: typeof downloadContentFromMessage = (message, type, opts = {}) =>
-		downloadContentFromMessage(message, type, { host: mediaHost, ...opts })
+		downloadContentFromMessage(message, type, { host: getMediaHost(), ...opts })
 
 	return {
 		...sock,
@@ -1362,10 +1294,12 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		sendReceipts,
 		readMessages,
 		refreshMediaConn,
-		// Function (not getter) so the spread in chats.ts preserves the live closure binding.
-		getMediaHost: () => mediaHost,
+		// `getMediaHost` is already re-exported from the base socket via
+		// the `...sock` spread above. Keeping the explicit re-export here
+		// so the typed return shape from this layer is unchanged.
+		getMediaHost,
 		/** Build a media URL using the socket's current `media_conn` host. */
-		getMediaUrl: (directPath: string) => getUrlFromDirectPath(directPath, mediaHost),
+		getMediaUrl: (directPath: string) => getUrlFromDirectPath(directPath, getMediaHost()),
 		/**
 		 * Download a media message via the per-socket `media_conn` host. Same
 		 * signature as the standalone utility; pass `options.host` to
@@ -1411,7 +1345,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 								}
 
 								content.directPath = media.directPath
-								content.url = getUrlFromDirectPath(content.directPath!, mediaHost)
+								content.url = getUrlFromDirectPath(content.directPath!, getMediaHost())
 
 								logger.debug({ directPath: media.directPath, key: result.key }, 'media update successful')
 							} catch (err: any) {

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -675,7 +675,25 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 			})
 		}
 
-		await authState.keys.transaction(async () => {
+		// H0 fix: NO outer `keys.transaction` here. Wrapping relayMessage in an
+		// outer legacy transaction makes every inner `transactWith` (e.g. the
+		// per-session lock in `encryptMessage`) NESTED. Nested transactWiths
+		// release their per-record lock when `work()` returns but defer the
+		// durable commit to the outermost transaction. While the outer is still
+		// running between encrypt-release and outer-commit, a concurrent inbound
+		// decrypt for the same wireJid can acquire `session:wireJid`, load the
+		// pre-commit state from durable storage, advance its receiving chain,
+		// and commit — clobbering the sending-chain advance the encrypt was
+		// going to commit later. The bench trace shows this directly: same
+		// `wireJid`, encrypt stages `BacNgC: N+1`, concurrent decrypt's commit
+		// lands with `BacNgC: N` (the pre-encrypt value), and the next encrypt
+		// re-emits counter N → peer reports "old counter N+1 / N".
+		//
+		// The inner `transactWith({ records: [{ type: 'session', id: wireJid }] })`
+		// in `signalRepository.encryptMessage` is the correct serialization
+		// scope: it commits atomically per encrypt and naturally serializes
+		// against inbound decrypts on the same wireJid.
+		await (async () => {
 			const mediaType = getMediaType(message)
 			if (mediaType) {
 				extraAttrs['mediatype'] = mediaType
@@ -1148,7 +1166,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 			if (messageRetryManager && !participant) {
 				messageRetryManager.addRecentMessage(destinationJid, msgId, message)
 			}
-		}, meId)
+		})()
 
 		return msgId
 	}

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -19,6 +19,8 @@ import {
 	bindWaitForEvent,
 	decryptMediaRetryData,
 	DEF_MEDIA_HOST,
+	downloadContentFromMessage,
+	downloadMediaMessage,
 	encodeNewsletterMessage,
 	encodeSignedDeviceIdentity,
 	encodeWAMessage,
@@ -1328,6 +1330,27 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		}
 	})
 
+	/**
+	 * Download helpers that auto-inject the per-socket `mediaHost` (the
+	 * hostname WhatsApp returned in the last `media_conn` IQ — see
+	 * `refreshMediaConn` above). Routing downloads through the assigned
+	 * host avoids hitting the wrong shard / regional CDN and matches the
+	 * behavior the upload path already has via `getWAUploadToServer`.
+	 *
+	 * Callers can still pass `options.host` to override (e.g. to follow a
+	 * redirect to a different shard); the auto-injection only fills the
+	 * default. Callers can also still import the standalone utilities
+	 * `downloadMediaMessage` / `downloadContentFromMessage` if they want
+	 * to bypass the socket binding entirely (e.g. historical messages
+	 * downloaded after the socket has closed).
+	 */
+	const downloadMediaMessageWithHost = <Type extends 'buffer' | 'stream'>(
+		...[message, type, options, ctx]: Parameters<typeof downloadMediaMessage<Type>>
+	) => downloadMediaMessage<Type>(message, type, { host: mediaHost, ...options }, ctx)
+
+	const downloadContentFromMessageWithHost: typeof downloadContentFromMessage = (message, type, opts = {}) =>
+		downloadContentFromMessage(message, type, { host: mediaHost, ...opts })
+
 	return {
 		...sock,
 		userDevicesCache,
@@ -1341,6 +1364,20 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		refreshMediaConn,
 		// Function (not getter) so the spread in chats.ts preserves the live closure binding.
 		getMediaHost: () => mediaHost,
+		/** Build a media URL using the socket's current `media_conn` host. */
+		getMediaUrl: (directPath: string) => getUrlFromDirectPath(directPath, mediaHost),
+		/**
+		 * Download a media message via the per-socket `media_conn` host. Same
+		 * signature as the standalone utility; pass `options.host` to
+		 * override the auto-injected default.
+		 */
+		downloadMediaMessage: downloadMediaMessageWithHost,
+		/**
+		 * Lower-level helper if you already have a `DownloadableMessage`
+		 * (e.g. extracted from a quoted message). Auto-injects the
+		 * socket's `mediaHost`.
+		 */
+		downloadContentFromMessage: downloadContentFromMessageWithHost,
 		waUploadToServer,
 		fetchPrivacySettings,
 		sendPeerDataOperationMessage,

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -16,6 +16,7 @@ import {
 import {
 	type AuthenticationCreds,
 	type LIDMapping,
+	type MediaConnInfo,
 	type NewChatMessageCapInfo,
 	QueryIds,
 	ReachoutTimelockEnforcementType,
@@ -31,6 +32,7 @@ import {
 	bytesToCrockford,
 	configureSuccessfulPairing,
 	Curve,
+	DEF_MEDIA_HOST,
 	derivePairingCodeKey,
 	generateLoginNode,
 	generateMdTagPrefix,
@@ -45,6 +47,7 @@ import {
 	signedKeyPair,
 	xmppSignedPreKey
 } from '../Utils'
+import { makeMutex } from '../Utils/make-mutex'
 import {
 	assertNodeErrorFree,
 	type BinaryNode,
@@ -268,6 +271,85 @@ export const makeSocket = (config: SocketConfig) => {
 
 		return result
 	}
+
+	// --- media_conn machinery ---
+	//
+	// `mediaHost` is the per-socket CDN hostname WhatsApp returned in the
+	// most recent `media_conn` IQ. Lives on the BASE socket so every
+	// layer above (chats.ts app-state sync, messages-send.ts uploads,
+	// process-message.ts history sync) can route their downloads /
+	// uploads through the correct shard for this connection. Pre-Stage-11
+	// it lived in messages-send.ts which made it invisible to chats.ts
+	// (lower in the layering) — app-state external-blob downloads kept
+	// hitting `mmg.whatsapp.net` even when the socket was assigned a
+	// different host, producing 400s under `extractSyncdPatches`.
+	let mediaConn: Promise<MediaConnInfo> | undefined
+	let mediaHost: string = DEF_MEDIA_HOST
+	const mediaConnMutex = makeMutex()
+
+	/**
+	 * Safely await the cached `mediaConn`. A previously-stored rejected
+	 * promise would otherwise rethrow forever and poison every caller;
+	 * we catch, clear the slot, and let the caller fall through to a
+	 * fresh fetch.
+	 */
+	const safeAwaitMediaConn = async (): Promise<MediaConnInfo | undefined> => {
+		if (!mediaConn) return undefined
+		try {
+			return await mediaConn
+		} catch (err) {
+			logger.warn?.({ err }, 'previous media_conn fetch failed, will retry')
+			mediaConn = undefined
+			return undefined
+		}
+	}
+
+	const refreshMediaConn = async (forceGet = false): Promise<MediaConnInfo> => {
+		const cached = await safeAwaitMediaConn()
+		if (cached && !forceGet && new Date().getTime() - cached.fetchDate.getTime() <= cached.ttl * 1000) {
+			return cached
+		}
+
+		return mediaConnMutex.mutex(async () => {
+			// Re-check inside the lock: another caller may have refreshed.
+			const after = await safeAwaitMediaConn()
+			if (after && !forceGet && new Date().getTime() - after.fetchDate.getTime() <= after.ttl * 1000) {
+				return after
+			}
+
+			mediaConn = (async () => {
+				const result = await query({
+					tag: 'iq',
+					attrs: {
+						type: 'set',
+						xmlns: 'w:m',
+						to: S_WHATSAPP_NET
+					},
+					content: [{ tag: 'media_conn', attrs: {} }]
+				})
+				const mediaConnNode = getBinaryNodeChild(result, 'media_conn')!
+				const node: MediaConnInfo = {
+					hosts: getBinaryNodeChildren(mediaConnNode, 'host').map(({ attrs }) => ({
+						hostname: attrs.hostname!,
+						maxContentLengthBytes: +attrs.maxContentLengthBytes!
+					})),
+					auth: mediaConnNode.attrs.auth!,
+					ttl: +mediaConnNode.attrs.ttl!,
+					fetchDate: new Date()
+				}
+				logger.debug('fetched media conn')
+				if (node.hosts[0]) {
+					mediaHost = node.hosts[0].hostname
+				}
+
+				return node
+			})()
+
+			return mediaConn
+		})
+	}
+
+	const getMediaHost = () => mediaHost
 
 	// Validate current key-bundle on server; on failure, trigger pre-key upload and rethrow
 	const digestKeyBundle = async (): Promise<void> => {
@@ -1011,6 +1093,23 @@ export const makeSocket = (config: SocketConfig) => {
 			} catch (e) {
 				logger.warn({ e }, 'failed to run digest after login')
 			}
+
+			// Pre-fetch the media_conn host once the socket is ready so
+			// later downloads (app-state external blobs, history sync,
+			// media messages) hit the CDN shard WhatsApp assigned this
+			// connection instead of the hardcoded `mmg.whatsapp.net`
+			// fallback. The result is cached + TTL-managed inside
+			// `refreshMediaConn` itself, so subsequent calls are no-ops
+			// until the TTL expires. Failure here is non-fatal — uploads
+			// already re-fetch on demand, and downloads fall back to
+			// `DEF_MEDIA_HOST` (so we end up where we were before this
+			// fix), just with a structured warning the operator can
+			// alert on.
+			try {
+				await refreshMediaConn()
+			} catch (err) {
+				logger.warn({ err }, 'failed to pre-fetch media_conn on socket open')
+			}
 		} catch (err) {
 			logger.warn({ err }, 'failed to send initial passive iq')
 		}
@@ -1241,6 +1340,11 @@ export const makeSocket = (config: SocketConfig) => {
 		uploadPreKeysToServerIfRequired,
 		digestKeyBundle,
 		rotateSignedPreKey,
+		// Media routing (Stage 11): per-socket `media_conn`-derived host so
+		// any layer above can route its downloads / uploads through the
+		// shard WhatsApp assigned this connection.
+		refreshMediaConn,
+		getMediaHost,
 		requestPairingCode,
 		updateServerTimeOffset,
 		sendUnifiedSession,

--- a/src/Utils/chat-utils.ts
+++ b/src/Utils/chat-utils.ts
@@ -374,7 +374,20 @@ export const decodeSyncdPatch = async (
 	return result
 }
 
-export const extractSyncdPatches = async (result: BinaryNode, options: RequestInit) => {
+/**
+ * Decode the `<sync>` IQ result returned by the app-state-sync endpoint.
+ * When a collection's mutations are too large to fit inline, they're
+ * carried as an `ExternalBlobReference`; we fetch the blob via
+ * `downloadExternalBlob` — which in turn calls
+ * `downloadContentFromMessage` to hit the WhatsApp media CDN.
+ *
+ * `host` is the optional per-socket media-CDN hostname (from
+ * `sock.getMediaHost()`). Passing it threads through to the download so
+ * we hit the correct shard for this socket's region; omit it and the
+ * download falls back to `DEF_MEDIA_HOST` (`mmg.whatsapp.net`) which
+ * may 400 on regions WhatsApp routed to a different host.
+ */
+export const extractSyncdPatches = async (result: BinaryNode, options: RequestInit, host?: string) => {
 	const syncNode = getBinaryNodeChild(result, 'sync')
 	const collectionNodes = getBinaryNodeChildren(syncNode, 'collection')
 
@@ -400,7 +413,7 @@ export const extractSyncdPatches = async (result: BinaryNode, options: RequestIn
 				}
 
 				const blobRef = proto.ExternalBlobReference.decode(snapshotNode.content as Buffer)
-				const data = await downloadExternalBlob(blobRef, options)
+				const data = await downloadExternalBlob(blobRef, options, host)
 				snapshot = proto.SyncdSnapshot.decode(data)
 			}
 
@@ -426,8 +439,8 @@ export const extractSyncdPatches = async (result: BinaryNode, options: RequestIn
 	return final
 }
 
-export const downloadExternalBlob = async (blob: proto.IExternalBlobReference, options: RequestInit) => {
-	const stream = await downloadContentFromMessage(blob, 'md-app-state', { options })
+export const downloadExternalBlob = async (blob: proto.IExternalBlobReference, options: RequestInit, host?: string) => {
+	const stream = await downloadContentFromMessage(blob, 'md-app-state', { options, host })
 	const bufferArray: Buffer[] = []
 	for await (const chunk of stream) {
 		bufferArray.push(chunk)
@@ -436,8 +449,12 @@ export const downloadExternalBlob = async (blob: proto.IExternalBlobReference, o
 	return Buffer.concat(bufferArray)
 }
 
-export const downloadExternalPatch = async (blob: proto.IExternalBlobReference, options: RequestInit) => {
-	const buffer = await downloadExternalBlob(blob, options)
+export const downloadExternalPatch = async (
+	blob: proto.IExternalBlobReference,
+	options: RequestInit,
+	host?: string
+) => {
+	const buffer = await downloadExternalBlob(blob, options, host)
 	const syncData = proto.SyncdMutations.decode(buffer)
 	return syncData
 }
@@ -507,7 +524,8 @@ export const decodePatches = async (
 	options: RequestInit,
 	minimumVersionNumber?: number,
 	logger?: ILogger,
-	validateMacs = true
+	validateMacs = true,
+	host?: string
 ) => {
 	const newState: LTHashState = {
 		...initial,
@@ -520,7 +538,7 @@ export const decodePatches = async (
 		const { version, keyId, snapshotMac } = syncd
 		if (syncd.externalMutations) {
 			logger?.trace({ name, version }, 'downloading external patch')
-			const ref = await downloadExternalPatch(syncd.externalMutations, options)
+			const ref = await downloadExternalPatch(syncd.externalMutations, options, host)
 			logger?.debug({ name, version, mutations: ref.mutations.length }, 'downloaded external patch')
 			syncd.mutations?.push(...ref.mutations)
 		}

--- a/src/Utils/history.ts
+++ b/src/Utils/history.ts
@@ -30,8 +30,12 @@ const extractPnFromMessages = (messages: proto.IHistorySyncMsg[]): string | unde
 	return undefined
 }
 
-export const downloadHistory = async (msg: proto.Message.IHistorySyncNotification, options: RequestInit) => {
-	const stream = await downloadContentFromMessage(msg, 'md-msg-hist', { options })
+export const downloadHistory = async (
+	msg: proto.Message.IHistorySyncNotification,
+	options: RequestInit,
+	host?: string
+) => {
+	const stream = await downloadContentFromMessage(msg, 'md-msg-hist', { options, host })
 	// Pipe decrypted stream directly through zlib inflate
 	// This avoids allocating an intermediate buffer for the compressed data
 	const inflater = createInflate()
@@ -142,13 +146,14 @@ export const processHistoryMessage = (item: proto.IHistorySync, logger?: ILogger
 export const downloadAndProcessHistorySyncNotification = async (
 	msg: proto.Message.IHistorySyncNotification,
 	options: RequestInit,
-	logger?: ILogger
+	logger?: ILogger,
+	host?: string
 ) => {
 	let historyMsg: proto.HistorySync
 	if (msg.initialHistBootstrapInlinePayload) {
 		historyMsg = proto.HistorySync.decode(await inflatePromise(msg.initialHistBootstrapInlinePayload))
 	} else {
-		historyMsg = await downloadHistory(msg, options)
+		historyMsg = await downloadHistory(msg, options, host)
 	}
 
 	return processHistoryMessage(historyMsg, logger)

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -75,6 +75,13 @@ type ProcessMessageContext = {
 	options: RequestInit
 	signalRepository: SignalRepositoryWithLIDStore
 	getMessage: SocketConfig['getMessage']
+	/**
+	 * Optional getter for the per-socket `media_conn` CDN host. When
+	 * provided, history-sync downloads route through it; otherwise they
+	 * fall back to `DEF_MEDIA_HOST` and may 400 in regions WhatsApp
+	 * shards to a non-default CDN.
+	 */
+	getMediaHost?: () => string
 }
 
 const REAL_MSG_STUB_TYPES = new Set([
@@ -331,7 +338,8 @@ const processMessage = async (
 		keyStore,
 		logger,
 		options,
-		getMessage
+		getMessage,
+		getMediaHost
 	}: ProcessMessageContext
 ) => {
 	// M8: idempotency guard. Redelivered messages (from a retry-receipt
@@ -470,7 +478,12 @@ const processMessage = async (
 							})
 						}
 
-						const data = await downloadAndProcessHistorySyncNotification(histNotification, options, logger)
+						const data = await downloadAndProcessHistorySyncNotification(
+							histNotification,
+							options,
+							logger,
+							getMediaHost?.()
+						)
 
 						if (data.lidPnMappings?.length) {
 							logger?.debug({ count: data.lidPnMappings.length }, 'processing LID-PN mappings from history sync')


### PR DESCRIPTION
The send side already routes uploads through hostnames returned by the latest `media_conn` IQ (via `getWAUploadToServer` iterating `uploadInfo.hosts`), but the receive side used a hardcoded `mmg.whatsapp.net` (`DEF_MEDIA_HOST`) for downloads unless callers manually threaded `options.host` through every call site. Callers rarely did, so downloads on sockets routed to a non-default shard hit the wrong CDN — silent 4xx-or-slow with no obvious diagnostic.

## What changed

Three helpers exposed on the socket, each auto-injecting the current `mediaHost` (updated whenever `refreshMediaConn` runs):

- `sock.getMediaUrl(directPath)` — builds a media URL using the current media_conn host.
- `sock.downloadMediaMessage(msg, type, options?, ctx?)` — same signature as the standalone utility but with `options.host` pre-filled. Callers can still override via `options.host`.
- `sock.downloadContentFromMessage(downloadable, type, opts?)` — lower-level for when you already have a `DownloadableMessage` (e.g. extracted from a quoted message).

## Back-compat

Standalone utility exports (`downloadMediaMessage`, `downloadContentFromMessage`, `getUrlFromDirectPath`) keep working unchanged. They're useful for downloading historical media after the socket has closed, or in test fixtures. The new socket bindings just wrap them with the host pre-filled.

## Design

1. `mediaHost` is read lazily inside the wrapper closure (not captured at definition), so a refresh between the wrapper's definition and the actual call picks up the new host.
2. Spread order is `{ host: mediaHost, ...options }` so a caller override always wins — the auto-inject only fills the default.

## Verification

50 suites pass / 486 + 5 todo / 0 lint errors / types clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Socket caches and refreshes per-connection media CDN info and exposes refresh/get APIs.
  * Download helpers and media URL generation now default to the socket’s active media host; media host is threaded through sync, history, and message processing for consistent CDN routing.
  * Send flow simplified to avoid nested transaction scopes during encryption/session operations.

* **New Features**
  * Added a benchmark runner to measure connection CPU/memory across repeated socket runs.

* **Chores**
  * .gitignore updated to exclude benchmark logs and test DB.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->