### PR TITLE
fix(media): repacketize PTT Opus to code 3 so voice notes play on iOS

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -402,6 +402,11 @@ const buildOggPage = (headerType: number, granule: number, serial: number, seq: 
  * iOS. Returns the input untouched if it is not OGG/Opus or is already code 3.
  */
 export const repacketizeOggOpusToCode3 = (input: Buffer, framesPerPacket = 3): Buffer => {
+	// guard against a non-terminating loop / invalid Opus frame count (RFC 6716: M <= 48)
+	if (!Number.isInteger(framesPerPacket) || framesPerPacket < 1 || framesPerPacket > 48) {
+		throw new Error('framesPerPacket must be an integer between 1 and 48')
+	}
+
 	if (!Buffer.isBuffer(input) || input.length < 4 || input.toString('ascii', 0, 4) !== 'OggS') {
 		return input
 	}
@@ -412,17 +417,18 @@ export const repacketizeOggOpusToCode3 = (input: Buffer, framesPerPacket = 3): B
 	}
 
 	const audioPackets = packets.slice(2)
-	// already multi-frame? (first audio packet TOC code === 3) -> idempotent no-op
-	if (audioPackets[0]?.length && (audioPackets[0][0]! & 0x03) === 3) {
+	// Only handle a stream of single-frame ("code 0") packets, as libopus/ffmpeg emit.
+	// Anything else (already code 3, or code 1/2 which have a different layout) is left
+	// untouched to avoid misinterpreting/corrupting it.
+	if (!audioPackets.length || audioPackets.some(p => p.length < 1 || (p[0]! & 0x03) !== 0)) {
 		return input
 	}
 
-	const frames = audioPackets
-		.filter(p => p.length >= 1)
-		.map(p => ({ configStereo: p[0]! >> 2, samples: opusFrameSamples48k(p[0]! >> 3), data: p.subarray(1) }))
-	if (!frames.length) {
-		return input
-	}
+	const frames = audioPackets.map(p => ({
+		configStereo: p[0]! >> 2,
+		samples: opusFrameSamples48k(p[0]! >> 3),
+		data: p.subarray(1)
+	}))
 
 	const out: Buffer[] = [buildOggPage(0x02, 0, serial, 0, packets[0]!), buildOggPage(0x00, 0, serial, 1, packets[1]!)]
 	let seq = 2

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -284,6 +284,203 @@ export async function getAudioWaveform(buffer: Buffer | string | Readable, logge
 	}
 }
 
+// --- PTT (voice note) Opus repacketization ---------------------------------
+// WhatsApp's native voice notes pack several 20ms SILK frames per Opus packet
+// (TOC "code 3", e.g. 3x20ms = 60ms). libopus/ffmpeg emit one frame per packet
+// ("code 0"). iOS WhatsApp rejects code-0 PTT ("this audio is no longer
+// available, ask the sender to resend it"); Android tolerates it. Regrouping
+// the code-0 frames into code-3 packets makes voice notes play on iOS.
+
+const OGG_CRC_TABLE = (() => {
+	const table = new Uint32Array(256)
+	for (let i = 0; i < 256; i++) {
+		let r = (i << 24) >>> 0
+		for (let j = 0; j < 8; j++) {
+			r = r & 0x80000000 ? ((r << 1) ^ 0x04c11db7) >>> 0 : (r << 1) >>> 0
+		}
+
+		table[i] = r >>> 0
+	}
+
+	return table
+})()
+
+const oggPageCrc = (page: Buffer) => {
+	let crc = 0
+	for (let i = 0; i < page.length; i++) {
+		crc = (((crc << 8) >>> 0) ^ OGG_CRC_TABLE[((crc >>> 24) & 0xff) ^ page[i]!]!) >>> 0
+	}
+
+	return crc >>> 0
+}
+
+// Opus frame duration (in 48kHz samples) from the TOC config (RFC 6716 §3.1)
+const opusFrameSamples48k = (config: number) => {
+	const c = config & 0x1f
+	const ms = c < 12 ? [10, 20, 40, 60][c % 4]! : c < 16 ? (c % 2 === 0 ? 10 : 20) : [2.5, 5, 10, 20][c % 4]!
+	return Math.round(ms * 48)
+}
+
+const parseOggPackets = (buf: Buffer) => {
+	const packets: Buffer[] = []
+	let cur: Buffer[] = []
+	let off = 0
+	let serial = 0
+	let preSkip = 0
+	while (off + 27 <= buf.length) {
+		if (buf.toString('ascii', off, off + 4) !== 'OggS') {
+			break
+		}
+
+		serial = buf.readUInt32LE(off + 14)
+		const nseg = buf[off + 26]!
+		const segTableStart = off + 27
+		let dataOff = segTableStart + nseg
+		for (let s = 0; s < nseg; s++) {
+			const len = buf[segTableStart + s]!
+			cur.push(buf.subarray(dataOff, dataOff + len))
+			dataOff += len
+			if (len < 255) {
+				packets.push(Buffer.concat(cur))
+				cur = []
+			}
+		}
+
+		off = dataOff
+	}
+
+	if (cur.length) {
+		packets.push(Buffer.concat(cur))
+	}
+
+	if ((packets[0]?.length ?? 0) >= 12 && packets[0]!.subarray(0, 8).toString('ascii') === 'OpusHead') {
+		preSkip = packets[0]!.readUInt16LE(10)
+	}
+
+	return { packets, serial, preSkip }
+}
+
+const encodeOpusFrameLength = (len: number): number[] => {
+	if (len < 252) {
+		return [len]
+	}
+
+	const b0 = 252 + (len % 4)
+	return [b0, Math.floor((len - b0) / 4)]
+}
+
+const buildOggPage = (headerType: number, granule: number, serial: number, seq: number, packet: Buffer) => {
+	const segs: number[] = []
+	let rem = packet.length
+	while (rem >= 255) {
+		segs.push(255)
+		rem -= 255
+	}
+
+	segs.push(rem)
+	const header = Buffer.alloc(27 + segs.length)
+	header.write('OggS', 0, 'ascii')
+	header[4] = 0
+	header[5] = headerType
+	header.writeBigUInt64LE(BigInt(granule), 6)
+	header.writeUInt32LE(serial >>> 0, 14)
+	header.writeUInt32LE(seq >>> 0, 18)
+	header[26] = segs.length
+	for (let i = 0; i < segs.length; i++) {
+		header[27 + i] = segs[i]!
+	}
+
+	const page = Buffer.concat([header, packet])
+	page.writeUInt32LE(oggPageCrc(page), 22)
+	return page
+}
+
+/**
+ * Regroups single-frame ("code 0") Opus packets of an OGG/Opus stream into
+ * multi-frame ("code 3") packets (default 3x20ms = 60ms), matching the
+ * packetization WhatsApp's native client uses for voice notes so they play on
+ * iOS. Returns the input untouched if it is not OGG/Opus or is already code 3.
+ */
+export const repacketizeOggOpusToCode3 = (input: Buffer, framesPerPacket = 3): Buffer => {
+	if (!Buffer.isBuffer(input) || input.length < 4 || input.toString('ascii', 0, 4) !== 'OggS') {
+		return input
+	}
+
+	const { packets, serial, preSkip } = parseOggPackets(input)
+	if (packets.length < 3 || packets[0]!.subarray(0, 8).toString('ascii') !== 'OpusHead') {
+		return input
+	}
+
+	const audioPackets = packets.slice(2)
+	// already multi-frame? (first audio packet TOC code === 3) -> idempotent no-op
+	if (audioPackets[0]?.length && (audioPackets[0][0]! & 0x03) === 3) {
+		return input
+	}
+
+	const frames = audioPackets
+		.filter(p => p.length >= 1)
+		.map(p => ({ configStereo: p[0]! >> 2, samples: opusFrameSamples48k(p[0]! >> 3), data: p.subarray(1) }))
+	if (!frames.length) {
+		return input
+	}
+
+	const out: Buffer[] = [buildOggPage(0x02, 0, serial, 0, packets[0]!), buildOggPage(0x00, 0, serial, 1, packets[1]!)]
+	let seq = 2
+	let samplesDone = 0
+	let i = 0
+	while (i < frames.length) {
+		// a code-3 packet must hold frames of the same config; libopus may switch
+		// SILK<->CELT between frames, so only group consecutive same-config frames
+		const cs = frames[i]!.configStereo
+		const group: Buffer[] = []
+		while (i < frames.length && group.length < framesPerPacket && frames[i]!.configStereo === cs) {
+			group.push(frames[i]!.data)
+			samplesDone += frames[i]!.samples
+			i++
+		}
+
+		const toc = ((cs << 2) | 3) & 0xff
+		const frameCountByte = (0x80 | group.length) & 0xff // VBR, no padding, count
+		const lengths: number[] = []
+		for (let k = 0; k < group.length - 1; k++) {
+			lengths.push(...encodeOpusFrameLength(group[k]!.length))
+		}
+
+		const packet = Buffer.concat([Buffer.from([toc, frameCountByte, ...lengths]), ...group])
+		out.push(buildOggPage(i >= frames.length ? 0x04 : 0x00, preSkip + samplesDone, serial, seq, packet))
+		seq++
+	}
+
+	return Buffer.concat(out)
+}
+
+/**
+ * Resolves a PTT media upload to a Buffer and repacketizes its Opus stream to
+ * code 3 so the voice note plays on iOS. Falls back to the original media/buffer
+ * on any failure (worst case: current behaviour).
+ */
+export const repacketizePttOpus = async (
+	media: WAMediaUpload,
+	opts?: RequestInit & { maxContentLength?: number },
+	logger?: ILogger
+): Promise<WAMediaUpload> => {
+	let buffer: Buffer
+	try {
+		const { stream } = await getStream(media, opts)
+		buffer = await toBuffer(stream)
+	} catch (err) {
+		logger?.warn({ err }, 'ptt repacketize: could not buffer media, sending as-is')
+		return media
+	}
+
+	try {
+		return repacketizeOggOpusToCode3(buffer)
+	} catch (err) {
+		logger?.warn({ err }, 'ptt repacketize: skipped, sending original opus')
+		return buffer
+	}
+}
+
 export const toReadable = (buffer: Buffer) => {
 	const readable = new Readable({ read: () => {} })
 	readable.push(buffer)

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -38,7 +38,8 @@ import {
 	getAudioDuration,
 	getAudioWaveform,
 	getRawMediaUploadData,
-	type MediaDownloadOptions
+	type MediaDownloadOptions,
+	repacketizePttOpus
 } from './messages-media'
 import { shouldIncludeReportingToken } from './reporting-utils'
 
@@ -143,6 +144,15 @@ export const prepareWAMessageMedia = async (
 		media: (message as any)[mediaType]
 	}
 	delete (uploadData as any)[mediaType]
+
+	// PTT voice notes must use Opus "code 3" packetization (multiple frames per
+	// packet) to play on iOS WhatsApp; libopus/ffmpeg emit "code 0", which iOS
+	// rejects ("audio no longer available"). Regroup so iOS accepts the voice note
+	// (Android already tolerates both). No-op if already code 3 / not OGG/Opus.
+	if (mediaType === 'audio' && uploadData.ptt === true) {
+		uploadData.media = await repacketizePttOpus(uploadData.media, options.options, logger)
+	}
+
 	// check if cacheable + generate cache key
 	const cacheableKey =
 		typeof uploadData.media === 'object' &&

--- a/src/__tests__/Utils/repacketize-opus.test.ts
+++ b/src/__tests__/Utils/repacketize-opus.test.ts
@@ -1,0 +1,54 @@
+import { repacketizeOggOpusToCode3 } from '../../Utils/messages-media'
+
+// real 16kHz mono libopus voice note (config 9 / code 0), generated with ffmpeg
+const FIXTURE_CODE0_B64 = 'T2dnUwACAAAAAAAAAADRF8N4AAAAABrZBg4BE09wdXNIZWFkAQE4AYA+AAAAAABPZ2dTAAAAAAAAAAAAANEXw3gBAAAAKmrtQwE+T3B1c1RhZ3MNAAAATGF2ZjYwLjE2LjEwMAEAAAAdAAAAZW5jb2Rlcj1MYXZjNjAuMzEuMTAyIGxpYm9wdXNPZ2dTAAR4OQAAAAAAANEXw3gCAAAAUo0GDxBiLzIxLi8xLTAwMjIuLyokSIEXHsDRoWZDgg239q4j7Islgr8sDawhc1tUPpJ52sN/lZricaCsK74ObV0ATayeThFrbCi8fN0RQ7+gQn3pcpFMHz7pdrdBDwSaAyb07mD8CBH+/2EY/5Ajv3d2rAQo1IBInh53O+7mvuNvyHbXIFjzC9fw6ufUaPrHjdQjDgbLjeAGbw+dsws+30IlOkCAgEiZnWCUDj3hLRlFoRnFTbrC6nnd6T8Ic1Xu0hyYDGqGrJXNS2R3hgOwqD/azbC5ytzASJlJ0XVde452NkOYBQW4VQTaAE0xhK7t1MmHBp9YC/QuQ1N78inXeL91H0ZnQ9b3YEiZSdF1XXuAZN1ieKhSnbn2yKTRjbmAOrNp6USGmqUEYN1RKRgWVemWJacGz/BImUnRdV18lw6HWGFeNIEH+CyT27cW+9BAla0x3mbR+pWMJv5KkEZjayPz1aufgEiZSdF1XXxkEGZxJLtViHlHZYuNjqfIao5Z8kpf16Sa99bSSpIs+ceI8ApRpx4P7XBImUnSVtVXEC3yyATWY9V4Alm0o0/AtERLdZMYGWgwewOl8YO1vqWP0EDTSN5ImUnRdV17jnZAFEvgN0hb+Muj5oCBmOD4/tpKlBffFwlo699BH+m/FThv38V4r6hImUnRdV17gGT/PK2rwVCTVQx7vMXYv1PB400X3SvkKrp2XwZF3+eV5pVRPE2PREtImUnRdV18Wlr1hHgq8ApDJGi21HenekHDa1xNzJJW6mYssPFSNO6ZjwIDkmgFf9ubqEiZSdF1XXxiA85694XMm4E/NrQkJXE35J6XtC5yt5xv3KOlBGaXj/hdaNsrnBe9B6KASJlJ0lbVXI9iqe8CLSg/h1wcg3LqFJ0Huh0bYwJYDR0nD+bvqmWRbiM3yLxO9EiZSdF1XXuSEHfye17dfIMP6wky9BRLxmDai01yxEgYQPPLYs8LQvvYr8h+FMqASJlJ0XVde4CpWCheJ+Xvv983rkBzzxIXtgo1Xme/uOGTwJfGMSLWfJmASAVzBzhnxH0AtZdPyeuCMN4q/IcCWV97yezvZckiK4I4rUnk'
+
+const firstAudioToc = (buf: Buffer) => {
+	let off = 0
+	let page = 0
+	while (off + 27 <= buf.length) {
+		if (buf.toString('ascii', off, off + 4) !== 'OggS') {
+			break
+		}
+
+		const nseg = buf[off + 26]!
+		let dataOff = off + 27 + nseg
+		let dl = 0
+		for (let s = 0; s < nseg; s++) {
+			dl += buf[off + 27 + s]!
+		}
+
+		page++
+		if (page >= 3) {
+			const toc = buf[dataOff]!
+			return { config: toc >> 3, code: toc & 0x03 }
+		}
+
+		off = dataOff + dl
+	}
+
+	return null
+}
+
+describe('repacketizeOggOpusToCode3', () => {
+	const input = Buffer.from(FIXTURE_CODE0_B64, 'base64')
+
+	it('regroups code 0 frames into code 3 packets, preserving config + OpusHead', () => {
+		expect(firstAudioToc(input)).toEqual({ config: 9, code: 0 })
+		const out = repacketizeOggOpusToCode3(input)
+		expect(out.subarray(0, 4).toString('ascii')).toBe('OggS')
+		expect(out.includes(Buffer.from('OpusHead'))).toBe(true)
+		expect(firstAudioToc(out)).toEqual({ config: 9, code: 3 })
+	})
+
+	it('is idempotent (already code 3 stays unchanged)', () => {
+		const once = repacketizeOggOpusToCode3(input)
+		const twice = repacketizeOggOpusToCode3(once)
+		expect(twice.equals(once)).toBe(true)
+	})
+
+	it('returns non-OGG input untouched', () => {
+		const junk = Buffer.from('this is not an ogg stream')
+		expect(repacketizeOggOpusToCode3(junk)).toBe(junk)
+	})
+})


### PR DESCRIPTION
## Problem

Voice notes sent with `ptt: true` play on **Android** but are **rejected by WhatsApp on iOS** — *"this audio is no longer available, ask the sender to resend it."* The message is delivered and downloadable on Android, so it is **not** a transport/upload problem. Reported repeatedly (see #1797, and the same media path in #1828).

## Root cause

The determinant is the **Opus packetization (TOC "code")** — not the container, mimetype, waveform, `seconds`, or transport:

- WhatsApp's **native** voice notes use Opus **code 3** (multiple 20 ms SILK frames per packet, e.g. 3×20 ms = 60 ms).
- `libopus`/`ffmpeg` — the usual way to produce the `.ogg` passed to `sendMessage` — emit **code 0** (one frame per packet).
- **iOS WhatsApp accepts code 3 and rejects code 0** for PTT; Android tolerates both.

Sample rate matters too (native PTT is 16 kHz mono; 48 kHz is also rejected on iOS) but it is *necessary-not-sufficient* — even a clean 16 kHz mono `code 0` stream is rejected. **Code 3 framing is the decisive factor.**

> TOC reminder (RFC 6716 §3.1): `config = toc >> 3`, `code = toc & 0x03`.

### How it was isolated (controlled A/B on a real iPhone)

1. **Decrypt a genuine native voice note** → `config 9 / code 3`. **Re-upload those exact bytes via Baileys** (`sendMessage({ audio, ptt:true })`) → **plays on iOS** → proves Baileys' transport/upload is correct.
2. **ffmpeg 16 kHz mono opus** (`config 9 / code 0`) via Baileys → **iOS rejects**.
3. **Re-packetize that same ffmpeg output to code 3** → via Baileys → **plays on iOS**.

Same transport, same audio content — only the packet framing changes.

## What this PR does

Adds a dependency-free OGG/Opus repacketizer (`repacketizeOggOpusToCode3`) and applies it in `prepareWAMessageMedia` **only on the `ptt` path**:

- Regroups consecutive same-`config` `code 0` frames into `code 3` packets (default 3 frames/packet), rewriting OGG pages with recomputed `granulepos` and CRC-32.
- **Idempotent** — returns the input untouched if it is already `code 3` or not OGG/Opus.
- **Safe** — `repacketizePttOpus` buffers the media and falls back to the original on any error (worst case = current behaviour).
- Grouping respects the per-frame `config` (libopus can switch SILK↔CELT between frames; a `code 3` packet requires a uniform config).

## Alternatives (happy to switch)

- **(this PR) default on the `ptt` path** — fixes it for everyone, no API change.
- **opt-in** — gate behind a media option if you'd rather not change default behaviour (one line).
- **utility only** — `repacketizeOggOpusToCode3` is exported, so callers can apply it themselves.

## Tests

`src/__tests__/Utils/repacketize-opus.test.ts`: a real `code 0` fixture → asserts `code 3` output (config preserved, `OpusHead` intact), idempotency, and non-OGG passthrough. The end-to-end fix was validated by sending a UI-recorded voice note to a real iPhone.

## Related

- #1797 (closed) — "Audio is not Playable in Mobile"
- #1828 — waveform regression on the same media path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS playback for PTT voice notes by repacketizing Opus to TOC code 3 (multi-frame) during media preparation. No API changes; Android behavior is unchanged.

- **Bug Fixes**
  - Adds `repacketizeOggOpusToCode3` to regroup `code 0` frames into `code 3`, updating OGG granulepos and CRC.
  - Applies repacketization in `prepareWAMessageMedia` only when `ptt: true`; no-op for `code 1/2/3` or non-OGG/Opus, and falls back to the original on any error.
  - Groups only same-config frames to avoid SILK/CELT mixing; defaults to 3 frames/packet (validated 1–48); preserves `OpusHead` and config.
  - Adds a unit test verifying conversion to `code 3`, idempotency, and non-OGG passthrough.

<sup>Written for commit ae88776a2f5e19253bb6d39ddc1ba54468634f83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved Push-to-Talk (PTT) voice note handling by repacketizing Opus audio for better compatibility and more reliable playback, especially on iOS.
  * Automatically applies the update only to PTT voice notes; other audio types are unaffected.

* **Bug Fixes**
  * Added resilient fallback behavior: if repacketization isn’t possible, the original voice note audio is used to avoid transmission failures.

* **Tests**
  * Added Jest coverage to verify correct repacketization, idempotency, and non-OGG no-op behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->