### PR TITLE
exclude __tests__ from tsc

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,5 +35,5 @@
     "checkJs": false,
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/__tests__/**"]
 }


### PR DESCRIPTION
without this, tsc goes crazy, as detects __tests__ as a typescript directory. excluding it will make tsc compile the current code without errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude `src/__tests__/**` from TypeScript compilation so `tsc` no longer treats test files as source. This stops false type errors from tests and lets builds pass.

<sup>Written for commit f6d3f2f6481d16c1b96d9358671d3a2e4c2ea938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript configuration to exclude test directories from compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->