### PR TITLE
Security: bufferToUInt reads beyond buffer length without bounds check

### DIFF
--- a/src/WABinary/generic-utils.ts
+++ b/src/WABinary/generic-utils.ts
@@ -58,7 +58,7 @@ export const getBinaryNodeChildString = (node: BinaryNode | undefined, childTag:
 
 export const getBinaryNodeChildUInt = (node: BinaryNode, childTag: string, length: number) => {
 	const buff = getBinaryNodeChildBuffer(node, childTag)
-	if (buff) {
+	if (buff && buff.length >= length) {
 		return bufferToUInt(buff, length)
 	}
 }


### PR DESCRIPTION
## Problem

`getBinaryNodeChildUInt` calls `bufferToUInt(buff, length)` but never validates that `buff.length >= length`. Since `buff` comes from decoded binary protocol nodes (`getBinaryNodeChildBuffer`), a malformed or truncated message from the WhatsApp server (or a MITM) can cause out-of-bounds reads. In Node.js, reading beyond a Buffer returns `undefined`, producing `NaN` (256 * a + undefined), which silently corrupts downstream logic that relies on these integer fields for protocol handling (e.g., parsing device IDs, version numbers, counters).


**Severity**: `medium`
**File**: `src/WABinary/generic-utils.ts`

## Solution

In `getBinaryNodeChildUInt`, add a length guard before calling `bufferToUInt`:


## Changes

- `src/WABinary/generic-utils.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a bounds check in getBinaryNodeChildUInt to ensure the buffer is at least the requested length before calling bufferToUInt. This prevents out-of-bounds reads from malformed or truncated protocol nodes and avoids NaN values that could corrupt parsing state.

<sup>Written for commit 9a1caa000550e76e3bc805e18465522da387e20b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary value handling by validating that a retrieved buffer is present and long enough before converting it to an unsigned integer.
  * Reduced the chance of incorrect numeric parsing when binary data is shorter than expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->