### PR TITLE
[BREAKING CHANGES] use msgpackr to serialize data

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "async-mutex": "^0.5.0",
     "libsignal": "^6.0.0",
     "lru-cache": "^11.1.0",
+    "msgpackr": "^2.0.4",
     "music-metadata": "^11.12.3",
     "p-queue": "^9.0.0",
     "pino": "^9.6",
@@ -137,3 +138,4 @@
     "node": ">=20.0.0"
   }
 }
+

--- a/src/Signal/Group/sender-key-record.ts
+++ b/src/Signal/Group/sender-key-record.ts
@@ -1,5 +1,5 @@
-import { BufferJSON } from '../../Utils/generics'
 import { SenderKeyState } from './sender-key-state'
+import { packr } from '../..'
 
 export interface SenderKeyStateStructure {
 	senderKeyId: number
@@ -58,12 +58,11 @@ export class SenderKeyRecord {
 		this.senderKeyStates.push(new SenderKeyState(id, iteration, chainKey, keyPair))
 	}
 
-	public serialize(): SenderKeyStateStructure[] {
-		return this.senderKeyStates.map(state => state.getStructure())
+	public serialize(): Uint8Array {
+		return packr.pack(this.senderKeyStates.map(state => state.getStructure()))
 	}
 	static deserialize(data: Uint8Array): SenderKeyRecord {
-		const str = Buffer.from(data).toString('utf-8')
-		const parsed = JSON.parse(str, BufferJSON.reviver)
+		const parsed = packr.unpack(data) as SenderKeyStateStructure[]
 		return new SenderKeyRecord(parsed)
 	}
 }

--- a/src/Signal/libsignal.ts
+++ b/src/Signal/libsignal.ts
@@ -540,7 +540,7 @@ function signalStorage(
 		},
 		storeSenderKey: async (senderKeyName: SenderKeyName, key: SenderKeyRecord) => {
 			const keyId = senderKeyName.toString()
-			await keys.set({ 'sender-key': { [keyId]: Buffer.from(key.serialize()) } })
+			await keys.set({ 'sender-key': { [keyId]: key.serialize() } })
 		},
 		getOurRegistrationId: () => creds.registrationId,
 		getOurIdentity: () => {

--- a/src/Signal/libsignal.ts
+++ b/src/Signal/libsignal.ts
@@ -540,8 +540,7 @@ function signalStorage(
 		},
 		storeSenderKey: async (senderKeyName: SenderKeyName, key: SenderKeyRecord) => {
 			const keyId = senderKeyName.toString()
-			const serialized = JSON.stringify(key.serialize())
-			await keys.set({ 'sender-key': { [keyId]: Buffer.from(serialized, 'utf-8') } })
+			await keys.set({ 'sender-key': { [keyId]: Buffer.from(key.serialize()) } })
 		},
 		getOurRegistrationId: () => creds.registrationId,
 		getOurIdentity: () => {

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -14,6 +14,9 @@ import type {
 import { DisconnectReason } from '../Types'
 import { type BinaryNode, getAllBinaryNodeChildren, jidDecode } from '../WABinary'
 import { sha256 } from './crypto'
+import { Packr } from "msgpackr"
+
+export const packr = new Packr()
 
 export const BufferJSON = {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/Utils/use-multi-file-auth-state.ts
+++ b/src/Utils/use-multi-file-auth-state.ts
@@ -1,27 +1,20 @@
-import { Mutex } from 'async-mutex'
 import { mkdir, readFile, stat, unlink, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { proto } from '../../WAProto/index.js'
 import type { AuthenticationCreds, AuthenticationState, SignalDataTypeMap } from '../Types'
 import { initAuthCreds } from './auth-utils'
-import { BufferJSON } from './generics'
+import { makeKeyedMutex } from './make-mutex'
+import { packr } from './index.js'
+
 
 // We need to lock files due to the fact that we are using async functions to read and write files
 // https://github.com/WhiskeySockets/Baileys/issues/794
 // https://github.com/nodejs/node/issues/26338
-// Use a Map to store mutexes for each file path
-const fileLocks = new Map<string, Mutex>()
+// Keyed mutex: serializes access per file path and ref-counts its entries, so an
+// idle path is freed instead of leaking a Mutex per key file for the process' life.
+const fileMutex = makeKeyedMutex()
 
-// Get or create a mutex for a specific file path
-const getFileLock = (path: string): Mutex => {
-	let mutex = fileLocks.get(path)
-	if (!mutex) {
-		mutex = new Mutex()
-		fileLocks.set(path, mutex)
-	}
-
-	return mutex
-}
+const fixFileName = (file?: string) => file?.replace(/\//g, '__')?.replace(/:/g, '-')
 
 /**
  * stores the full authentication state in a single folder.
@@ -36,49 +29,41 @@ export const useMultiFileAuthState = async (
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const writeData = async (data: any, file: string) => {
 		const filePath = join(folder, fixFileName(file)!)
-		const mutex = getFileLock(filePath)
 
-		return mutex.acquire().then(async release => {
+		return fileMutex.mutex(filePath, async () => {
 			try {
-				await writeFile(filePath, JSON.stringify(data, BufferJSON.replacer))
-			} finally {
-				release()
+				await writeFile(filePath, packr.pack(data), {
+					encoding: 'utf-8',
+					signal: AbortSignal.timeout(15000)
+				})
+				
+			} catch (error) {
+				await removeData(file)
+				throw error
 			}
 		})
 	}
 
 	const readData = async (file: string) => {
-		try {
-			const filePath = join(folder, fixFileName(file)!)
-			const mutex = getFileLock(filePath)
 
-			return await mutex.acquire().then(async release => {
-				try {
-					const data = await readFile(filePath, { encoding: 'utf-8' })
-					return JSON.parse(data, BufferJSON.reviver)
-				} finally {
-					release()
-				}
-			})
-		} catch (error) {
-			return null
-		}
+		const filePath = join(folder, fixFileName(file)!)
+		return await fileMutex.mutex(filePath, async () => {
+				
+			const data = await readFile(filePath, {
+				signal: AbortSignal.timeout(15000)
+			}).catch(() => null)
+			if (!data) return null
+			return packr.unpack(data)
+		})
 	}
 
 	const removeData = async (file: string) => {
-		try {
 			const filePath = join(folder, fixFileName(file)!)
-			const mutex = getFileLock(filePath)
-
-			return mutex.acquire().then(async release => {
+			return fileMutex.mutex(filePath, async () => {
 				try {
 					await unlink(filePath)
-				} catch {
-				} finally {
-					release()
-				}
+				} catch {}
 			})
-		} catch {}
 	}
 
 	const folderInfo = await stat(folder).catch(() => {})
@@ -92,9 +77,8 @@ export const useMultiFileAuthState = async (
 		await mkdir(folder, { recursive: true })
 	}
 
-	const fixFileName = (file?: string) => file?.replace(/\//g, '__')?.replace(/:/g, '-')
 
-	const creds: AuthenticationCreds = (await readData('creds.json')) || initAuthCreds()
+	const creds: AuthenticationCreds = (await readData('creds.bin')) || initAuthCreds()
 
 	return {
 		state: {
@@ -104,7 +88,7 @@ export const useMultiFileAuthState = async (
 					const data: { [_: string]: SignalDataTypeMap[typeof type] } = {}
 					await Promise.all(
 						ids.map(async id => {
-							let value = await readData(`${type}-${id}.json`)
+							let value = await readData(`${type}-${id}.bin`)
 							if (type === 'app-state-sync-key' && value) {
 								value = proto.Message.AppStateSyncKeyData.fromObject(value)
 							}
@@ -120,7 +104,7 @@ export const useMultiFileAuthState = async (
 					for (const category in data) {
 						for (const id in data[category as keyof SignalDataTypeMap]) {
 							const value = data[category as keyof SignalDataTypeMap]![id]
-							const file = `${category}-${id}.json`
+							const file = `${category}-${id}.bin`
 							tasks.push(value ? writeData(value, file) : removeData(file))
 						}
 					}
@@ -130,7 +114,7 @@ export const useMultiFileAuthState = async (
 			}
 		},
 		saveCreds: async () => {
-			return writeData(creds, 'creds.json')
+			return writeData(creds, 'creds.bin')
 		}
 	}
 }


### PR DESCRIPTION
This PR builds upon the approach proposed in #2639 by replacing the JSON-based serialization used in useMultiFileAuthState with MessagePack (msgpackr).

Instead of serializing authentication data through JSON.stringify/JSON.parse (together with BufferJSON.replacer/BufferJSON.reviver), authentication state is stored as binary (.bin) files using MessagePack.

The binary format reduces serialization/deserialization overhead, produces smaller files on disk, and avoids the UTF-8 string conversion required by JSON.


**NOTE**
This PR focuses only on the serialization format used by useMultiFileAuthState. It is independent from the locking and filesystem reliability improvements proposed in #2639, while remaining compatible with that approach.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch auth state and sender key serialization from JSON to MessagePack using `msgpackr`, writing `.bin` files for smaller, faster disk I/O. BREAKING: file formats and names changed from `.json` to `.bin`.

- **New Features**
  - Store `useMultiFileAuthState` and sender keys as MessagePack via a shared `packr` instance (no JSON/Buffer conversions).
  - Add a keyed mutex for per-file locking and 15s I/O timeouts to improve reliability.
  - Include `msgpackr` as a dependency.

- **Migration**
  - Auth files now end with `.bin` (e.g., `creds.bin`, `<type>-<id>.bin`) instead of `.json`.
  - Existing `.json` auth stores are not read; re-authenticate or migrate your files to MessagePack before upgrading.

<sup>Written for commit 1aa77b906f62ae0d9113c063d99783bf76ae9565. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated internal data serialization from JSON to binary format using msgpackr library
  * Updated authentication state and cryptographic key storage to use binary files instead of JSON files
  * Improved data persistence mechanism with enhanced file-locking behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->