### PR TITLE
fix: nest profile picture tctoken and avoid usync on lookup

### DIFF
--- a/src/Signal/lid-mapping.ts
+++ b/src/Signal/lid-mapping.ts
@@ -109,6 +109,29 @@ export class LIDMappingStore {
 		return (await this.getLIDsForPNs([pn]))?.[0]?.lid || null
 	}
 
+	async getKnownLIDForPN(pn: string): Promise<string | null> {
+		if (!isPnUser(pn) && !isHostedPnUser(pn)) return null
+
+		const decoded = jidDecode(pn)
+		if (!decoded) return null
+
+		const pnUser = decoded.user
+		let lidUser = this.mappingCache.get(`pn:${pnUser}`)
+		if (!lidUser) {
+			const stored = await this.keys.get('lid-mapping', [pnUser])
+			lidUser = stored[pnUser]
+			if (lidUser) {
+				this.mappingCache.set(`pn:${pnUser}`, lidUser)
+				this.mappingCache.set(`lid:${lidUser}`, pnUser)
+			}
+		}
+
+		if (!lidUser) return null
+
+		const pnDevice = decoded.device !== undefined ? decoded.device : 0
+		return `${lidUser}${!!pnDevice ? `:${pnDevice}` : ''}@${decoded.server === 'hosted' ? 'hosted.lid' : 'lid'}`
+	}
+
 	async getLIDsForPNs(pns: string[]): Promise<LIDMapping[] | null> {
 		if (pns.length === 0) return null
 

--- a/src/Signal/lid-mapping.ts
+++ b/src/Signal/lid-mapping.ts
@@ -119,8 +119,9 @@ export class LIDMappingStore {
 		let lidUser = this.mappingCache.get(`pn:${pnUser}`)
 		if (!lidUser) {
 			const stored = await this.keys.get('lid-mapping', [pnUser])
-			lidUser = stored[pnUser]
-			if (lidUser) {
+			const storedLidUser = stored[pnUser]
+			if (typeof storedLidUser === 'string' && storedLidUser) {
+				lidUser = storedLidUser
 				this.mappingCache.set(`pn:${pnUser}`, lidUser)
 				this.mappingCache.set(`lid:${lidUser}`, pnUser)
 			}

--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -736,7 +736,8 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	 * type = "image for the high res picture"
 	 */
 	const profilePictureUrl = async (jid: string, type: 'preview' | 'image' = 'preview', timeoutMs?: number) => {
-		const baseContent: BinaryNode[] = [{ tag: 'picture', attrs: { type, query: 'url' } }]
+		const pictureNode: BinaryNode = { tag: 'picture', attrs: { type, query: 'url' } }
+		const content: BinaryNode[] = [pictureNode]
 
 		// WA Web only includes tctoken for user JIDs (not groups/newsletters)
 		// and never for own profile pic (Chat model for self has no tcToken).
@@ -746,15 +747,16 @@ export const makeChatsSocket = (config: SocketConfig) => {
 		const me = authState.creds.me
 		const isSelf =
 			me && (normalizedJid === jidNormalizedUser(me.id) || (me.lid && normalizedJid === jidNormalizedUser(me.lid)))
-		let content: BinaryNode[] | undefined = baseContent
 
 		if (serverProps.profilePicPrivacyToken && isUserJid && !isSelf) {
-			content = await buildTcTokenFromJid({
+			const tcTokenContent = await buildTcTokenFromJid({
 				authState,
 				jid: normalizedJid,
-				baseContent,
 				getLIDForPN
 			})
+			if (tcTokenContent?.length) {
+				pictureNode.content = tcTokenContent
+			}
 		}
 
 		jid = jidNormalizedUser(jid)

--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -89,6 +89,7 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	} = sock
 
 	const getLIDForPN = signalRepository.lidMapping.getLIDForPN.bind(signalRepository.lidMapping)
+	const getKnownLIDForPN = signalRepository.lidMapping.getKnownLIDForPN.bind(signalRepository.lidMapping)
 
 	let privacySettings: { [_: string]: string } | undefined
 
@@ -752,7 +753,7 @@ export const makeChatsSocket = (config: SocketConfig) => {
 			const tcTokenContent = await buildTcTokenFromJid({
 				authState,
 				jid: normalizedJid,
-				getLIDForPN
+				getLIDForPN: getKnownLIDForPN
 			})
 			if (tcTokenContent?.length) {
 				pictureNode.content = tcTokenContent


### PR DESCRIPTION
- nest profile-picture `tctoken` inside the `<picture>` node, matching WA Web and whatsmeow
- avoid triggering PN→LID USync while only checking for a profile-picture tctoken (probably a ban vector)
- keep profile-picture tctoken attachment limited to locally known token/mapping stat

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Nest the profile-picture tctoken inside the `<picture>` node and avoid PN→LID USync when only fetching a profile photo URL. Matches WA Web/`whatsmeow` behavior and reduces potential ban risk.

- **Bug Fixes**
  - Nest tctoken under `<picture>` in profile picture URL queries.
  - Use `getKnownLIDForPN` (cached PN→LID, no USync) to build the tctoken; accept only non-empty stored LIDs and attach the token only when the mapping is locally known.

<sup>Written for commit 2d91a4733b5cf3f911935396e45ba7f9e9d22a33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved identity resolution to return known device-aware IDs for privacy-number users, enhancing profile picture token generation.

* **Refactor**
  * Reworked profile picture payload construction to integrate the new identity resolver and streamline privacy-token insertion for non-self users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->