### PR TITLE
fix: nest profile picture tc token

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -64,6 +64,18 @@ import {
 import { USyncQuery, USyncUser } from '../WAUSync'
 import { makeSocket } from './socket.js'
 
+export const buildProfilePictureQueryContent = (
+	type: 'preview' | 'image',
+	tcTokenContent?: BinaryNode[]
+): BinaryNode[] => {
+	const picture: BinaryNode = { tag: 'picture', attrs: { type, query: 'url' } }
+	if (tcTokenContent?.length) {
+		picture.content = tcTokenContent
+	}
+
+	return [picture]
+}
+
 export const makeChatsSocket = (config: SocketConfig) => {
 	const {
 		logger,
@@ -736,8 +748,6 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	 * type = "image for the high res picture"
 	 */
 	const profilePictureUrl = async (jid: string, type: 'preview' | 'image' = 'preview', timeoutMs?: number) => {
-		const baseContent: BinaryNode[] = [{ tag: 'picture', attrs: { type, query: 'url' } }]
-
 		// WA Web only includes tctoken for user JIDs (not groups/newsletters)
 		// and never for own profile pic (Chat model for self has no tcToken).
 		// Including tctoken for own JID causes the server to never respond.
@@ -746,13 +756,12 @@ export const makeChatsSocket = (config: SocketConfig) => {
 		const me = authState.creds.me
 		const isSelf =
 			me && (normalizedJid === jidNormalizedUser(me.id) || (me.lid && normalizedJid === jidNormalizedUser(me.lid)))
-		let content: BinaryNode[] | undefined = baseContent
+		let tcTokenContent: BinaryNode[] | undefined
 
 		if (serverProps.profilePicPrivacyToken && isUserJid && !isSelf) {
-			content = await buildTcTokenFromJid({
+			tcTokenContent = await buildTcTokenFromJid({
 				authState,
 				jid: normalizedJid,
-				baseContent,
 				getLIDForPN
 			})
 		}
@@ -767,7 +776,7 @@ export const makeChatsSocket = (config: SocketConfig) => {
 					type: 'get',
 					xmlns: 'w:profile:picture'
 				},
-				content
+				content: buildProfilePictureQueryContent(type, tcTokenContent)
 			},
 			timeoutMs
 		)

--- a/src/Utils/tc-token-utils.ts
+++ b/src/Utils/tc-token-utils.ts
@@ -138,8 +138,9 @@ export async function buildTcTokenFromJid({
 		const tcTokenData = await authState.keys.get('tctoken', [storageJid])
 		const entry = tcTokenData?.[storageJid]
 		const tcTokenBuffer = entry?.token
+		const timestamp = entry?.timestamp
 
-		if (!tcTokenBuffer?.length || isTcTokenExpired(entry?.timestamp)) {
+		if (!tcTokenBuffer?.length || timestamp === undefined || isTcTokenExpired(timestamp)) {
 			if (tcTokenBuffer) {
 				// Preserve senderTimestamp so shouldSendNewTcToken() keeps its dedupe state
 				// after we drop the unusable peer token. Only wipe the record entirely when
@@ -156,7 +157,7 @@ export async function buildTcTokenFromJid({
 
 		baseContent.push({
 			tag: 'tctoken',
-			attrs: {},
+			attrs: { t: String(timestamp) },
 			content: tcTokenBuffer
 		})
 

--- a/src/__tests__/Socket/chats.test.ts
+++ b/src/__tests__/Socket/chats.test.ts
@@ -1,0 +1,29 @@
+import { buildProfilePictureQueryContent } from '../../Socket/chats'
+import type { BinaryNode } from '../../WABinary'
+
+describe('buildProfilePictureQueryContent', () => {
+	it('builds a profile picture query without tctoken content', () => {
+		expect(buildProfilePictureQueryContent('preview')).toEqual([
+			{
+				tag: 'picture',
+				attrs: { type: 'preview', query: 'url' }
+			}
+		])
+	})
+
+	it('nests tctoken under the picture node', () => {
+		const tcToken: BinaryNode = {
+			tag: 'tctoken',
+			attrs: { t: '1770000000' },
+			content: Buffer.from([4, 1, 33])
+		}
+
+		expect(buildProfilePictureQueryContent('image', [tcToken])).toEqual([
+			{
+				tag: 'picture',
+				attrs: { type: 'image', query: 'url' },
+				content: [tcToken]
+			}
+		])
+	})
+})

--- a/src/__tests__/Utils/tc-token.test.ts
+++ b/src/__tests__/Utils/tc-token.test.ts
@@ -404,6 +404,7 @@ describe('buildTcTokenFromJid', () => {
 		expect(result).toHaveLength(1)
 		const node = result![0]!
 		expect(node.tag).toBe('tctoken')
+		expect(node.attrs).toEqual({ t: RECENT_TS })
 		expect(node.content).toBe(VALID_TOKEN)
 	})
 
@@ -490,6 +491,7 @@ describe('buildTcTokenFromJid', () => {
 		expect(result![0]).toBe(existingNode)
 		const appended = result![1]!
 		expect(appended.tag).toBe('tctoken')
+		expect(appended.attrs).toEqual({ t: RECENT_TS })
 		expect(appended.content).toBe(VALID_TOKEN)
 	})
 
@@ -524,6 +526,22 @@ describe('buildTcTokenFromJid', () => {
 		const result = await buildTcTokenFromJid({ authState: { keys: mockKeys }, getLIDForPN: noopGetLID, jid: TEST_JID })
 
 		expect(result).toBeUndefined()
+	})
+
+	it('does not append tctoken to baseContent when token has no timestamp', async () => {
+		// @ts-ignore
+		mockKeys.get.mockResolvedValue({ [TEST_JID]: { token: VALID_TOKEN } })
+		const existingNode: BinaryNode = { tag: 'picture', attrs: { type: 'image' } }
+
+		const result = await buildTcTokenFromJid({
+			authState: { keys: mockKeys },
+			getLIDForPN: noopGetLID,
+			jid: TEST_JID,
+			baseContent: [existingNode]
+		})
+
+		expect(result).toEqual([existingNode])
+		expect(mockKeys.set).toHaveBeenCalledWith({ tctoken: { [TEST_JID]: null } })
 	})
 })
 
@@ -576,6 +594,7 @@ describe('tctoken integration scenarios', () => {
 			expect(result2).toBeDefined()
 			const node2 = result2![0]!
 			expect(node2.tag).toBe('tctoken')
+			expect(node2.attrs).toEqual({ t: recentTs })
 			expect(node2.content).toBe(TOKEN_A)
 		})
 	})
@@ -603,6 +622,7 @@ describe('tctoken integration scenarios', () => {
 			const result2 = await buildTcTokenFromJid({ authState: { keys: mockKeys }, getLIDForPN: noopGetLID, jid: JID_A })
 			expect(result2).toBeDefined()
 			const freshNode = result2![0]!
+			expect(freshNode.attrs).toEqual({ t: freshTs })
 			expect(freshNode.content).toBe(TOKEN_B)
 		})
 	})


### PR DESCRIPTION
## Summary

- Nest the generated `tctoken` under the `picture` query node for `profilePictureUrl`.
- Include the `t` attribute when building a tc token from the participant JID helper.
- Add unit coverage for the generated IQ shape and tc-token helper output.

## Protocol / behavior context

Profile-picture requests send an IQ with a `picture` child query. The tc token belongs in that picture query payload, not as a top-level IQ sibling. This change is validated from the request-building path and does not require pairing a live WhatsApp number.

## WA Web captured JS sanity

Ran:

```bash
./tools/wa-web-sanity.sh 'OutProfilePictureGetRequest|OutProfilePictureTCTokenMixin|tctoken'
```

Relevant matches from the captured WA Web bundle:

- `WA/Smax/OutProfilePictureGetRequest.js`
- `WA/Smax/OutProfilePictureTCTokenMixin.js`
- `WA/Wap/Dict.js`

Relevant excerpt:

```js
mergeTCTokenMixin(...)
smax("tctoken", { t: ... })
```

This matches the shape locked by this PR: `tctoken` is part of the profile-picture request and carries the `t` attribute.

## Tests

- `yarn lint` (0 errors; existing warnings remain)
- `yarn test`

Fixes #2589

Drafted with Codex, reviewed and tested by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile picture privacy token expiration detection to properly validate token timestamps.
  * Improved handling of expired tokens by clearing invalid stored entries.

* **Tests**
  * Added test coverage for profile picture query requests with privacy tokens.
  * Extended token validation test coverage to verify timestamp attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->