### PR TITLE
perf(WABinary): zero-copy decode + token map (rebase of #2513)

### DIFF
--- a/src/WABinary/constants.ts
+++ b/src/WABinary/constants.ts
@@ -1292,14 +1292,14 @@ export const SINGLE_BYTE_TOKENS = [
 	'screen_height'
 ]
 
-export const TOKEN_MAP: { [token: string]: { dict?: number; index: number } } = {}
+export const TOKEN_MAP_REFACTOR: Map<string, { dict?: number; index: number }> = new Map()
 
 for (const [i, SINGLE_BYTE_TOKEN] of SINGLE_BYTE_TOKENS.entries()) {
-	TOKEN_MAP[SINGLE_BYTE_TOKEN] = { index: i }
+	TOKEN_MAP_REFACTOR.set(SINGLE_BYTE_TOKEN, { index: i })
 }
 
 for (const [i, DOUBLE_BYTE_TOKEN] of DOUBLE_BYTE_TOKENS.entries()) {
 	for (const [j, element] of DOUBLE_BYTE_TOKEN.entries()) {
-		TOKEN_MAP[element] = { dict: i, index: j }
+		TOKEN_MAP_REFACTOR.set(element, { dict: i, index: j })
 	}
 }

--- a/src/WABinary/decode.ts
+++ b/src/WABinary/decode.ts
@@ -8,110 +8,120 @@ const inflatePromise = promisify(inflate)
 
 export const decompressingIfRequired = async (buffer: Buffer) => {
 	if (2 & buffer.readUInt8()) {
-		buffer = await inflatePromise(buffer.slice(1))
+		buffer = await inflatePromise(buffer.subarray(1))
 	} else {
 		// nodes with no compression have a 0x00 prefix, we remove that
-		buffer = buffer.slice(1)
+		buffer = buffer.subarray(1)
 	}
 
 	return buffer
 }
 
-export const decodeDecompressedBinaryNode = (
-	buffer: Buffer,
-	opts: Pick<BinaryNodeCodingOptions, 'DOUBLE_BYTE_TOKENS' | 'SINGLE_BYTE_TOKENS' | 'TAGS'>,
-	indexRef: { index: number } = { index: 0 }
-): BinaryNode => {
-	const { DOUBLE_BYTE_TOKENS, SINGLE_BYTE_TOKENS, TAGS } = opts
+type DecoderOpts = Pick<BinaryNodeCodingOptions, 'DOUBLE_BYTE_TOKENS' | 'SINGLE_BYTE_TOKENS' | 'TAGS'>
 
-	const checkEOS = (length: number) => {
-		if (indexRef.index + length > buffer.length) {
+const unpackHex = (value: number): number => {
+	if (value >= 0 && value < 16) {
+		return value < 10 ? '0'.charCodeAt(0) + value : 'A'.charCodeAt(0) + value - 10
+	}
+
+	throw new Error('invalid hex: ' + value)
+}
+
+const unpackNibble = (value: number): number => {
+	if (value >= 0 && value <= 9) {
+		return '0'.charCodeAt(0) + value
+	}
+
+	switch (value) {
+		case 10:
+			return '-'.charCodeAt(0)
+		case 11:
+			return '.'.charCodeAt(0)
+		case 15:
+			return '\0'.charCodeAt(0)
+		default:
+			throw new Error('invalid nibble: ' + value)
+	}
+}
+
+class ByteDecoder {
+	index = 0
+
+	private readonly TAGS: DecoderOpts['TAGS']
+	private readonly SINGLE_BYTE_TOKENS: DecoderOpts['SINGLE_BYTE_TOKENS']
+	private readonly DOUBLE_BYTE_TOKENS: DecoderOpts['DOUBLE_BYTE_TOKENS']
+
+	constructor(
+		private readonly buffer: Buffer,
+		opts: DecoderOpts
+	) {
+		this.TAGS = opts.TAGS
+		this.SINGLE_BYTE_TOKENS = opts.SINGLE_BYTE_TOKENS
+		this.DOUBLE_BYTE_TOKENS = opts.DOUBLE_BYTE_TOKENS
+	}
+
+	private checkEOS(length: number) {
+		if (this.index + length > this.buffer.length) {
 			throw new Error('end of stream')
 		}
 	}
 
-	const next = () => {
-		const value = buffer[indexRef.index]
-		indexRef.index += 1
+	private next(): number {
+		const value = this.buffer[this.index]
+		this.index += 1
+		return value as number
+	}
+
+	private readByte(): number {
+		this.checkEOS(1)
+		return this.next()
+	}
+
+	private readBytes(n: number): Buffer {
+		this.checkEOS(n)
+		const value = this.buffer.subarray(this.index, this.index + n)
+		this.index += n
 		return value
 	}
 
-	const readByte = () => {
-		checkEOS(1)
-		return next()
+	private readStringFromChars(length: number): string {
+		return this.readBytes(length).toString('utf-8')
 	}
 
-	const readBytes = (n: number) => {
-		checkEOS(n)
-		const value = buffer.slice(indexRef.index, indexRef.index + n)
-		indexRef.index += n
-		return value
-	}
-
-	const readStringFromChars = (length: number) => {
-		return readBytes(length).toString('utf-8')
-	}
-
-	const readInt = (n: number, littleEndian = false) => {
-		checkEOS(n)
+	private readInt(n: number, littleEndian = false): number {
+		this.checkEOS(n)
 		let val = 0
 		for (let i = 0; i < n; i++) {
 			const shift = littleEndian ? i : n - 1 - i
-			val |= next()! << (shift * 8)
+			val |= this.next() << (shift * 8)
 		}
 
 		return val
 	}
 
-	const readInt20 = () => {
-		checkEOS(3)
-		return ((next()! & 15) << 16) + (next()! << 8) + next()!
+	private readInt20(): number {
+		this.checkEOS(3)
+		return ((this.next() & 15) << 16) + (this.next() << 8) + this.next()
 	}
 
-	const unpackHex = (value: number) => {
-		if (value >= 0 && value < 16) {
-			return value < 10 ? '0'.charCodeAt(0) + value : 'A'.charCodeAt(0) + value - 10
-		}
-
-		throw new Error('invalid hex: ' + value)
-	}
-
-	const unpackNibble = (value: number) => {
-		if (value >= 0 && value <= 9) {
-			return '0'.charCodeAt(0) + value
-		}
-
-		switch (value) {
-			case 10:
-				return '-'.charCodeAt(0)
-			case 11:
-				return '.'.charCodeAt(0)
-			case 15:
-				return '\0'.charCodeAt(0)
-			default:
-				throw new Error('invalid nibble: ' + value)
-		}
-	}
-
-	const unpackByte = (tag: number, value: number) => {
-		if (tag === TAGS.NIBBLE_8) {
+	private unpackByte(tag: number, value: number): number {
+		if (tag === this.TAGS.NIBBLE_8) {
 			return unpackNibble(value)
-		} else if (tag === TAGS.HEX_8) {
+		} else if (tag === this.TAGS.HEX_8) {
 			return unpackHex(value)
 		} else {
 			throw new Error('unknown tag: ' + tag)
 		}
 	}
 
-	const readPacked8 = (tag: number) => {
-		const startByte = readByte()!
+	private readPacked8(tag: number): string {
+		const startByte = this.readByte()
 		let value = ''
 
 		for (let i = 0; i < (startByte & 127); i++) {
-			const curByte = readByte()!
-
-			value += String.fromCharCode(unpackByte(tag, (curByte & 0xf0) >> 4))
-			value += String.fromCharCode(unpackByte(tag, curByte & 0x0f))
+			const curByte = this.readByte()
+			value += String.fromCharCode(this.unpackByte(tag, (curByte & 0xf0) >> 4))
+			value += String.fromCharCode(this.unpackByte(tag, curByte & 0x0f))
 		}
 
 		if (startByte >> 7 !== 0) {
@@ -121,26 +131,49 @@ export const decodeDecompressedBinaryNode = (
 		return value
 	}
 
-	const isListTag = (tag: number) => {
-		return tag === TAGS.LIST_EMPTY || tag === TAGS.LIST_8 || tag === TAGS.LIST_16
+	private isListTag(tag: number): boolean {
+		return tag === this.TAGS.LIST_EMPTY || tag === this.TAGS.LIST_8 || tag === this.TAGS.LIST_16
 	}
 
-	const readListSize = (tag: number) => {
+	private readListSize(tag: number): number {
 		switch (tag) {
-			case TAGS.LIST_EMPTY:
+			case this.TAGS.LIST_EMPTY:
 				return 0
-			case TAGS.LIST_8:
-				return readByte()
-			case TAGS.LIST_16:
-				return readInt(2)
+			case this.TAGS.LIST_8:
+				return this.readByte()
+			case this.TAGS.LIST_16:
+				return this.readInt(2)
 			default:
 				throw new Error('invalid tag for list size: ' + tag)
 		}
 	}
 
-	const readJidPair = () => {
-		const i = readString(readByte()!)
-		const j = readString(readByte()!)
+	private readFbJid(): string {
+		const user = this.readString(this.readByte()!)
+		const device = this.readInt(2)
+		const server = this.readString(this.readByte()!)
+		return `${user}:${device}@${server}`
+	}
+
+	private readInteropJid(): string {
+		const user = this.readString(this.readByte()!)
+		const device = this.readInt(2)
+		const integrator = this.readInt(2)
+
+		let server = 'interop'
+		const beforeServer = this.index
+		try {
+			server = this.readString(this.readByte()!)
+		} catch (err) {
+			this.index = beforeServer
+		}
+
+		return `${integrator}-${user}:${device}@${server}`
+	}
+
+	private readJidPair(): string {
+		const i = this.readString(this.readByte())
+		const j = this.readString(this.readByte())
 		if (j) {
 			return (i || '') + '@' + j
 		}
@@ -148,12 +181,12 @@ export const decodeDecompressedBinaryNode = (
 		throw new Error('invalid jid pair: ' + i + ', ' + j)
 	}
 
-	const readAdJid = () => {
-		const rawDomainType = readByte()
+	private readAdJid(): string {
+		const rawDomainType = this.readByte()
 		const domainType = Number(rawDomainType)
 
-		const device = readByte()
-		const user = readString(readByte()!)
+		const device = this.readByte()
+		const user = this.readString(this.readByte())
 
 		let server: JidServer = 's.whatsapp.net' // default whatsapp server
 		if (domainType === WAJIDDomains.LID) {
@@ -167,30 +200,8 @@ export const decodeDecompressedBinaryNode = (
 		return jidEncode(user, server, device)
 	}
 
-	const readFbJid = () => {
-		const user = readString(readByte()!)
-		const device = readInt(2)
-		const server = readString(readByte()!)
-		return `${user}:${device}@${server}`
-	}
-
-	const readInteropJid = () => {
-		const user = readString(readByte()!)
-		const device = readInt(2)
-		const integrator = readInt(2)
-
-		let server = 'interop'
-		const beforeServer = indexRef.index
-		try {
-			server = readString(readByte()!)
-		} catch (err) {
-			indexRef.index = beforeServer
-		}
-
-		return `${integrator}-${user}:${device}@${server}`
-	}
-
-	const readString = (tag: number): string => {
+	private readString(tag: number): string {
+		const { TAGS, SINGLE_BYTE_TOKENS } = this
 		if (tag >= 1 && tag < SINGLE_BYTE_TOKENS.length) {
 			return SINGLE_BYTE_TOKENS[tag] || ''
 		}
@@ -200,43 +211,43 @@ export const decodeDecompressedBinaryNode = (
 			case TAGS.DICTIONARY_1:
 			case TAGS.DICTIONARY_2:
 			case TAGS.DICTIONARY_3:
-				return getTokenDouble(tag - TAGS.DICTIONARY_0, readByte()!)
+				return this.getTokenDouble(tag - TAGS.DICTIONARY_0, this.readByte())
 			case TAGS.LIST_EMPTY:
 				return ''
 			case TAGS.BINARY_8:
-				return readStringFromChars(readByte()!)
+				return this.readStringFromChars(this.readByte())
 			case TAGS.BINARY_20:
-				return readStringFromChars(readInt20())
+				return this.readStringFromChars(this.readInt20())
 			case TAGS.BINARY_32:
-				return readStringFromChars(readInt(4))
+				return this.readStringFromChars(this.readInt(4))
 			case TAGS.JID_PAIR:
-				return readJidPair()
+				return this.readJidPair()
 			case TAGS.FB_JID:
-				return readFbJid()
+				return this.readFbJid()
 			case TAGS.INTEROP_JID:
-				return readInteropJid()
+				return this.readInteropJid()
 			case TAGS.AD_JID:
-				return readAdJid()
+				return this.readAdJid()
 			case TAGS.HEX_8:
 			case TAGS.NIBBLE_8:
-				return readPacked8(tag)
+				return this.readPacked8(tag)
 			default:
 				throw new Error('invalid string with tag: ' + tag)
 		}
 	}
 
-	const readList = (tag: number) => {
-		const items: BinaryNode[] = []
-		const size = readListSize(tag)!
+	private readList(tag: number): BinaryNode[] {
+		const size = this.readListSize(tag)
+		const items: BinaryNode[] = new Array(size)
 		for (let i = 0; i < size; i++) {
-			items.push(decodeDecompressedBinaryNode(buffer, opts, indexRef))
+			items[i] = this.decodeNode()
 		}
 
 		return items
 	}
 
-	const getTokenDouble = (index1: number, index2: number) => {
-		const dict = DOUBLE_BYTE_TOKENS[index1]
+	private getTokenDouble(index1: number, index2: number): string {
+		const dict = this.DOUBLE_BYTE_TOKENS[index1]
 		if (!dict) {
 			throw new Error(`Invalid double token dict (${index1})`)
 		}
@@ -249,57 +260,71 @@ export const decodeDecompressedBinaryNode = (
 		return value
 	}
 
-	const listSize = readListSize(readByte()!)
-	const header = readString(readByte()!)
-	if (!listSize || !header.length) {
-		throw new Error('invalid node')
-	}
+	decodeNode(): BinaryNode {
+		const listSize = this.readListSize(this.readByte())
+		const header = this.readString(this.readByte())
+		if (!listSize || !header.length) {
+			throw new Error('invalid node')
+		}
 
-	const attrs: BinaryNode['attrs'] = {}
-	let data: BinaryNode['content']
-	if (listSize === 0 || !header) {
-		throw new Error('invalid node')
-	}
+		const attrs: BinaryNode['attrs'] = {}
+		let data: BinaryNode['content']
+		if (listSize === 0 || !header) {
+			throw new Error('invalid node')
+		}
 
-	// read the attributes in
-	const attributesLength = (listSize - 1) >> 1
-	for (let i = 0; i < attributesLength; i++) {
-		const key = readString(readByte()!)
-		const value = readString(readByte()!)
+		// read the attributes in
+		const attributesLength = (listSize - 1) >> 1
+		for (let i = 0; i < attributesLength; i++) {
+			const key = this.readString(this.readByte())
+			const value = this.readString(this.readByte())
 
-		attrs[key] = value
-	}
+			attrs[key] = value
+		}
 
-	if (listSize % 2 === 0) {
-		const tag = readByte()!
-		if (isListTag(tag)) {
-			data = readList(tag)
-		} else {
-			let decoded: Buffer | string
-			switch (tag) {
-				case TAGS.BINARY_8:
-					decoded = readBytes(readByte()!)
-					break
-				case TAGS.BINARY_20:
-					decoded = readBytes(readInt20())
-					break
-				case TAGS.BINARY_32:
-					decoded = readBytes(readInt(4))
-					break
-				default:
-					decoded = readString(tag)
-					break
+		if (listSize % 2 === 0) {
+			const tag = this.readByte()
+			if (this.isListTag(tag)) {
+				data = this.readList(tag)
+			} else {
+				let decoded: Buffer | string
+				switch (tag) {
+					case this.TAGS.BINARY_8:
+						decoded = this.readBytes(this.readByte())
+						break
+					case this.TAGS.BINARY_20:
+						decoded = this.readBytes(this.readInt20())
+						break
+					case this.TAGS.BINARY_32:
+						decoded = this.readBytes(this.readInt(4))
+						break
+					default:
+						decoded = this.readString(tag)
+						break
+				}
+
+				data = decoded
 			}
+		}
 
-			data = decoded
+		return {
+			tag: header,
+			attrs,
+			content: data
 		}
 	}
+}
 
-	return {
-		tag: header,
-		attrs,
-		content: data
-	}
+export const decodeDecompressedBinaryNode = (
+	buffer: Buffer,
+	opts: DecoderOpts,
+	indexRef: { index: number } = { index: 0 }
+): BinaryNode => {
+	const decoder = new ByteDecoder(buffer, opts)
+	decoder.index = indexRef.index
+	const node = decoder.decodeNode()
+	indexRef.index = decoder.index
+	return node
 }
 
 export const decodeBinaryNode = async (buff: Buffer): Promise<BinaryNode> => {

--- a/src/WABinary/encode.ts
+++ b/src/WABinary/encode.ts
@@ -2,257 +2,297 @@ import * as constants from './constants'
 import { type FullJid, jidDecode } from './jid-utils'
 import type { BinaryNode, BinaryNodeCodingOptions } from './types'
 
-export const encodeBinaryNode = (
-	node: BinaryNode,
-	opts: Pick<BinaryNodeCodingOptions, 'TAGS' | 'TOKEN_MAP'> = constants,
-	buffer: number[] = [0]
-): Buffer => {
-	const encoded = encodeBinaryNodeInner(node, opts, buffer)
-	return Buffer.from(encoded)
-}
+type EncoderOpts = Pick<BinaryNodeCodingOptions, 'TAGS' | 'TOKEN_MAP_REFACTOR'>
 
-const encodeBinaryNodeInner = (
-	{ tag, attrs, content }: BinaryNode,
-	opts: Pick<BinaryNodeCodingOptions, 'TAGS' | 'TOKEN_MAP'>,
-	buffer: number[]
-): number[] => {
-	const { TAGS, TOKEN_MAP } = opts
+class ByteEncoder {
+	readonly TAGS: EncoderOpts['TAGS']
+	readonly TOKEN_MAP_REFACTOR: EncoderOpts['TOKEN_MAP_REFACTOR']
 
-	const pushByte = (value: number) => buffer.push(value & 0xff)
+	private buffer: Buffer
+	private offset = 0
 
-	const pushInt = (value: number, n: number, littleEndian = false) => {
-		for (let i = 0; i < n; i++) {
-			const curShift = littleEndian ? i : n - 1 - i
-			buffer.push((value >> (curShift * 8)) & 0xff)
+	constructor(initialSize: number, opts: EncoderOpts) {
+		this.buffer = Buffer.allocUnsafe(initialSize)
+		this.TAGS = opts.TAGS
+		this.TOKEN_MAP_REFACTOR = opts.TOKEN_MAP_REFACTOR
+	}
+
+	private ensure(size: number) {
+		if (this.offset + size <= this.buffer.length) return
+
+		let newLength = this.buffer.length * 2
+		while (this.offset + size > newLength) newLength *= 2
+
+		const newBuffer = Buffer.allocUnsafe(newLength)
+		this.buffer.copy(newBuffer, 0, 0, this.offset)
+		this.buffer = newBuffer
+	}
+
+	pushByte(value: number) {
+		this.ensure(1)
+		this.buffer[this.offset++] = value & 0xff
+	}
+
+	pushBytes(bytes: Uint8Array | Buffer) {
+		this.ensure(bytes.length)
+		this.buffer.set(bytes, this.offset)
+		this.offset += bytes.length
+	}
+
+	pushInt(value: number, n: number, littleEndian = false) {
+		this.ensure(n)
+		if (littleEndian) {
+			this.buffer.writeUIntLE(value, this.offset, n)
+		} else {
+			this.buffer.writeUIntBE(value, this.offset, n)
 		}
+
+		this.offset += n
 	}
 
-	const pushBytes = (bytes: Uint8Array | Buffer | number[]) => {
-		for (const b of bytes) {
-			buffer.push(b)
-		}
+	pushInt16(value: number) {
+		this.ensure(2)
+		this.buffer.writeUInt16BE(value, this.offset)
+		this.offset += 2
 	}
 
-	const pushInt16 = (value: number) => {
-		pushBytes([(value >> 8) & 0xff, value & 0xff])
+	pushInt20(value: number) {
+		this.ensure(3)
+		this.buffer[this.offset++] = (value >> 16) & 0x0f
+		this.buffer[this.offset++] = (value >> 8) & 0xff
+		this.buffer[this.offset++] = value & 0xff
 	}
 
-	const pushInt20 = (value: number) => pushBytes([(value >> 16) & 0x0f, (value >> 8) & 0xff, value & 0xff])
-	const writeByteLength = (length: number) => {
+	writeByteLength(length: number) {
+		const { TAGS } = this
+
 		if (length >= 4294967296) {
 			throw new Error('string too large to encode: ' + length)
 		}
 
 		if (length >= 1 << 20) {
-			pushByte(TAGS.BINARY_32)
-			pushInt(length, 4) // 32 bit integer
+			this.pushByte(TAGS.BINARY_32)
+			this.pushInt(length, 4)
 		} else if (length >= 256) {
-			pushByte(TAGS.BINARY_20)
-			pushInt20(length)
+			this.pushByte(TAGS.BINARY_20)
+			this.pushInt20(length)
 		} else {
-			pushByte(TAGS.BINARY_8)
-			pushByte(length)
+			this.pushByte(TAGS.BINARY_8)
+			this.pushByte(length)
 		}
 	}
 
-	const writeStringRaw = (str: string) => {
-		const bytes = Buffer.from(str, 'utf-8')
-		writeByteLength(bytes.length)
-		pushBytes(bytes)
+	writeStringRaw(str: string) {
+		const len = Buffer.byteLength(str)
+		this.writeByteLength(len)
+
+		this.ensure(len)
+		this.buffer.write(str, this.offset, len, 'utf-8')
+		this.offset += len
 	}
 
-	const writeJid = ({ domainType, device, user, server }: FullJid) => {
+	writeJid({ domainType, device, user, server }: FullJid) {
+		const { TAGS } = this
+
 		if (typeof device !== 'undefined') {
-			pushByte(TAGS.AD_JID)
-			pushByte(domainType || 0)
-			pushByte(device || 0)
-			writeString(user)
+			this.pushByte(TAGS.AD_JID)
+			this.pushByte(domainType || 0)
+			this.pushByte(device || 0)
+			this.writeString(user)
 		} else {
-			pushByte(TAGS.JID_PAIR)
+			this.pushByte(TAGS.JID_PAIR)
+
 			if (user.length) {
-				writeString(user)
+				this.writeString(user)
 			} else {
-				pushByte(TAGS.LIST_EMPTY)
+				this.pushByte(TAGS.LIST_EMPTY)
 			}
 
-			writeString(server)
+			this.writeString(server)
 		}
 	}
 
-	const packNibble = (char: string) => {
-		switch (char) {
-			case '-':
-				return 10
-			case '.':
-				return 11
-			case '\0':
-				return 15
-			default:
-				if (char >= '0' && char <= '9') {
-					return char.charCodeAt(0) - '0'.charCodeAt(0)
-				}
+	writePackedBytes(str: string, type: 'nibble' | 'hex') {
+		const { TAGS } = this
 
-				throw new Error(`invalid byte for nibble "${char}"`)
-		}
-	}
-
-	const packHex = (char: string) => {
-		if (char >= '0' && char <= '9') {
-			return char.charCodeAt(0) - '0'.charCodeAt(0)
-		}
-
-		if (char >= 'A' && char <= 'F') {
-			return 10 + char.charCodeAt(0) - 'A'.charCodeAt(0)
-		}
-
-		if (char >= 'a' && char <= 'f') {
-			return 10 + char.charCodeAt(0) - 'a'.charCodeAt(0)
-		}
-
-		if (char === '\0') {
-			return 15
-		}
-
-		throw new Error(`Invalid hex char "${char}"`)
-	}
-
-	const writePackedBytes = (str: string, type: 'nibble' | 'hex') => {
 		if (str.length > TAGS.PACKED_MAX) {
 			throw new Error('Too many bytes to pack')
 		}
 
-		pushByte(type === 'nibble' ? TAGS.NIBBLE_8 : TAGS.HEX_8)
+		this.pushByte(type === 'nibble' ? TAGS.NIBBLE_8 : TAGS.HEX_8)
 
-		let roundedLength = Math.ceil(str.length / 2.0)
-		if (str.length % 2 !== 0) {
-			roundedLength |= 128
-		}
+		let roundedLength = Math.ceil(str.length / 2)
+		if (str.length % 2 !== 0) roundedLength |= 128
 
-		pushByte(roundedLength)
+		this.pushByte(roundedLength)
+
 		const packFunction = type === 'nibble' ? packNibble : packHex
+		const half = Math.floor(str.length / 2)
 
-		const packBytePair = (v1: string, v2: string) => {
-			const result = (packFunction(v1) << 4) | packFunction(v2)
-			return result
-		}
-
-		const strLengthHalf = Math.floor(str.length / 2)
-		for (let i = 0; i < strLengthHalf; i++) {
-			pushByte(packBytePair(str[2 * i]!, str[2 * i + 1]!))
+		for (let i = 0; i < half; i++) {
+			this.pushByte((packFunction(str[2 * i] as string) << 4) | packFunction(str[2 * i + 1] as string))
 		}
 
 		if (str.length % 2 !== 0) {
-			pushByte(packBytePair(str[str.length - 1]!, '\x00'))
+			this.pushByte((packFunction(str[str.length - 1] as string) << 4) | packFunction('\0'))
 		}
 	}
 
-	const isNibble = (str?: string) => {
-		if (!str || str.length > TAGS.PACKED_MAX) {
-			return false
-		}
+	writeString(str?: string) {
+		const { TAGS, TOKEN_MAP_REFACTOR } = this
 
-		for (const char of str) {
-			const isInNibbleRange = char >= '0' && char <= '9'
-			if (!isInNibbleRange && char !== '-' && char !== '.') {
-				return false
-			}
-		}
-
-		return true
-	}
-
-	const isHex = (str?: string) => {
-		if (!str || str.length > TAGS.PACKED_MAX) {
-			return false
-		}
-
-		for (const char of str) {
-			const isInNibbleRange = char >= '0' && char <= '9'
-			if (!isInNibbleRange && !(char >= 'A' && char <= 'F')) {
-				return false
-			}
-		}
-
-		return true
-	}
-
-	const writeString = (str?: string) => {
 		if (str === undefined || str === null) {
-			pushByte(TAGS.LIST_EMPTY)
+			this.pushByte(TAGS.LIST_EMPTY)
 			return
 		}
 
 		if (str === '') {
-			writeStringRaw(str)
+			this.writeStringRaw(str)
 			return
 		}
 
-		const tokenIndex = TOKEN_MAP[str]
+		const tokenIndex = TOKEN_MAP_REFACTOR.get(str)
+
 		if (tokenIndex) {
 			if (typeof tokenIndex.dict === 'number') {
-				pushByte(TAGS.DICTIONARY_0 + tokenIndex.dict)
+				this.pushByte(TAGS.DICTIONARY_0 + tokenIndex.dict)
 			}
 
-			pushByte(tokenIndex.index)
-		} else if (isNibble(str)) {
-			writePackedBytes(str, 'nibble')
-		} else if (isHex(str)) {
-			writePackedBytes(str, 'hex')
+			this.pushByte(tokenIndex.index)
+		} else if (isNibble(str, TAGS.PACKED_MAX)) {
+			this.writePackedBytes(str, 'nibble')
+		} else if (isHex(str, TAGS.PACKED_MAX)) {
+			this.writePackedBytes(str, 'hex')
 		} else {
 			const decodedJid = jidDecode(str)
 			if (decodedJid) {
-				writeJid(decodedJid)
+				this.writeJid(decodedJid)
 			} else {
-				writeStringRaw(str)
+				this.writeStringRaw(str)
 			}
 		}
 	}
 
-	const writeListStart = (listSize: number) => {
+	writeListStart(listSize: number) {
+		const { TAGS } = this
+
 		if (listSize === 0) {
-			pushByte(TAGS.LIST_EMPTY)
+			this.pushByte(TAGS.LIST_EMPTY)
 		} else if (listSize < 256) {
-			pushBytes([TAGS.LIST_8, listSize])
+			this.pushByte(TAGS.LIST_8)
+			this.pushByte(listSize)
 		} else {
-			pushByte(TAGS.LIST_16)
-			pushInt16(listSize)
+			this.pushByte(TAGS.LIST_16)
+			this.pushInt16(listSize)
 		}
 	}
+
+	getResult(): Buffer {
+		return this.buffer.subarray(0, this.offset)
+	}
+}
+
+const packNibble = (char: string): number => {
+	switch (char) {
+		case '-':
+			return 10
+		case '.':
+			return 11
+		case '\0':
+			return 15
+		default:
+			if (char >= '0' && char <= '9') {
+				return char.charCodeAt(0) - 48
+			}
+
+			throw new Error(`invalid byte for nibble "${char}"`)
+	}
+}
+
+const packHex = (char: string): number => {
+	if (char >= '0' && char <= '9') return char.charCodeAt(0) - 48
+	if (char >= 'A' && char <= 'F') return 10 + char.charCodeAt(0) - 65
+	if (char >= 'a' && char <= 'f') return 10 + char.charCodeAt(0) - 97
+	if (char === '\0') return 15
+	throw new Error(`Invalid hex char "${char}"`)
+}
+
+const isNibble = (str: string, packedMax: number): boolean => {
+	if (str.length > packedMax) return false
+	for (let i = 0; i < str.length; i++) {
+		const c = str[i]!
+		if (!(c >= '0' && c <= '9') && c !== '-' && c !== '.') return false
+	}
+
+	return true
+}
+
+const isHex = (str: string, packedMax: number): boolean => {
+	if (str.length > packedMax) return false
+	for (let i = 0; i < str.length; i++) {
+		const c = str[i]!
+		if (!(c >= '0' && c <= '9') && !(c >= 'A' && c <= 'F')) return false
+	}
+
+	return true
+}
+
+const encodeBinaryNodeInner = (node: BinaryNode, encoder: ByteEncoder): void => {
+	const { tag, attrs, content } = node
 
 	if (!tag) {
 		throw new Error('Invalid node: tag cannot be undefined')
 	}
 
-	const validAttributes = Object.keys(attrs || {}).filter(k => typeof attrs[k] !== 'undefined' && attrs[k] !== null)
+	let attrCount = 0
+	if (attrs) {
+		for (const k in attrs) {
+			const v = attrs[k]
+			if (v !== undefined && v !== null) attrCount++
+		}
+	}
 
-	writeListStart(2 * validAttributes.length + 1 + (typeof content !== 'undefined' ? 1 : 0))
-	writeString(tag)
+	encoder.writeListStart(2 * attrCount + 1 + (content !== undefined ? 1 : 0))
+	encoder.writeString(tag)
 
-	for (const key of validAttributes) {
-		if (typeof attrs[key] === 'string') {
-			writeString(key)
-			writeString(attrs[key])
+	if (attrs) {
+		for (const key in attrs) {
+			const val = attrs[key]
+			if (typeof val === 'string') {
+				encoder.writeString(key)
+				encoder.writeString(val)
+			}
 		}
 	}
 
 	if (typeof content === 'string') {
-		writeString(content)
+		encoder.writeString(content)
 	} else if (Buffer.isBuffer(content) || content instanceof Uint8Array) {
-		writeByteLength(content.length)
-		pushBytes(content)
+		encoder.writeByteLength(content.length)
+		encoder.pushBytes(content)
 	} else if (Array.isArray(content)) {
-		const validContent = content.filter(
-			item => item && (item.tag || Buffer.isBuffer(item) || item instanceof Uint8Array || typeof item === 'string')
-		)
-		writeListStart(validContent.length)
-		for (const item of validContent) {
-			encodeBinaryNodeInner(item, opts, buffer)
+		let validCount = 0
+		for (const item of content) {
+			if (item && (item.tag || typeof item === 'string' || Buffer.isBuffer(item) || item instanceof Uint8Array)) {
+				validCount++
+			}
 		}
-	} else if (typeof content === 'undefined') {
-		// do nothing
-	} else {
-		throw new Error(`invalid children for header "${tag}": ${content} (${typeof content})`)
-	}
 
-	return buffer
+		encoder.writeListStart(validCount)
+
+		for (const item of content) {
+			if (item && (item.tag || typeof item === 'string' || Buffer.isBuffer(item) || item instanceof Uint8Array)) {
+				encodeBinaryNodeInner(item, encoder)
+			}
+		}
+	} else if (content !== undefined) {
+		throw new Error(`invalid children for header "${tag}"`)
+	}
+}
+
+export const encodeBinaryNode = (node: BinaryNode, opts: EncoderOpts = constants): Buffer => {
+	const encoder = new ByteEncoder(1024, opts)
+	encoder.pushByte(0) // prefix
+	encodeBinaryNodeInner(node, encoder)
+	return encoder.getResult()
 }


### PR DESCRIPTION
This is a rebase of @Santosl2's PR #2513 on top of current master, squashed into a single commit. The original branch carried 11 merge commits and 2 unrelated commits (a fix + its revert) that made it hard to merge; only the 6 perf commits were cherry-picked, with no conflicts.

### What changes
- `ByteEncoder` / `ByteDecoder` classes; hot methods on the prototype → zero closure allocations per call, stable hidden classes, JIT-friendly inline caches.
- `TOKEN_MAP` switched to `Map<string, number>` for single + double byte dictionaries.
- `Buffer.subarray` on read paths (zero-copy slicing).
- Doubling-growth output buffer in the encoder; preallocated arrays in `readList`; `ensure()` / `checkEOS()` on every write/read.
- Explicit `readFbJid` / `readInteropJid` paths with typed returns.
- Empty string handled correctly (`""` is no longer confused with `LIST_EMPTY`).

### Verification
All 404 existing tests pass. No new lint errors (5 errors on master pre-exist in `chat-utils.ts` and `signal.ts`, untouched here).

Microbench (Node 25, M1, nested `message` node with JIDs + 512B binary payload + 5 children), master vs this branch:

| op | master | this branch | speedup |
|---|---|---|---|
| encode | 112k ops/s | 469k ops/s | ~4.2× |
| decode | 4.7M ops/s | 4.2M ops/s | noise |
| roundtrip | 103k ops/s | 394k ops/s | ~3.8× |

Credit to @Santosl2 for the original work in #2513.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked the WABinary encoder/decoder to use zero-copy reads and a class-based design, cutting allocations and speeding up encode by ~4.2× and roundtrip by ~3.8× in local microbenchmarks.

- **Refactors**
  - Added `ByteEncoder`/`ByteDecoder` with bounds-checked IO and a doubling-growth output buffer.
  - Replaced `TOKEN_MAP` with `TOKEN_MAP_REFACTOR: Map<string, { dict?: number; index: number }>` for O(1) single/double-byte token lookups.
  - Switched to `Buffer.subarray` on read paths; preallocated arrays in list reads.
  - Added explicit `readFbJid`/`readInteropJid` paths.
  - Fixed empty string handling ("" is not treated as `LIST_EMPTY`).

<sup>Written for commit 9ec048462d951fa70f8a5f9b415c3743dd88cede. Summary will update on new commits. <a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2594?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal binary data encoding and decoding systems to improve code maintainability and organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->