### PR TITLE
Added support for the 'lid_refresh' event (ACK) in the case when the LID becomes irrelevant; to prohibit the user from sending messages, which may lead to account suspension or ban

### DIFF
--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -84,6 +84,8 @@ export const DEFAULT_CONNECTION_CONFIG: SocketConfig = {
 	generateHighQualityLinkPreview: false,
 	enableAutoSessionRecreation: true,
 	enableRecentMessageCache: true,
+	enableLidMigrationSafety: true,
+	refreshMappingOnLidMigration: true,
 	options: {},
 	appStateMacVerification: {
 		patch: false,

--- a/src/Signal/lid-mapping.ts
+++ b/src/Signal/lid-mapping.ts
@@ -1,5 +1,5 @@
 import { LRUCache } from 'lru-cache'
-import type { LIDMapping, SignalKeyStoreWithTransaction } from '../Types'
+import type { LIDMapping, SignalKeyStoreWithTransaction, OptionsWithForce } from '../Types'
 import type { ILogger } from '../Utils/logger'
 import { isHostedPnUser, isLidUser, isPnUser, jidDecode, jidNormalizedUser, WAJIDDomains } from '../WABinary'
 
@@ -105,15 +105,16 @@ export class LIDMappingStore {
 		}
 	}
 
-	async getLIDForPN(pn: string): Promise<string | null> {
-		return (await this.getLIDsForPNs([pn]))?.[0]?.lid || null
+	async getLIDForPN(pn: string, options: OptionsWithForce & {} = {}): Promise<string | null> {
+		return (await this.getLIDsForPNs([pn], options))?.[0]?.lid || null
 	}
 
-	async getLIDsForPNs(pns: string[]): Promise<LIDMapping[] | null> {
+	async getLIDsForPNs(pns: string[], { force }: OptionsWithForce & {} = {}): Promise<LIDMapping[] | null> {
 		if (pns.length === 0) return null
 
 		const sortedPns = [...new Set(pns)].sort()
-		const cacheKey = sortedPns.join(',')
+		const forceCachePrefix = 'force'
+		const cacheKey = `${force ? `${forceCachePrefix}:` : ''}${sortedPns.join(',')}`
 
 		const inflight = this.inflightLIDLookups.get(cacheKey)
 		if (inflight) {
@@ -121,7 +122,7 @@ export class LIDMappingStore {
 			return inflight
 		}
 
-		const promise = this._getLIDsForPNsImpl(pns)
+		const promise = this._getLIDsForPNsImpl(pns, { force })
 		this.inflightLIDLookups.set(cacheKey, promise)
 
 		try {
@@ -131,7 +132,7 @@ export class LIDMappingStore {
 		}
 	}
 
-	private async _getLIDsForPNsImpl(pns: string[]): Promise<LIDMapping[] | null> {
+	private async _getLIDsForPNsImpl(pns: string[], { force }: OptionsWithForce & {}): Promise<LIDMapping[] | null> {
 		const usyncFetch: { [_: string]: number[] } = {}
 		const successfulPairs: { [_: string]: LIDMapping } = {}
 		const pending: Array<{ pn: string; pnUser: string; decoded: ReturnType<typeof jidDecode> }> = []
@@ -161,7 +162,10 @@ export class LIDMappingStore {
 			if (!decoded) continue
 
 			const pnUser = decoded.user
-			const cached = this.mappingCache.get(`pn:${pnUser}`)
+			const cached = force ?
+				undefined :
+				this.mappingCache.get(`pn:${pnUser}`)
+
 			if (cached && typeof cached === 'string') {
 				if (!addResolvedPair(pn, decoded, cached)) {
 					this.logger.warn(`Invalid entry for ${pn} (pair not resolved)`)
@@ -176,17 +180,22 @@ export class LIDMappingStore {
 
 		if (pending.length) {
 			const pnUsers = [...new Set(pending.map(item => item.pnUser))]
-			const stored = await this.keys.get('lid-mapping', pnUsers)
-			for (const pnUser of pnUsers) {
-				const lidUser = stored[pnUser]
-				if (lidUser && typeof lidUser === 'string') {
-					this.mappingCache.set(`pn:${pnUser}`, lidUser)
-					this.mappingCache.set(`lid:${lidUser}`, pnUser)
+			if (!force) {
+				const stored = await this.keys.get('lid-mapping', pnUsers)
+				for (const pnUser of pnUsers) {
+					const lidUser = stored[pnUser]
+					if (lidUser && typeof lidUser === 'string') {
+						this.mappingCache.set(`pn:${pnUser}`, lidUser)
+						this.mappingCache.set(`lid:${lidUser}`, pnUser)
+					}
 				}
 			}
 
 			for (const { pn, pnUser, decoded } of pending) {
-				const cached = this.mappingCache.get(`pn:${pnUser}`)
+				const cached = force ?
+					undefined :
+					this.mappingCache.get(`pn:${pnUser}`)
+
 				if (cached && typeof cached === 'string') {
 					if (!addResolvedPair(pn, decoded, cached)) {
 						this.logger.warn(`Invalid entry for ${pn} (pair not resolved)`)

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -11,6 +11,7 @@ import {
 	STATUS_EXPIRY_SECONDS
 } from '../Defaults'
 import type {
+	LIDMigrationUpdate,
 	GroupParticipant,
 	MessageReceiptType,
 	MessageRelayOptions,
@@ -75,6 +76,7 @@ import {
 	getBinaryNodeChildren,
 	getBinaryNodeChildString,
 	getBinaryNodeChildUInt,
+	isHostedLidUser,
 	isJidGroup,
 	isJidNewsletter,
 	isJidStatusBroadcast,
@@ -1845,8 +1847,54 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		}
 	}
 
+	const handleLidRefreshAck = async (attrs: BinaryNode['attrs']) => {
+		// NOTE: Yes, it is a string right from the WhatsApp x_x
+		const refreshLidTrue = 'true'
+		if (!config.enableLidMigrationSafety || attrs['refresh_lid'] !== refreshLidTrue)
+			return
+
+		const oldLid = attrs.from || attrs.remoteJid
+		if (!oldLid || (!isLidUser(oldLid) && !isHostedLidUser(oldLid))) {
+			logger.warn({ attrs }, `received 'refresh_lid' ack without a LID sender`)
+			return
+		}
+
+		let pn: string|undefined
+		let newLid: string|undefined
+
+		try {
+			pn = (await signalRepository.lidMapping.getPNForLID(oldLid)) || undefined
+
+			if (pn && config.refreshMappingOnLidMigration) {
+				const refreshedLid = await signalRepository.lidMapping.getLIDForPN(pn, { force: true })
+				if (refreshedLid && !areJidsSameUser(refreshedLid, oldLid)) {
+					newLid = refreshedLid
+					await signalRepository
+						.migrateSession(pn, newLid)
+						.catch(err => logger.warn({ err: err, pn: pn, oldLid: oldLid, newLid: newLid }, `failed to migrate Signal session after 'refresh_lid' ack`))
+				}
+			}
+		} catch (err) {
+			logger.warn(
+				{ err, oldLid },
+				`failed to refresh LID mapping after 'refresh_lid' ack`,
+			)
+		}
+
+		const migration: LIDMigrationUpdate = {
+			oldLid: oldLid,
+			reason: 'ack-refresh-lid',
+			pn: pn,
+			newLid: newLid,
+			messageId: attrs.id,
+		}
+
+		ev.emit('lid-migration.update', migration)
+	}
+
 	const handleBadAck = async ({ attrs }: BinaryNode) => {
 		const key: WAMessageKey = { remoteJid: attrs.from, fromMe: true, id: attrs.id }
+		await handleLidRefreshAck(attrs)
 
 		// WARNING: REFRAIN FROM ENABLING THIS FOR NOW. IT WILL CAUSE A LOOP
 		// // current hypothesis is that if pash is sent in the ack

--- a/src/Types/Auth.ts
+++ b/src/Types/Auth.ts
@@ -24,6 +24,14 @@ export type LIDMapping = {
 	lid: string
 }
 
+export type LIDMigrationUpdate = {
+	oldLid: string
+	newLid?: string
+	pn?: string
+	messageId?: string
+	reason: 'ack-refresh-lid'
+}
+
 export type LTHashState = {
 	version: number
 	hash: Buffer

--- a/src/Types/Events.ts
+++ b/src/Types/Events.ts
@@ -1,6 +1,6 @@
 import type { Boom } from '@hapi/boom'
 import { proto } from '../../WAProto/index.js'
-import type { AuthenticationCreds, LIDMapping } from './Auth'
+import type { AuthenticationCreds, LIDMapping, LIDMigrationUpdate } from './Auth'
 import type { WACallEvent } from './Call'
 import type { Chat, ChatUpdate, PresenceData } from './Chat'
 import type { Contact } from './Contact'
@@ -52,6 +52,7 @@ export type BaileysEventMap = {
 	/** update the given chats */
 	'chats.update': ChatUpdate[]
 	'lid-mapping.update': LIDMapping
+	'lid-migration.update': LIDMigrationUpdate
 	/** delete chats with given ID */
 	'chats.delete': string[]
 	/** presence of contact in a chat updated */

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -109,6 +109,12 @@ export type SocketConfig = {
 	/** Enable recent message caching for retry handling */
 	enableRecentMessageCache: boolean
 
+	/** Handle ACKs with 'refresh_lid': 'true', emit 'lid-migration.update' */
+	enableLidMigrationSafety: boolean
+
+	/** Force-refresh PN-->LID mappings when a refresh_lid ACK is received */
+	refreshMappingOnLidMigration: boolean
+
 	/**
 	 * Returns if a jid should be ignored,
 	 * no event for that jid will be triggered.

--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -66,3 +66,7 @@ export type WABusinessProfile = {
 }
 
 export type CurveKeyPair = { private: Uint8Array; public: Uint8Array }
+
+export type OptionsWithForce = {
+	force?: boolean
+}

--- a/src/__tests__/Signal/lid-mapping.test.ts
+++ b/src/__tests__/Signal/lid-mapping.test.ts
@@ -44,4 +44,32 @@ describe('LIDMappingStore', () => {
 			expect(result).toBeNull()
 		})
 	})
+
+	describe('getLIDsForPNs', () => {
+		it('force refreshes a PN mapping through USync instead of using cache or storage', async () => {
+			const pn = '12345678900@s.whatsapp.net'
+			const oldLid = '11111111111111@lid'
+			const newLid = '22222222222222@lid'
+
+			// @ts-ignore
+			mockKeys.get.mockResolvedValue({} as SignalDataTypeMap['lid-mapping'])
+
+			await lidMappingStore.storeLIDPNMappings([{ pn: pn, lid: oldLid }])
+
+			jest.clearAllMocks()
+			mockPnToLIDFunc.mockResolvedValue([{ pn: pn, lid: newLid }])
+
+			const result = await lidMappingStore.getLIDsForPNs([ pn ], { force: true })
+
+			expect(mockKeys.get).not.toHaveBeenCalled()
+			expect(mockPnToLIDFunc).toHaveBeenCalledWith([ pn ])
+			expect(mockKeys.set).toHaveBeenCalledWith({
+				'lid-mapping': {
+					'12345678900': '22222222222222',
+					'22222222222222_reverse': '12345678900'
+				}
+			})
+			expect(result).toEqual([{ pn: pn, lid: newLid }])
+		})
+	})
 })


### PR DESCRIPTION
Hi,

While working with WhatsApp, I noticed a case. **From time to time user's LID can change spontaneously**, and WA works it out with a message: _"This phone number is connected to a new WhatsApp account."_ _"Message the new account"_. (see the screenshot below; DO NOT confuse it with the case when the user simply chenge their phone number).

In _this_ case, chat becomes stale, and the abitily send send messages is disabled. Attempting to send a message the first time does not result in any restrictons. The user simply recieves an ACK with the `refresh_lid`: `"true"` (yes, it is a string right from WhatsApp). This is supposed to be intended to inform that they need to refresh their LID mappings

Further attempts to send a message to an irrelevant chat can lead to an account suspension or ban. So, I added a new type of event, the purpose of which is to inform the host they need to update their mappings and use the new LID instead, which is returned as a payload. I have added new logic, as well as new feature flags & tests.

I'd appreciate it if you could consider my suggestions.

Baileys user, — Kenny

<img width="986" height="1280" alt="photo_2026-06-26_17-02-05" src="https://github.com/user-attachments/assets/8b0a5959-8e1c-4bee-8b7d-af05ed802177" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle WhatsApp ACKs with `refresh_lid: 'true'` to stop sending to stale LIDs. Emits a `lid-migration.update` event and refreshes PN→LID mapping and session to keep messaging safe.

- **New Features**
  - Emit `lid-migration.update` with `oldLid`, optional `newLid`, `pn`, `messageId`, and `reason: 'ack-refresh-lid'`.
  - New `SocketConfig` flags: `enableLidMigrationSafety` and `refreshMappingOnLidMigration` (default: true).
  - `LIDMappingStore` supports forced lookups: `getLIDForPN(pn, { force: true })` to bypass cache/storage.
  - Auto-migrate the Signal session to the refreshed LID when detected.

- **Migration**
  - Listen for `lid-migration.update`; stop sending to `oldLid` and switch to `newLid` when provided.
  - To keep previous behavior, disable `enableLidMigrationSafety` or `refreshMappingOnLidMigration`.

<sup>Written for commit 3b581a713a6e6863dc2bffeebce538848d588a0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer handling for LID migration acknowledgements, including a new migration update event for listeners.
  * Introduced an option to refresh identity mappings on demand when resolving IDs.
  * Added new configuration settings to control LID migration safety behavior.

* **Bug Fixes**
  * Improved ID resolution so forced refreshes bypass stale cached or stored mappings and re-run lookup flow.
  * Ensured migration acknowledgements can trigger a session update when a refreshed mapping is needed.

* **Tests**
  * Added coverage for forced mapping refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->