### PR TITLE
fix: ignore empty link code companion reg

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -107,6 +107,30 @@ function isValidEnforcementType(value: string | undefined): value is ReachoutTim
 	return typeof value === 'string' && ENFORCEMENT_TYPE_VALUES.has(value)
 }
 
+export const extractLinkCodeCompanionRegBuffers = (node: BinaryNode) => {
+	const linkCodeCompanionReg = getBinaryNodeChild(node, 'link_code_companion_reg')
+	const ref = getBinaryNodeChildBuffer(linkCodeCompanionReg, 'link_code_pairing_ref')
+	const primaryIdentityPublicKey = getBinaryNodeChildBuffer(linkCodeCompanionReg, 'primary_identity_pub')
+	const primaryEphemeralPublicKeyWrapped = getBinaryNodeChildBuffer(
+		linkCodeCompanionReg,
+		'link_code_pairing_wrapped_primary_ephemeral_pub'
+	)
+
+	if (ref === undefined || primaryIdentityPublicKey === undefined || primaryEphemeralPublicKeyWrapped === undefined) {
+		return undefined
+	}
+
+	return {
+		ref: ref instanceof Buffer ? ref : Buffer.from(ref),
+		primaryIdentityPublicKey:
+			primaryIdentityPublicKey instanceof Buffer ? primaryIdentityPublicKey : Buffer.from(primaryIdentityPublicKey),
+		primaryEphemeralPublicKeyWrapped:
+			primaryEphemeralPublicKeyWrapped instanceof Buffer
+				? primaryEphemeralPublicKeyWrapped
+				: Buffer.from(primaryEphemeralPublicKeyWrapped)
+	}
+}
+
 export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	const { logger, retryRequestDelayMs, maxMsgRetryCount, getMessage, shouldIgnoreJid, enableAutoSessionRecreation } =
 		config
@@ -1127,15 +1151,17 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				}
 
 				break
-			case 'link_code_companion_reg':
-				const linkCodeCompanionReg = getBinaryNodeChild(node, 'link_code_companion_reg')
-				const ref = toRequiredBuffer(getBinaryNodeChildBuffer(linkCodeCompanionReg, 'link_code_pairing_ref'))
-				const primaryIdentityPublicKey = toRequiredBuffer(
-					getBinaryNodeChildBuffer(linkCodeCompanionReg, 'primary_identity_pub')
-				)
-				const primaryEphemeralPublicKeyWrapped = toRequiredBuffer(
-					getBinaryNodeChildBuffer(linkCodeCompanionReg, 'link_code_pairing_wrapped_primary_ephemeral_pub')
-				)
+			case 'link_code_companion_reg': {
+				const linkCodeCompanionRegBuffers = extractLinkCodeCompanionRegBuffers(node)
+				if (!linkCodeCompanionRegBuffers) {
+					logger.debug(
+						{ id: node.attrs.id, type: node.attrs.type },
+						'link_code_companion_reg notification without pairing data, skipping'
+					)
+					break
+				}
+
+				const { ref, primaryIdentityPublicKey, primaryEphemeralPublicKeyWrapped } = linkCodeCompanionRegBuffers
 				const codePairingPublicKey = await decipherLinkPublicKey(primaryEphemeralPublicKeyWrapped)
 				const companionSharedKey = Curve.sharedKey(
 					authState.creds.pairingEphemeralKeyPair.private,
@@ -1196,6 +1222,8 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				authState.creds.registered = true
 				ev.emit('creds.update', authState.creds)
 				break
+			}
+
 			case 'privacy_token':
 				await handlePrivacyTokenNotification(node)
 				break

--- a/src/__tests__/Socket/messages-recv.test.ts
+++ b/src/__tests__/Socket/messages-recv.test.ts
@@ -1,0 +1,62 @@
+import { extractLinkCodeCompanionRegBuffers } from '../../Socket/messages-recv'
+import type { BinaryNode } from '../../WABinary'
+
+const linkCodeCompanionRegNode = (content?: BinaryNode[]): BinaryNode => ({
+	tag: 'notification',
+	attrs: {
+		from: '@s.whatsapp.net',
+		type: 'link_code_companion_reg',
+		id: '3728034975'
+	},
+	content
+})
+
+describe('extractLinkCodeCompanionRegBuffers', () => {
+	it('returns undefined for notification without pairing data', () => {
+		expect(extractLinkCodeCompanionRegBuffers(linkCodeCompanionRegNode())).toBeUndefined()
+	})
+
+	it('returns undefined when a required pairing field is missing', () => {
+		const node = linkCodeCompanionRegNode([
+			{
+				tag: 'link_code_companion_reg',
+				attrs: {},
+				content: [
+					{ tag: 'link_code_pairing_ref', attrs: {}, content: Buffer.from('ref') },
+					{ tag: 'primary_identity_pub', attrs: {}, content: Buffer.from('identity') }
+				]
+			}
+		])
+
+		expect(extractLinkCodeCompanionRegBuffers(node)).toBeUndefined()
+	})
+
+	it('extracts required pairing buffers', () => {
+		const ref = Buffer.from('ref')
+		const primaryIdentityPublicKey = Buffer.from('identity')
+		const primaryEphemeralPublicKeyWrapped = new Uint8Array([1, 2, 3])
+		const node = linkCodeCompanionRegNode([
+			{
+				tag: 'link_code_companion_reg',
+				attrs: {},
+				content: [
+					{ tag: 'link_code_pairing_ref', attrs: {}, content: ref },
+					{ tag: 'primary_identity_pub', attrs: {}, content: primaryIdentityPublicKey },
+					{
+						tag: 'link_code_pairing_wrapped_primary_ephemeral_pub',
+						attrs: {},
+						content: primaryEphemeralPublicKeyWrapped
+					}
+				]
+			}
+		])
+
+		const result = extractLinkCodeCompanionRegBuffers(node)
+
+		expect(result).toEqual({
+			ref,
+			primaryIdentityPublicKey,
+			primaryEphemeralPublicKeyWrapped: Buffer.from(primaryEphemeralPublicKeyWrapped)
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- Guard `link_code_companion_reg` notifications before reading pairing buffers.
- Skip/log notifications that do not carry the full pairing payload instead of throwing `Invalid buffer`.
- Add fixture coverage for empty, partial, and complete `link_code_companion_reg` nodes.

## Protocol / behavior context

During pairing-code linking, WhatsApp can send `notification type="link_code_companion_reg"` without the `primary_hello` pairing fields. The crash happens when Baileys treats that notification as a full primary hello and calls `toRequiredBuffer()` on missing children.

This keeps the existing primary-hello path unchanged when all required fields are present.

## WA Web captured JS sanity

Ran:

```bash
./tools/wa-web-sanity.sh 'link_code_companion_reg|companion_reg_refresh|DeviceLinkingHandleNotification|primary_identity_pub|link_code_pairing_wrapped_primary_ephemeral_pub'
```

Relevant matches from the captured WA Web bundle:

- `WAWeb/Alt/DeviceLinkingHandleNotification.js`
- `WA/Smax/InMdPrimaryHelloNotifyCompanionRequest.js`
- `WA/Smax/InMdRefreshCodeNotifyCompanionRequest.js`

Relevant excerpt:

```js
n.stage === "primary_hello" ? c(e) : n.stage === "refresh_code" ? d(e) : bad_stanza(487)
```

That matches the defensive behavior here: only the primary-hello path requires the cryptographic pairing fields.

## Tests

- `yarn lint`
- `yarn test`
- Manual pairing-code smoke test reached `connection=open`

Fixes #2600

Drafted with Codex, reviewed and tested by me.