### PR TITLE
docs: add complete examples for status broadcast (text, image, video, audio, reshare)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1185,24 +1185,88 @@ await sock.updateDefaultDisappearingMode(ephemeral)
 ## Broadcast Lists & Stories
 
 ### Send Broadcast & Stories
-- Messages can be sent to broadcasts & stories. You need to add the following message options in sendMessage, like this:
+Messages can be sent to broadcasts & stories using `sendMessage` with `statusJidList` in the options.
+
+> **Note:** For stories, use `status@broadcast` as the JID. `statusJidList` must contain the list of contacts who will receive the status.
+
+#### Text Status
 ```ts
 await sock.sendMessage(
-    jid,
+    'status@broadcast',
+    { text: 'Hello from Baileys!' },
     {
-        image: {
-            url: url
-        },
-        caption: caption
-    },
-    {
-        backgroundColor: backgroundColor,
-        font: font,
-        statusJidList: statusJidList,
+        statusJidList: ['628xxx@s.whatsapp.net'],
+        backgroundColor: '#FF6B6B', // optional background color
+        font: 2,                    // optional font style (0-6)
         broadcast: true
     }
 )
 ```
+
+#### Image Status with Caption
+```ts
+await sock.sendMessage(
+    'status@broadcast',
+    {
+        image: { url: './image.jpg' }, // or use Buffer
+        caption: 'Check this out!'
+    },
+    {
+        statusJidList: ['628xxx@s.whatsapp.net'],
+        broadcast: true
+    }
+)
+```
+
+#### Video Status with Caption + Reshare Enabled
+```ts
+await sock.sendMessage(
+    'status@broadcast',
+    {
+        video: { url: './video.mp4' }, // or use Buffer
+        caption: 'Watch this!',
+        // Add contextInfo.featureEligibilities.canBeReshared to enable
+        // the reshare button for recipients (requires "Allow Resharing"
+        // to be enabled in WhatsApp Privacy settings on the sender's phone)
+        contextInfo: {
+            featureEligibilities: { canBeReshared: true }
+        }
+    },
+    {
+        statusJidList: ['628xxx@s.whatsapp.net'],
+        broadcast: true
+    }
+)
+```
+
+#### Audio Status (Voice)
+> ⚠️ **Important:** Audio status **requires both `ptt: true` AND `backgroundColor`** in the options, otherwise the status will appear on WhatsApp Web but **will not be visible on mobile devices**.
+
+```ts
+await sock.sendMessage(
+    'status@broadcast',
+    {
+        audio: fs.readFileSync('./audio.ogg'),
+        mimetype: 'audio/ogg; codecs=opus',
+        ptt: true  // required for audio status to appear on mobile
+    },
+    {
+        statusJidList: ['628xxx@s.whatsapp.net'],
+        backgroundColor: '#000000', // required — without this, status won't show on mobile
+        broadcast: true
+    }
+)
+```
+
+> **Note:** Audio/voice statuses **cannot be reshared** — this is a WhatsApp platform restriction. If reshare is needed, wrap the audio in a video with a black background:
+> ```bash
+> ffmpeg -f lavfi -i color=c=black:s=1080x1920:r=25 -i audio.ogg \
+>   -c:v libx264 -c:a aac -shortest output.mp4
+> ```
+> Then send as a video status with `canBeReshared: true`.
+
+---
+
 - Message body can be a `extendedTextMessage` or `imageMessage` or `videoMessage` or `voiceMessage`, see the [AnyRegularMessageContent type alias](https://baileys.wiki/docs/api/type-aliases/AnyRegularMessageContent/)
 - You can add `backgroundColor` and other options in the message options, see the [MiscMessageGenerationOptions type alias](https://baileys.wiki/docs/api/type-aliases/MiscMessageGenerationOptions/)
 - `broadcast: true` enables broadcast mode

--- a/README.md
+++ b/README.md
@@ -1185,9 +1185,9 @@ await sock.updateDefaultDisappearingMode(ephemeral)
 ## Broadcast Lists & Stories
 
 ### Send Broadcast & Stories
-Messages can be sent to broadcasts & stories using `sendMessage` with `statusJidList` in the options.
+Messages can be sent to broadcasts & stories using `sendMessage`.
 
-> **Note:** For stories, use `status@broadcast` as the JID. `statusJidList` must contain the list of contacts who will receive the status.
+> **Note:** For stories, use `status@broadcast` as the JID. `statusJidList` is required for stories — it must contain the list of contacts who will receive the status update. For broadcast lists, use the broadcast list JID (e.g. `12345678@broadcast`) instead.
 
 #### Text Status
 ```ts
@@ -1246,7 +1246,7 @@ await sock.sendMessage(
 await sock.sendMessage(
     'status@broadcast',
     {
-        audio: fs.readFileSync('./audio.ogg'),
+        audio: { url: './audio.ogg' }, // or use Buffer: { audio: fs.readFileSync('./audio.ogg') }
         mimetype: 'audio/ogg; codecs=opus',
         ptt: true  // required for audio status to appear on mobile
     },


### PR DESCRIPTION
## Summary

Expands the **"Broadcast Lists & Stories"** section in the README with complete, verified working examples for all supported status types.

Closes #2633

---

## What's changed

The existing section only showed one image example and mentioned (without code) that voice/video were supported. This PR adds:

### ✅ Text status example
With `backgroundColor` and `font` options documented.

### ✅ Image status with caption
Using `status@broadcast` explicitly as JID (was using generic `jid` before).

### ✅ Video status with caption + reshare
Documents `contextInfo.featureEligibilities.canBeReshared: true` — a field defined in `WAProto/WAProto.proto` (`ContextInfo.FeatureEligibilities`, field 4) that enables the reshare button for recipients. **This was completely undocumented** and is not mentioned anywhere in the README or baileys.wiki.

### ✅ Audio/voice status — critical mobile visibility fix
Documents that **both `ptt: true` AND `backgroundColor`** are required in the options for audio status to be visible on mobile devices. Without these, the status appears on WhatsApp Web but is **silently invisible on Android/iOS**. The root cause is referenced in `src/Utils/messages.js` (*"computed backgroundColor audio status"* comment).

### ✅ Audio reshare limitation + workaround
Documents that audio statuses cannot be reshared (WA platform restriction), with an `ffmpeg` workaround to wrap audio in a black-background video for reshare support.

---

## Verification

All behaviors verified by sending real status updates (Baileys v7.0.0-rc.9) and confirming receipt/visibility on physical Android devices. The `canBeReshared` field was discovered by reading `WAProto/WAProto.proto` directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds complete, working examples for sending status updates (text, image, video, audio) via `sendMessage` to `status@broadcast`, with clear options and reshare behavior that work on web and mobile. Clarifies `statusJidList` rules and standardizes media examples. Closes #2633.

- **Highlights**
  - Stories: use `status@broadcast` with `statusJidList`; broadcast lists use their own JID (e.g. `1234@broadcast`) and don’t require `statusJidList`.
  - Text: supports `backgroundColor` and `font`.
  - Video: enable reshare via `contextInfo.featureEligibilities.canBeReshared`; requires “Allow Resharing” enabled in sender’s privacy settings.
  - Audio: must include `ptt: true` and `backgroundColor` for mobile visibility; example uses `{ url }` with a Buffer alternative noted.
  - Audio cannot be reshared; workaround provided using `ffmpeg` to wrap audio in a video.

<sup>Written for commit 651e0879ca04ab7b4993a5bef3d131a59f996c4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote broadcast & stories messaging docs with dedicated sendMessage examples for text, image (caption), video (reshare flag), and audio/voice statuses; clarifies story recipient requirements, audio visibility requirements, that audio statuses cannot be reshared, and includes guidance for converting audio to video for resharing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->