### PR TITLE
fix: emit labels.association remove event for tombstone mutations

### DIFF
--- a/src/Types/Chat.ts
+++ b/src/Types/Chat.ts
@@ -47,6 +47,7 @@ export type BotListInfo = {
 export type ChatMutation = {
 	syncAction: proto.ISyncActionData
 	index: string[]
+	operation?: proto.SyncdMutation.SyncdOperation
 }
 
 export type WAPatchCreate = {

--- a/src/Utils/chat-utils.ts
+++ b/src/Utils/chat-utils.ts
@@ -285,7 +285,7 @@ export const decodeSyncdMutations = async (
 		}
 
 		const indexStr = Buffer.from(syncAction.index!).toString()
-		onMutation({ syncAction, index: JSON.parse(indexStr) })
+		onMutation({ syncAction, index: JSON.parse(indexStr), operation: operation ?? undefined })
 
 		ltGenerator.mix({
 			indexMac: record.index!.blob!,
@@ -834,7 +834,8 @@ export const processSyncAction = (
 
 	const {
 		syncAction: { value: action },
-		index: [type, id, msgId, fromMe]
+		index: [type, id, msgId, fromMe],
+		operation
 	} = syncAction
 
 	if (action?.muteAction) {
@@ -964,6 +965,19 @@ export const processSyncAction = (
 							messageId: syncAction.index[3],
 							labelId: syncAction.index[1]
 						} as MessageLabelAssociation)
+		})
+	} else if (
+		operation === proto.SyncdMutation.SyncdOperation.REMOVE &&
+		type === LabelAssociationType.Chat
+	) {
+		// Tombstone REMOVE: WhatsApp sends label removals with operation=REMOVE and empty labelAssociationAction
+		ev.emit('labels.association', {
+			type: 'remove',
+			association: {
+				type: LabelAssociationType.Chat,
+				chatId: msgId!,
+				labelId: id!
+			} as ChatLabelAssociation
 		})
 	} else if (action?.localeSetting?.locale) {
 		ev.emit('settings.update', { setting: 'locale', value: action.localeSetting.locale })


### PR DESCRIPTION
WhatsApp sends label REMOVE operations as tombstone mutations: the mutation has operation=REMOVE but an empty labelAssociationAction field. The existing handler only checks action?.labelAssociationAction (undefined for tombstones) and falls through to "unprocessable update", so label removal events are never emitted.

Two changes:
1. decodeSyncdMutations: include operation in the onMutation callback object so processSyncAction can access it. Requires adding operation as an optional field to the ChatMutation type.
2. processSyncAction: add a handler for tombstone REMOVE mutations on label_jid associations that emits labels.association with type:remove.

Tested on Baileys 7.0.0-rc.9 with WhatsApp mobile (iOS/Android).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing label removal events by handling WhatsApp tombstone REMOVE mutations. Now emits `labels.association` with type: remove when a label is removed.

- **Bug Fixes**
  - Include mutation `operation` in `decodeSyncdMutations` and add it to `ChatMutation`.
  - Handle tombstone `REMOVE` on `label_jid` in `processSyncAction` and emit `labels.association` with `type: remove`.

<sup>Written for commit 61b08cb3b66201a336c5b4c7276bb9f3e0f12e9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label removal synchronization to properly handle deletion of labels from chats and maintain accurate label associations across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->