### PR TITLE
fix(auth): share AsyncLocalStorage across sockets to stop heap leak

### DIFF
--- a/src/Utils/auth-utils.ts
+++ b/src/Utils/auth-utils.ts
@@ -28,6 +28,10 @@ interface TransactionContext {
 	dbQueries: number
 }
 
+// Shared across sockets on purpose: a per-socket instance leaks the heap under Node's legacy
+// async-context propagation. The context lives in the run scope, so sockets never collide.
+const txStorage = new AsyncLocalStorage<TransactionContext>()
+
 /**
  * Adds caching capability to a SignalKeyStore
  * @param store the store to add caching to
@@ -118,8 +122,6 @@ export const addTransactionCapability = (
 	logger: ILogger,
 	{ maxCommitRetries, delayBetweenTriesMs }: TransactionCapabilityOptions
 ): SignalKeyStoreWithTransaction => {
-	const txStorage = new AsyncLocalStorage<TransactionContext>()
-
 	// Queues for concurrency control (keyed by signal data type - bounded set)
 	const keyQueues = new Map<string, PQueue>()
 

--- a/src/Utils/auth-utils.ts
+++ b/src/Utils/auth-utils.ts
@@ -28,9 +28,11 @@ interface TransactionContext {
 	dbQueries: number
 }
 
-// Shared across sockets on purpose: a per-socket instance leaks the heap under Node's legacy
-// async-context propagation. The context lives in the run scope, so sockets never collide.
-const txStorage = new AsyncLocalStorage<TransactionContext>()
+// One instance per process: a per-socket AsyncLocalStorage leaks the heap under Node's legacy
+// async-context propagation, where every live instance tags every pending async resource. The
+// value is keyed by store token so a store only ever sees its own context, even when another
+// wrapped store runs inside its transaction.
+const txStorage = new AsyncLocalStorage<Map<symbol, TransactionContext>>()
 
 /**
  * Adds caching capability to a SignalKeyStore
@@ -122,6 +124,9 @@ export const addTransactionCapability = (
 	logger: ILogger,
 	{ maxCommitRetries, delayBetweenTriesMs }: TransactionCapabilityOptions
 ): SignalKeyStoreWithTransaction => {
+	// Identifies this store's slot inside the shared transaction map
+	const storeToken = Symbol('signalTxStore')
+
 	// Queues for concurrency control (keyed by signal data type - bounded set)
 	const keyQueues = new Map<string, PQueue>()
 
@@ -181,10 +186,17 @@ export const addTransactionCapability = (
 	}
 
 	/**
+	 * Resolve this store's transaction context from the shared async-local map
+	 */
+	function getContext(): TransactionContext | undefined {
+		return txStorage.getStore()?.get(storeToken)
+	}
+
+	/**
 	 * Check if currently in a transaction
 	 */
 	function isInTransaction(): boolean {
-		return !!txStorage.getStore()
+		return !!getContext()
 	}
 
 	/**
@@ -218,7 +230,7 @@ export const addTransactionCapability = (
 
 	return {
 		get: async (type, ids) => {
-			const ctx = txStorage.getStore()
+			const ctx = getContext()
 
 			if (!ctx) {
 				// No transaction - direct read without exclusive lock for concurrency
@@ -253,7 +265,7 @@ export const addTransactionCapability = (
 		},
 
 		set: async data => {
-			const ctx = txStorage.getStore()
+			const ctx = getContext()
 
 			if (!ctx) {
 				// No transaction - direct write with queue protection
@@ -303,10 +315,10 @@ export const addTransactionCapability = (
 		isInTransaction,
 
 		transaction: async (work, key) => {
-			const existing = txStorage.getStore()
+			const stores = txStorage.getStore()
 
-			// Nested transaction - reuse existing context
-			if (existing) {
+			// Nested transaction on this same store - reuse existing context
+			if (stores?.get(storeToken)) {
 				logger.trace('reusing existing transaction context')
 				return work()
 			}
@@ -323,10 +335,14 @@ export const addTransactionCapability = (
 						dbQueries: 0
 					}
 
+					// Inherit contexts from outer stores so they stay isolated by token
+					const next = new Map(stores)
+					next.set(storeToken, ctx)
+
 					logger.trace('entering transaction')
 
 					try {
-						const result = await txStorage.run(ctx, work)
+						const result = await txStorage.run(next, work)
 
 						// Commit mutations
 						await commitWithRetry(ctx.mutations)

--- a/src/__tests__/Utils/auth-utils.test.ts
+++ b/src/__tests__/Utils/auth-utils.test.ts
@@ -94,6 +94,43 @@ describe('addTransactionCapability', () => {
 		expect((await backingB.get('app-state-sync-key', ['1']))['1']).toMatchObject({ keyId: 2 })
 	})
 
+	it('does not leak a transaction context into another store in the same async chain', async () => {
+		const backingA = memoryStore()
+		const backingB = memoryStore()
+		const a = addTransactionCapability(backingA, silentLogger(), opts)
+		const b = addTransactionCapability(backingB, silentLogger(), opts)
+
+		await a.transaction(async () => {
+			// b is untouched by a's ambient context
+			expect(b.isInTransaction()).toBe(false)
+			await b.set({ 'app-state-sync-key': key(9) as never })
+			await a.set({ 'app-state-sync-key': key(1) as never })
+		}, 'app-state-sync-key')
+
+		// b's write went straight to its own backing store, not into a's mutations
+		expect((await backingB.get('app-state-sync-key', ['1']))['1']).toMatchObject({ keyId: 9 })
+		expect((await backingA.get('app-state-sync-key', ['1']))['1']).toMatchObject({ keyId: 1 })
+	})
+
+	it('keeps nested transactions across stores isolated by token', async () => {
+		const backingA = memoryStore()
+		const backingB = memoryStore()
+		const a = addTransactionCapability(backingA, silentLogger(), opts)
+		const b = addTransactionCapability(backingB, silentLogger(), opts)
+
+		await a.transaction(async () => {
+			await a.set({ 'app-state-sync-key': key(1) as never })
+			await b.transaction(async () => {
+				expect(a.isInTransaction()).toBe(true)
+				expect(b.isInTransaction()).toBe(true)
+				await b.set({ 'app-state-sync-key': key(2) as never })
+			}, 'app-state-sync-key')
+		}, 'app-state-sync-key')
+
+		expect((await backingA.get('app-state-sync-key', ['1']))['1']).toMatchObject({ keyId: 1 })
+		expect((await backingB.get('app-state-sync-key', ['1']))['1']).toMatchObject({ keyId: 2 })
+	})
+
 	it('reads buffered writes before commit and reuses nested transactions', async () => {
 		const store = addTransactionCapability(memoryStore(), silentLogger(), opts)
 

--- a/src/__tests__/Utils/auth-utils.test.ts
+++ b/src/__tests__/Utils/auth-utils.test.ts
@@ -1,11 +1,48 @@
 import { Boom } from '@hapi/boom'
-import type { AuthenticationCreds, Contact } from '../../Types'
-import { assertMeId, initAuthCreds } from '../../Utils/auth-utils'
+import type { AuthenticationCreds, Contact, SignalDataSet, SignalKeyStore } from '../../Types'
+import { addTransactionCapability, assertMeId, initAuthCreds } from '../../Utils/auth-utils'
+import type { ILogger } from '../../Utils/logger'
 
 const credsWithMe = (me?: Partial<Contact>): AuthenticationCreds => ({
 	...initAuthCreds(),
 	me: me as Contact | undefined
 })
+
+const silentLogger = (): ILogger => {
+	const logger: ILogger = {
+		level: 'silent',
+		trace: () => {},
+		debug: () => {},
+		info: () => {},
+		warn: () => {},
+		error: () => {},
+		child: () => logger
+	}
+	return logger
+}
+
+const memoryStore = (): SignalKeyStore => {
+	const data: Record<string, Record<string, unknown>> = {}
+	return {
+		get: (type, ids) => {
+			const out: Record<string, unknown> = {}
+			for (const id of ids) {
+				const value = data[type]?.[id]
+				if (value !== undefined) {
+					out[id] = value
+				}
+			}
+
+			return out as never
+		},
+		set: update => {
+			for (const type in update) {
+				data[type] = data[type] || {}
+				Object.assign(data[type], update[type as keyof SignalDataSet])
+			}
+		}
+	}
+}
 
 describe('assertMeId', () => {
 	it('returns me.id when authenticated', () => {
@@ -33,5 +70,45 @@ describe('assertMeId', () => {
 	it('throws Boom 401 when me.id is empty string', () => {
 		const creds = credsWithMe({ id: '' })
 		expect(() => assertMeId(creds)).toThrow(/not authenticated/)
+	})
+})
+
+describe('addTransactionCapability', () => {
+	const opts = { maxCommitRetries: 1, delayBetweenTriesMs: 0 }
+	const key = (n: number) => ({ '1': { keyId: n, publicKey: new Uint8Array([n]), keySignature: new Uint8Array([n]) } })
+
+	it('isolates committed data across stores sharing the singleton', async () => {
+		const backingA = memoryStore()
+		const backingB = memoryStore()
+		const a = addTransactionCapability(backingA, silentLogger(), opts)
+		const b = addTransactionCapability(backingB, silentLogger(), opts)
+
+		await a.transaction(async () => {
+			await a.set({ 'app-state-sync-key': key(1) as never })
+		}, 'app-state-sync-key')
+		await b.transaction(async () => {
+			await b.set({ 'app-state-sync-key': key(2) as never })
+		}, 'app-state-sync-key')
+
+		expect((await backingA.get('app-state-sync-key', ['1']))['1']).toMatchObject({ keyId: 1 })
+		expect((await backingB.get('app-state-sync-key', ['1']))['1']).toMatchObject({ keyId: 2 })
+	})
+
+	it('reads buffered writes before commit and reuses nested transactions', async () => {
+		const store = addTransactionCapability(memoryStore(), silentLogger(), opts)
+
+		await store.transaction(async () => {
+			expect(store.isInTransaction()).toBe(true)
+			await store.set({ 'app-state-sync-key': key(7) as never })
+			const buffered = await store.transaction(async () => store.get('app-state-sync-key', ['1']), 'app-state-sync-key')
+			expect(buffered['1']).toMatchObject({ keyId: 7 })
+		}, 'app-state-sync-key')
+
+		expect(store.isInTransaction()).toBe(false)
+	})
+
+	it('reports no transaction outside of run scope', () => {
+		const store = addTransactionCapability(memoryStore(), silentLogger(), opts)
+		expect(store.isInTransaction()).toBe(false)
 	})
 })


### PR DESCRIPTION
## Problem

`addTransactionCapability` creates a new `AsyncLocalStorage` on every call, which means once per `makeWASocket`. That instance is never `.disable()`d.

On Node's legacy async-context propagation (Node 22, before `AsyncContextFrame` became the default), every live `AsyncLocalStorage` stamps an internal slot on every pending async resource. Memory cost therefore grows as O(live ALS instances × live async resources).

Under reconnection churn each new socket adds another immortal ALS instance. When a burst of pending promises/timeouts coincides with a high instance count, the heap blows past the V8 limit and the process OOMs (`FATAL ERROR: Reached heap limit`) even with `--max-old-space-size=4096`. This is the internal V8 ceiling, not the kernel OOM-killer.

## Evidence

A heap snapshot of an affected worker (~1.3 GB live) was 85% `(object properties)` arrays owned by Promises and Timeouts, each carrying ~500 distinct `Symbol(kResourceStore)` keys, i.e. ~500 live `AsyncLocalStorage` instances tagging every async resource.

Minimal repro on `node:22-slim` with 20k pending promises:

| live ALS instances | heapUsed |
|---|---|
| 0 | 4.4 MB |
| 1 | 6.1 MB |
| 100 | 123.8 MB |

It scales linearly with the number of ALS instances and does not reproduce on Node 24 (which uses `AsyncContextFrame`), confirming the cause is the legacy per-resource tagging.

## Fix

Hoist `txStorage` to a single module-level `AsyncLocalStorage` per process instead of one per socket. To keep each wrapped store isolated, the stored value is a `Map` keyed by a per-store token rather than a bare context: a store resolves only its own context, and a new transaction inherits the outer stores' contexts so nesting across stores stays isolated. This means one wrapped store called inside another store's transaction can no longer have its writes committed into the wrong backing store.

Raising the heap limit does not help (the cost is O(N) in churn) and reducing retries only delays it.

## Tests

Added regression tests in `src/__tests__/Utils/auth-utils.test.ts`: cross-store committed-data isolation, a store invoked inside another store's transaction not leaking into it, cross-store nesting staying isolated by token, buffered reads before commit, and nested-transaction reuse. `yarn lint` is clean and `yarn test` is green.
