### PR TITLE
fix(lid): bound LIDMappingStore cache to stop unbounded timer/memory growth

### DIFF
--- a/src/Signal/lid-mapping.ts
+++ b/src/Signal/lid-mapping.ts
@@ -4,9 +4,12 @@ import type { ILogger } from '../Utils/logger'
 import { isHostedPnUser, isLidUser, isPnUser, jidDecode, jidNormalizedUser, WAJIDDomains } from '../WABinary'
 
 export class LIDMappingStore {
+	// PATCH: `max` bounds the cache and `ttlAutopurge: false` drops the per-entry
+	// 3-day timer (TTL is checked lazily on get); evicted entries fall back to the DB.
 	private readonly mappingCache = new LRUCache<string, string>({
-		ttl: 3 * 24 * 60 * 60 * 1000, // 7 days
-		ttlAutopurge: true,
+		max: 10000,
+		ttl: 3 * 24 * 60 * 60 * 1000, // 3 days
+		ttlAutopurge: false,
 		updateAgeOnGet: true
 	})
 	private readonly keys: SignalKeyStoreWithTransaction


### PR DESCRIPTION
## Problem

`LIDMappingStore.mappingCache` was created as:

```ts
new LRUCache({ ttl: 3 * 24 * 60 * 60 * 1000, ttlAutopurge: true, updateAgeOnGet: true })
```

With **no `max`** and **`ttlAutopurge: true`**, the cache grows without bound and arms **one 3-day `setTimeout` per entry**. Under a flood of `@lid` mappings this accumulates tens of thousands of timers, leaking memory until OOM (heap dumps show a large `TimersList` of `259_200_000ms` timers).

## Change

```ts
new LRUCache({ max: 10000, ttl: 3 * 24 * 60 * 60 * 1000, ttlAutopurge: false, updateAgeOnGet: true })
```

- **`max: 10000`** — bounds the cache; evicted entries are simply re-fetched from the key store on the next miss.
- **`ttlAutopurge: false`** — removes the per-entry timer. TTL is still honored, just evaluated lazily on `get` instead of via a background timer.

Also fixed a stale `// 7 days` comment (the value has always been 3 days).

## Notes

- Behavior is preserved: the cache remains a fallback layer over the DB, so eviction only causes a re-read, never data loss.
- No public API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the `LIDMappingStore` cache and removed per-entry timers to stop unbounded memory/timer growth, preventing OOM under heavy `@lid` mapping traffic.

- **Bug Fixes**
  - Set `LRUCache` to `max: 10000` and `ttlAutopurge: false`; TTL stays 3 days and is checked on get.
  - Evicted entries re-fetch from the key store; no API/behavior changes. Fixed stale "7 days" comment.

<sup>Written for commit a6e43e3fe8041b7f090a301c5f7ea38b7a1dbe67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal caching configuration for improved performance and memory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->