### PR TITLE
fix: emit member tag removal updates

### DIFF
--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -530,10 +530,10 @@ const processMessage = async (
 				break
 			case proto.Message.ProtocolMessage.Type.GROUP_MEMBER_LABEL_CHANGE:
 				const labelAssociationMsg = protocolMsg.memberLabel
-				if (labelAssociationMsg?.label) {
+				if (labelAssociationMsg) {
 					ev.emit('group.member-tag.update', {
 						groupId: chat.id!,
-						label: labelAssociationMsg.label,
+						label: labelAssociationMsg.label || '',
 						participant: message.key.participant!,
 						participantAlt: message.key.participantAlt!,
 						messageTimestamp: Number(message.messageTimestamp)

--- a/src/__tests__/Utils/process-message.test.ts
+++ b/src/__tests__/Utils/process-message.test.ts
@@ -1,5 +1,9 @@
+import { jest } from '@jest/globals'
+import { proto } from '../../../WAProto'
 import type { WAMessage } from '../../Types'
-import { cleanMessage, getChatId } from '../../Utils/process-message'
+import processMessage, { cleanMessage, getChatId } from '../../Utils/process-message'
+
+type ProcessMessageContext = Parameters<typeof processMessage>[1]
 
 const createBaseMessage = (key: Partial<WAMessage['key']>, message?: Partial<WAMessage['message']>): WAMessage => {
 	return {
@@ -185,5 +189,84 @@ describe('getChatId', () => {
 
 	it('throws when broadcast key has no participant', () => {
 		expect(() => getChatId({ remoteJid: '12345@broadcast', fromMe: false, id: 'X' })).toThrow(/missing participant/)
+	})
+})
+
+const makeProcessContext = (): ProcessMessageContext =>
+	({
+		shouldProcessHistoryMsg: false,
+		creds: {
+			me: { id: 'me@s.whatsapp.net' },
+			accountSettings: {}
+		},
+		keyStore: {
+			get: jest.fn(),
+			set: jest.fn(),
+			transaction: jest.fn(async (code: () => unknown) => code())
+		},
+		ev: {
+			emit: jest.fn()
+		},
+		logger: {
+			warn: jest.fn(),
+			info: jest.fn(),
+			debug: jest.fn()
+		},
+		options: {},
+		signalRepository: {
+			lidMapping: {
+				storeLIDPNMappings: jest.fn(),
+				getLIDForPN: jest.fn()
+			}
+		},
+		getMessage: jest.fn()
+	}) as unknown as ProcessMessageContext
+
+const makeMemberLabelMessage = (label?: string): WAMessage => ({
+	key: {
+		remoteJid: '120363000000000000@g.us',
+		participant: '123456789@s.whatsapp.net',
+		participantAlt: '123456789@lid',
+		id: 'ABCDEF'
+	},
+	messageTimestamp: 1770000000,
+	message: {
+		protocolMessage: {
+			type: proto.Message.ProtocolMessage.Type.GROUP_MEMBER_LABEL_CHANGE,
+			memberLabel: {
+				label,
+				labelTimestamp: 1770000000
+			}
+		}
+	}
+})
+
+describe('processMessage member labels', () => {
+	it('emits group.member-tag.update when a label is set', async () => {
+		const context = makeProcessContext()
+
+		await processMessage(makeMemberLabelMessage('moderator'), context)
+
+		expect(context.ev.emit).toHaveBeenCalledWith('group.member-tag.update', {
+			groupId: '120363000000000000@g.us',
+			label: 'moderator',
+			participant: '123456789@s.whatsapp.net',
+			participantAlt: '123456789@lid',
+			messageTimestamp: 1770000000
+		})
+	})
+
+	it('emits group.member-tag.update with empty label when a label is removed', async () => {
+		const context = makeProcessContext()
+
+		await processMessage(makeMemberLabelMessage(), context)
+
+		expect(context.ev.emit).toHaveBeenCalledWith('group.member-tag.update', {
+			groupId: '120363000000000000@g.us',
+			label: '',
+			participant: '123456789@s.whatsapp.net',
+			participantAlt: '123456789@lid',
+			messageTimestamp: 1770000000
+		})
 	})
 })


### PR DESCRIPTION
## Summary

- Emit `group.member-tag.update` whenever a `memberLabel` patch is present, including removal patches.
- Use an empty `label` value when the labels list is absent or empty, so consumers can observe tag removal.
- Add unit coverage for both tag assignment and tag removal events.

## Protocol / behavior context

Member-tag removal can arrive as a `memberLabel` patch without populated labels. The previous guard required labels to be present, so removal updates were silently skipped. This is validated with deterministic app-state patch tests and does not require pairing a live WhatsApp number.

## WA Web captured JS sanity

Ran:

```bash
./tools/wa-web-sanity.sh 'HandleMemberLabelChange|SendMemberLabelAction|MemberLabelGroupRemoveHandler|memberLabel'
```

Relevant matches from the captured WA Web bundle:

- `WAWeb/Handle/MemberLabelChange.js`
- `WAWeb/Send/MemberLabelAction.js`
- `WAWeb/Member/LabelGroupRemoveHandler.js`

Relevant excerpt:

```js
var f = (n = a.label) != null ? n : "";
```

That matches this PR's event payload for removals/no-label patches: emit `group.member-tag.update` with `label: ''`.

## Tests

- `yarn lint` (0 errors; existing warnings remain)
- `yarn test`

Fixes #2502

Drafted with Codex, reviewed and tested by me.
