### PR TITLE
Implement devcontainer for #2564

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,50 @@
+{
+	"name": "Baileys",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:24-bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/common-utils:2": {
+			"installZsh": true,
+			"configureZshAsDefault": true
+		}
+	},
+	"onCreateCommand": "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none --no-modify-path && /home/node/.cargo/bin/rustup toolchain install nightly-2026-01-30 --component rustfmt --component clippy --target wasm32-unknown-unknown && /home/node/.cargo/bin/rustup default nightly-2026-01-30 && /home/node/.cargo/bin/cargo install wasm-pack",
+	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg python3-dev && bash -c 'BINARYEN_VERSION=129; tarball=\"binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz\"; curl -fsSL \"https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/${tarball}\" -o \"/tmp/${tarball}\" && tar -xzf \"/tmp/${tarball}\" -C /tmp && sudo cp /tmp/binaryen-version_${BINARYEN_VERSION}/bin/wasm-opt /usr/local/bin/ && rm -rf \"/tmp/${tarball}\" \"/tmp/binaryen-version_${BINARYEN_VERSION}\"' && curl -fsSL https://bun.sh/install | bash && export PATH=\"$HOME/.bun/bin:$HOME/.cargo/bin:$PATH\" && sudo corepack enable && corepack prepare pnpm@10.28.2 --activate && pnpm install --ignore-scripts && pnpm rebuild better-sqlite3 && pnpm build:bridge && pnpm build",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"dbaeumer.vscode-eslint",
+				"esbenp.prettier-vscode",
+				"ms-vscode.vscode-typescript-next",
+				"Orta.vscode-jest",
+				"rust-lang.rust-analyzer",
+				"tamasfe.even-better-toml",
+				"vadimcn.vscode-lldb",
+				"yy0931.vscode-sqlite3-editor"
+			],
+			"settings": {
+				"editor.defaultFormatter": "esbenp.prettier-vscode",
+				"editor.formatOnSave": true,
+				"editor.tabSize": 2,
+				"editor.insertSpaces": false,
+				"js/ts.tsdk.path": "node_modules/typescript/lib",
+				"eslint.useFlatConfig": true,
+				"jest.jestCommandLine": "pnpm --filter baileys jest",
+				"jest.testMatch": [
+					"**/*.test.ts"
+				],
+				"jest.runMode": "on-demand",
+				"rust-analyzer.cargo.target": "wasm32-unknown-unknown",
+				"rust-analyzer.check.command": "clippy"
+			}
+		}
+	},
+	"remoteEnv": {
+		"NODE_TLS_REJECT_UNAUTHORIZED": "0",
+		"WHATSAPP_RUST_BRIDGE_SKIP_PREBUILT": "1",
+		"PATH": "${containerEnv:PATH}:/home/node/.cargo/bin:/home/node/.bun/bin",
+		"RUSTUP_TOOLCHAIN": "nightly-2026-01-30"
+	},
+	"mounts": [
+		"source=baileys-pnpm-cache,target=/usr/local/share/.cache/pnpm,type=volume"
+	]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ test.ts
 TestData
 wa-logs*
 coverage
+/.pnpm-store
+/.vscode


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a reproducible VS Code Dev Container to standardize local setup with Node 24, Rust/wasm tooling, and editor presets. This speeds onboarding and aligns builds across machines.

- New Features
  - Node 24 Dev Container with zsh; feature pinned in `.devcontainer/devcontainer-lock.json`.
  - Tooling: Rust nightly `2026-01-30` with `wasm32-unknown-unknown`, `rustfmt`, `clippy`, `wasm-pack`, Binaryen `wasm-opt`, `ffmpeg`, `python3-dev`, `bun`.
  - Package management: Corepack with `pnpm@10.28.2` and a persistent `pnpm` cache volume; bootstraps repo (`pnpm install`, rebuild `better-sqlite3`, build steps).
  - Editor setup: VS Code extensions and settings for ESLint/Prettier/Jest/Rust Analyzer/LLDB/SQLite.
  - Env: sets `WHATSAPP_RUST_BRIDGE_SKIP_PREBUILT=1`, `NODE_TLS_REJECT_UNAUTHORIZED=0`, and PATH for cargo/bun.
  - .gitignore: add `/.pnpm-store` and `/.vscode`.

<sup>Written for commit f9dd22f975961c740e7a166f7c8303d3aa78c675. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration and tooling dependencies.
  * Updated repository ignore rules for build artifacts and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->