### PR TITLE
Implement devcontainer for reproducible development environments

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+{
+    "name": "Baileys",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye",
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": true,
+            "configureZshAsDefault": true
+        }
+    },
+    "onCreateCommand": "sudo corepack enable && corepack prepare yarn@4.9.2 --activate",
+    "postCreateCommand": "sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg && yarn install",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "ms-vscode.vscode-typescript-next",
+                "Orta.vscode-jest"
+            ],
+            "settings": {
+                "editor.defaultFormatter": "esbenp.prettier-vscode",
+                "editor.formatOnSave": true,
+                "editor.tabSize": 2,
+                "editor.insertSpaces": false,
+                "js/ts.tsdk.path": "node_modules/typescript/lib",
+                "eslint.useFlatConfig": true,
+                "jest.jestCommandLine": "yarn jest",
+                "jest.testMatch": [
+                    "**/*.test.ts"
+                ],
+                "jest.runMode": "on-demand"
+            }
+        }
+    },
+    "remoteEnv": {
+        "NODE_TLS_REJECT_UNAUTHORIZED": "0"
+    },
+    "forwardPorts": [],
+    "mounts": [
+        "source=baileys-yarn-cache,target=/usr/local/share/.cache/yarn,type=volume"
+    ]
+}


### PR DESCRIPTION
Introduces a devcontainer configuration that provides an isolated, reproducible development environment without polluting the host system. Supports VS Code and Zed editors.

Comes pre-configured with:
- Node 20 + Yarn 4 via Corepack
- ffmpeg (minimal install)
- ESLint, Prettier, TypeScript, and Jest extensions
- Yarn cache volume for faster rebuilds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a devcontainer for reproducible development in VS Code and Zed. It isolates the toolchain and speeds up setup while keeping the host clean.

- New Features
  - Based on `mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye` with zsh default.
  - Corepack enabled; `yarn@4.9.2` activated on create.
  - Installs `ffmpeg` and runs `yarn install` after container setup.
  - Preconfigures VS Code with ESLint, Prettier, TypeScript Next, and Jest (with sane Jest defaults).
  - Mounts a persistent `yarn` cache volume for quicker rebuilds.
  - Pins devcontainer features via `devcontainer-lock.json` for reproducibility.

<sup>Written for commit 575425775ed0f45f9f327347fa67561c820edba4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established standardized development environment configuration to ensure consistency across development setups.
  * Updated development environment dependencies and tooling for improved stability and developer experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhiskeySockets/Baileys/pull/2606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->