### PR TITLE
fix(example): convert messageTimestamp to ms in fetchMessageHistory call

### DIFF
--- a/Example/example.ts
+++ b/Example/example.ts
@@ -146,7 +146,10 @@ const startSock = async() => {
 
               // go to an old chat and send this
               if (text == "onDemandHistSync") {
-                const messageId = await sock.fetchMessageHistory(50, msg.key, msg.messageTimestamp!)
+                // proto field is `oldestMsgTimestampMs` (ms) but `messageTimestamp` is seconds
+                const tsRaw = msg.messageTimestamp!
+                const tsMs = (typeof tsRaw === 'number' ? tsRaw : tsRaw.toNumber()) * 1000
+                const messageId = await sock.fetchMessageHistory(50, msg.key, tsMs)
                 logger.debug({ id: messageId }, 'requested on-demand history resync')
               }
 


### PR DESCRIPTION
## Summary
- The `HistorySyncOnDemandRequest` proto field is `oldestMsgTimestampMs` (ms), but `WAMessage.messageTimestamp` is seconds.
- `Example/example.ts` was passing seconds directly into that field, silently mismatching units.
- Convert to ms before the call.

Found while investigating #2452.

## Test plan
- [x] `yarn example` still type-checks and runs
- [x] Sending `onDemandHistSync` from an old chat now logs a `tsMs` value in the ~1.7e12 range (correct ms) instead of ~1.7e9 (seconds)

Note: this fix alone does not resolve #2452 — the on-demand history response from WA still doesn't arrive (see comment thread on that issue). But the canonical example should be correct so others investigating don't burn time on this red herring.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert `WAMessage.messageTimestamp` (seconds) to milliseconds before calling `sock.fetchMessageHistory` in `Example/example.ts`, matching `HistorySyncOnDemandRequest.oldestMsgTimestampMs`. This fixes the seconds/ms mismatch so on‑demand history requests send a valid timestamp.

<sup>Written for commit 61f0ca38365b078f5f6ea5721559f522211c5e6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message timestamp format in history synchronization to correctly handle timestamp conversions, ensuring proper data retrieval and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->