### PR TITLE
example: fix logging of contact upserts

### DIFF
--- a/Example/example.ts
+++ b/Example/example.ts
@@ -185,7 +185,7 @@ const startSock = async() => {
 			}
 
 			if (events['contacts.upsert']) {
-				logger.debug(events['message-receipt.update'])
+				logger.debug(events['contacts.upsert'])
 			}
 
 			if(events['messages.reaction']) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed incorrect debug logging for `contacts.upsert` events; the handler now logs `events['contacts.upsert']` instead of `events['message-receipt.update']`, improving observability and debugging clarity.

<sup>Written for commit 2646afc878559e647b15fc87261e26f1bff008c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a debug log message for contact update events so it now reports the proper event type instead of showing an unrelated receipt update event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->