### PR TITLE
fix(auth): prevent memory leaks in useMultiFileAuthState

### DIFF
--- a/src/Utils/use-multi-file-auth-state.ts
+++ b/src/Utils/use-multi-file-auth-state.ts
@@ -1,26 +1,29 @@
-import { Mutex } from 'async-mutex'
-import { mkdir, readFile, stat, unlink, writeFile } from 'fs/promises'
+import { mkdir, readFile, rename, stat, unlink, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { proto } from '../../WAProto/index.js'
 import type { AuthenticationCreds, AuthenticationState, SignalDataTypeMap } from '../Types'
 import { initAuthCreds } from './auth-utils'
 import { BufferJSON } from './generics'
+import { makeKeyedMutex } from './make-mutex'
 
 // We need to lock files due to the fact that we are using async functions to read and write files
 // https://github.com/WhiskeySockets/Baileys/issues/794
 // https://github.com/nodejs/node/issues/26338
-// Use a Map to store mutexes for each file path
-const fileLocks = new Map<string, Mutex>()
+// Keyed mutex: serializes access per file path and ref-counts its entries, so an
+// idle path is freed instead of leaking a Mutex per key file for the process' life.
+const fileMutex = makeKeyedMutex()
 
-// Get or create a mutex for a specific file path
-const getFileLock = (path: string): Mutex => {
-	let mutex = fileLocks.get(path)
-	if (!mutex) {
-		mutex = new Mutex()
-		fileLocks.set(path, mutex)
+// PATCH: a stuck fs op leaks its FSReqPromise/Promise forever (heap → OOM).
+// Wrap each read/write in AbortController+timeout so the stuck one is aborted and freed.
+const FS_TIMEOUT_MS = 15000
+const withFsTimeout = async <T>(run: (signal: AbortSignal) => Promise<T>): Promise<T> => {
+	const ac = new AbortController()
+	const timer = setTimeout(() => ac.abort(), FS_TIMEOUT_MS)
+	try {
+		return await run(ac.signal)
+	} finally {
+		clearTimeout(timer)
 	}
-
-	return mutex
 }
 
 /**
@@ -36,13 +39,16 @@ export const useMultiFileAuthState = async (
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const writeData = async (data: any, file: string) => {
 		const filePath = join(folder, fixFileName(file)!)
-		const mutex = getFileLock(filePath)
 
-		return mutex.acquire().then(async release => {
+		return fileMutex.mutex(filePath, async () => {
+			// PATCH: atomic write (tmp + rename) with timeout. An abort mid-write
+			const tmpPath = `${filePath}.tmp`
 			try {
-				await writeFile(filePath, JSON.stringify(data, BufferJSON.replacer))
-			} finally {
-				release()
+				await withFsTimeout(signal => writeFile(tmpPath, JSON.stringify(data, BufferJSON.replacer), { signal }))
+				await rename(tmpPath, filePath)
+			} catch (error) {
+				await unlink(tmpPath).catch(() => {})
+				throw error
 			}
 		})
 	}
@@ -50,15 +56,11 @@ export const useMultiFileAuthState = async (
 	const readData = async (file: string) => {
 		try {
 			const filePath = join(folder, fixFileName(file)!)
-			const mutex = getFileLock(filePath)
 
-			return await mutex.acquire().then(async release => {
-				try {
-					const data = await readFile(filePath, { encoding: 'utf-8' })
-					return JSON.parse(data, BufferJSON.reviver)
-				} finally {
-					release()
-				}
+			return await fileMutex.mutex(filePath, async () => {
+				// PATCH: timeout via signal — a stuck readFile is aborted.
+				const data = await withFsTimeout<string>(signal => readFile(filePath, { encoding: 'utf-8', signal }))
+				return JSON.parse(data, BufferJSON.reviver)
 			})
 		} catch (error) {
 			return null
@@ -68,15 +70,11 @@ export const useMultiFileAuthState = async (
 	const removeData = async (file: string) => {
 		try {
 			const filePath = join(folder, fixFileName(file)!)
-			const mutex = getFileLock(filePath)
 
-			return mutex.acquire().then(async release => {
+			return fileMutex.mutex(filePath, async () => {
 				try {
 					await unlink(filePath)
-				} catch {
-				} finally {
-					release()
-				}
+				} catch {}
 			})
 		} catch {}
 	}


### PR DESCRIPTION
## Problem

`useMultiFileAuthState` accumulates memory in long-lived processes, especially when the auth folder lives on a network filesystem (NFS/EFS). Two distinct leaks were observed in heap dumps growing until OOM:

1. **Leaked `FSReqPromise` chains** — a stuck `fs` read/write (e.g. a hung network-FS I/O) never settles. The underlying libuv request stays alive as a global handle forever, dragging the awaiting `Promise`/`Context`/generator with it. The heap grows unbounded with `FSReqPromise`/`FileHandle`/`Promise` instances.
2. **Unbounded `fileLocks` map** — one `Mutex` was created per file path (pre-keys, sessions, lid-mappings, sender-keys are created constantly) and never removed, retaining memory proportional to *every* key file the process ever touched.

## Changes

- **Abort stuck fs ops:** each read/write is wrapped in an `AbortController` + timeout (`FS_TIMEOUT_MS`). A healthy op (a few ms) clears its own timer and is unchanged; only a stalled op is aborted, which closes the libuv request and frees the handle. Reads then return `null` and Baileys re-derives the key. (Deliberately uses a manual `AbortController` rather than `AbortSignal.timeout`, which would orphan one timer per op.)
- **Bounded locking:** replaced the hand-rolled `fileLocks` map with the existing ref-counted `makeKeyedMutex`, which frees a path's entry once it goes idle — removing the unbounded growth at the source and deduplicating the acquire/release boilerplate across `readData`/`writeData`/`removeData`.
- **Atomic writes:** writes now go to a `.tmp` file and `rename` into place. An abort mid-write leaves only the `.tmp`, so the final file (including `creds.json`) is never left partial/corrupted.

## Notes

- Behavior is unchanged on the happy path; only stuck I/O is affected.
- `makeKeyedMutex` was already in the codebase and is ref-counted, so no new locking primitive is introduced.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes memory leaks in the multi-file auth state by timing out stuck file I/O and bounding per-file locks. Also makes writes atomic to avoid partial files and prevent OOMs in long-running processes, especially on NFS/EFS.

- **Bug Fixes**
  - Abort hung read/write with an `AbortController`-based timeout to free leaked `FSReqPromise` handles; aborted reads return null.
  - Replace the unbounded `fileLocks` map with the ref-counted `makeKeyedMutex` to release idle path locks.
  - Write to `.tmp` then `rename` for atomic writes; cleanup `.tmp` on failure.

<sup>Written for commit 35dbf725b24ad714c8370500a620e232cce3a6d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file operation reliability with enhanced timeout handling
  * Implemented atomic write operations for better data consistency
  * Enhanced cleanup procedures for file system operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->