### PR TITLE
perf(auth): remove global mutex from cacheable signal key store

### DIFF
--- a/src/Utils/auth-utils.ts
+++ b/src/Utils/auth-utils.ts
@@ -47,8 +47,16 @@ export function makeCacheableSignalKeyStore(
 			deleteOnExpire: true
 		})
 
-	// Mutex for protecting cache operations
-	const cacheMutex = new Mutex()
+	// Note: no global mutex here. The cache is a read-through write-through
+	// layer over `store`; the worst a race can do is trigger a redundant
+	// `store.get` for the same missing id (idempotent) or have two writers
+	// repopulate the same cache entry with the same value. Serializing all
+	// signal key access through one mutex created contention on hot paths
+	// (decrypt fan-out, group sender keys) for no correctness benefit —
+	// the underlying store is the source of truth. Concurrency that must
+	// be serialized (read-modify-write of pre-keys, transactional sets)
+	// is handled by `addTransactionCapability` below, which uses per-key
+	// mutexes.
 
 	function getUniqueId(type: string, id: string) {
 		return `${type}.${id}`
@@ -56,48 +64,44 @@ export function makeCacheableSignalKeyStore(
 
 	return {
 		async get(type, ids) {
-			return cacheMutex.runExclusive(async () => {
-				const data: { [_: string]: SignalDataTypeMap[typeof type] } = {}
-				const idsToFetch: string[] = []
+			const data: { [_: string]: SignalDataTypeMap[typeof type] } = {}
+			const idsToFetch: string[] = []
 
-				for (const id of ids) {
-					const item = (await cache.get<SignalDataTypeMap[typeof type]>(getUniqueId(type, id))) as any
-					if (typeof item !== 'undefined') {
+			for (const id of ids) {
+				const item = (await cache.get<SignalDataTypeMap[typeof type]>(getUniqueId(type, id))) as any
+				if (typeof item !== 'undefined') {
+					data[id] = item
+				} else {
+					idsToFetch.push(id)
+				}
+			}
+
+			if (idsToFetch.length) {
+				logger?.trace({ items: idsToFetch.length }, 'loading from store')
+				const fetched = await store.get(type, idsToFetch)
+				for (const id of idsToFetch) {
+					const item = fetched[id]
+					if (item) {
 						data[id] = item
-					} else {
-						idsToFetch.push(id)
+						// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+						await cache.set(getUniqueId(type, id), item as SignalDataTypeMap[keyof SignalDataTypeMap])
 					}
 				}
+			}
 
-				if (idsToFetch.length) {
-					logger?.trace({ items: idsToFetch.length }, 'loading from store')
-					const fetched = await store.get(type, idsToFetch)
-					for (const id of idsToFetch) {
-						const item = fetched[id]
-						if (item) {
-							data[id] = item
-							// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-							await cache.set(getUniqueId(type, id), item as SignalDataTypeMap[keyof SignalDataTypeMap])
-						}
-					}
-				}
-
-				return data
-			})
+			return data
 		},
 		async set(data) {
-			return cacheMutex.runExclusive(async () => {
-				let keys = 0
-				for (const type in data) {
-					for (const id in data[type as keyof SignalDataTypeMap]) {
-						await cache.set(getUniqueId(type, id), data[type as keyof SignalDataTypeMap]![id]!)
-						keys += 1
-					}
+			let keys = 0
+			for (const type in data) {
+				for (const id in data[type as keyof SignalDataTypeMap]) {
+					await cache.set(getUniqueId(type, id), data[type as keyof SignalDataTypeMap]![id]!)
+					keys += 1
 				}
+			}
 
-				logger?.trace({ keys }, 'updated cache')
-				await store.set(data)
-			})
+			logger?.trace({ keys }, 'updated cache')
+			await store.set(data)
 		},
 		async clear() {
 			await cache.flushAll()


### PR DESCRIPTION
`makeCacheableSignalKeyStore()` wrapped every `get()` and `set()` in a single shared `async-mutex` (`cacheMutex.runExclusive`). That mutex serialized **all** signal key access for the connection: every decrypt fan-out, every group sender-key lookup, every pre-key read queued behind the same lock — even for unrelated key types and IDs.

The mutex was not protecting anything correctness-critical. The cache is a read-through / write-through layer over the underlying store, which is the source of truth. The worst a race can do is:

- **On `get()`**: two concurrent callers miss the same id and both call `store.get()` — idempotent, returns the same value; last writer into the cache wins with the same value.
- **On `set()`**: the underlying `store.set()` is awaited; `cache.set()` is a best-effort write of the value we just persisted.

Operations that genuinely require serialization (read-modify-write of pre-keys, transactional batches) are handled by `addTransactionCapability` further down in the same file using **per-key** mutexes — not touched by this change.

API and types are unchanged. All 404 existing tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the global `async-mutex` from `makeCacheableSignalKeyStore` to eliminate cross-key serialization and improve concurrency on hot paths (decrypt fan-out, sender-key lookups, pre-key reads). API is unchanged; the cache stays read-through/write-through to the underlying store.

- **Refactors**
  - Removed shared lock around `get()` and `set()`, allowing concurrent cache misses/fills; the underlying store is the source of truth.
  - Kept required serialization via per-key mutexes in `addTransactionCapability` for read-modify-write and transactional work.

<sup>Written for commit 70eb9f4fba5aa7ef4da0a336b971cb8869ccd574. Summary will update on new commits. <a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2593?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance and concurrency handling in authentication caching mechanisms while maintaining existing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->