### PR TITLE
fix(pairing): skip link_code_companion_reg notifications without pairing data

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1127,14 +1127,14 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				}
 
 				break
-		case 'link_code_companion_reg':
-			const linkCodeCompanionReg = getBinaryNodeChild(node, 'link_code_companion_reg')
-			if(!getBinaryNodeChildBuffer(linkCodeCompanionReg, 'primary_identity_pub')) {
-				logger.debug({ node }, 'link_code_companion_reg notification without pairing data, skipping')
-				break
-			}
+		case 'link_code_companion_reg': {
+				const linkCodeCompanionReg = getBinaryNodeChild(node, 'link_code_companion_reg')
+				if(!getBinaryNodeChildBuffer(linkCodeCompanionReg, 'primary_identity_pub')) {
+					logger.debug({ node }, 'link_code_companion_reg notification without pairing data, skipping')
+					break
+				}
 
-			const ref = toRequiredBuffer(getBinaryNodeChildBuffer(linkCodeCompanionReg, 'link_code_pairing_ref'))
+				const ref = toRequiredBuffer(getBinaryNodeChildBuffer(linkCodeCompanionReg, 'link_code_pairing_ref'))
 				const primaryIdentityPublicKey = toRequiredBuffer(
 					getBinaryNodeChildBuffer(linkCodeCompanionReg, 'primary_identity_pub')
 				)
@@ -1201,6 +1201,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				authState.creds.registered = true
 				ev.emit('creds.update', authState.creds)
 				break
+			}
 			case 'privacy_token':
 				await handlePrivacyTokenNotification(node)
 				break

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1127,9 +1127,14 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				}
 
 				break
-			case 'link_code_companion_reg':
-				const linkCodeCompanionReg = getBinaryNodeChild(node, 'link_code_companion_reg')
-				const ref = toRequiredBuffer(getBinaryNodeChildBuffer(linkCodeCompanionReg, 'link_code_pairing_ref'))
+		case 'link_code_companion_reg':
+			const linkCodeCompanionReg = getBinaryNodeChild(node, 'link_code_companion_reg')
+			if(!getBinaryNodeChildBuffer(linkCodeCompanionReg, 'primary_identity_pub')) {
+				logger.debug({ node }, 'link_code_companion_reg notification without pairing data, skipping')
+				break
+			}
+
+			const ref = toRequiredBuffer(getBinaryNodeChildBuffer(linkCodeCompanionReg, 'link_code_pairing_ref'))
 				const primaryIdentityPublicKey = toRequiredBuffer(
 					getBinaryNodeChildBuffer(linkCodeCompanionReg, 'primary_identity_pub')
 				)


### PR DESCRIPTION
## Problem

During the pairing code flow, WhatsApp sends `link_code_companion_reg` notifications that do **not** contain the expected cryptographic fields (`primary_identity_pub`, `link_code_pairing_wrapped_primary_ephemeral_pub`).

These notifications arrive when the user opens the "Linked Devices" screen on their phone, **before** they enter the pairing code. The `processNotification` handler assumes all `link_code_companion_reg` messages are the full pairing response, calls `toRequiredBuffer()` on `undefined` fields, and crashes:

```
Error: Invalid buffer
    at toRequiredBuffer (messages-recv.ts)
    at processNotification (messages-recv.ts:884)
```

**Observed frames:**

Frame that works (IQ result from `requestPairingCode`):
```json
{"tag":"iq","attrs":{"type":"result"},"content":[{"tag":"link_code_companion_reg","attrs":{"stage":"companion_hello"},"content":[{"tag":"link_code_pairing_ref",...}]}]}
```

Frame that crashes (notification without pairing data):
```json
{"tag":"notification","attrs":{"type":"link_code_companion_reg","id":"3728034975"}}
```

The second frame has `tag: "notification"` (not `"iq"`), no child nodes with cryptographic keys.

## Fix

Check if `primary_identity_pub` exists before processing. If the notification lacks pairing data, log and skip instead of crashing. Case body wrapped in block scope to satisfy `noSwitchDeclarations` lint.

## Related

This fix is complementary to #2559 which hardens the `requestPairingCode` flow on the request side (`socket.ts`). This PR addresses the notification handler side (`messages-recv.ts`) where incoming `link_code_companion_reg` notifications without pairing data crash the handler.

## Impact

Without this fix, the pairing flow crashes before the user can finish entering the code. The socket dies, reconnection fails because partial creds were never saved, and the user sees "couldn't link device".

Fixes #2600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of companion registration notifications by validating required pairing data up front; notifications missing this data are now skipped with a debug log instead of proceeding and risking errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->