### PR TITLE
fix: atomic write creeds.json via temp file + rename

### DIFF
--- a/src/Utils/use-multi-file-auth-state.ts
+++ b/src/Utils/use-multi-file-auth-state.ts
@@ -39,13 +39,23 @@ export const useMultiFileAuthState = async (
 		const mutex = getFileLock(filePath)
 
 		return mutex.acquire().then(async release => {
+			const tmpPath = `${filePath}.tmp`
+			// Preserve restrictive permissions from the existing auth file
+			const existingStat = await stat(filePath).catch(() => undefined)
+			await writeFile(
+				tmpPath,
+				JSON.stringify(data, BufferJSON.replacer),
+				existingStat ? { mode: existingStat.mode & 0o777 } : undefined,
+			)
+			// Atomic rename; if it fails (e.g. cross-device), fall back to direct write
 			try {
-				const tmpPath = `${filePath}.tmp`
-				await writeFile(tmpPath, JSON.stringify(data, BufferJSON.replacer))
 				await rename(tmpPath, filePath)
 			} catch {
-				// Fallback to direct write if rename fails (e.g. cross-device)
-				await writeFile(filePath, JSON.stringify(data, BufferJSON.replacer))
+				await writeFile(
+					filePath,
+					JSON.stringify(data, BufferJSON.replacer),
+					existingStat ? { mode: existingStat.mode & 0o777 } : undefined,
+				)
 			} finally {
 				release()
 			}

--- a/src/Utils/use-multi-file-auth-state.ts
+++ b/src/Utils/use-multi-file-auth-state.ts
@@ -1,5 +1,5 @@
 import { Mutex } from 'async-mutex'
-import { mkdir, readFile, stat, unlink, writeFile } from 'fs/promises'
+import { mkdir, readFile, rename, stat, unlink, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { proto } from '../../WAProto/index.js'
 import type { AuthenticationCreds, AuthenticationState, SignalDataTypeMap } from '../Types'
@@ -40,6 +40,11 @@ export const useMultiFileAuthState = async (
 
 		return mutex.acquire().then(async release => {
 			try {
+				const tmpPath = `${filePath}.tmp`
+				await writeFile(tmpPath, JSON.stringify(data, BufferJSON.replacer))
+				await rename(tmpPath, filePath)
+			} catch {
+				// Fallback to direct write if rename fails (e.g. cross-device)
 				await writeFile(filePath, JSON.stringify(data, BufferJSON.replacer))
 			} finally {
 				release()


### PR DESCRIPTION
Baileys `useMultiFileAuthState` writes `creeds.json` with a direct `writeFile` call, which is non-atomic. If the process crashes or is killed during the write, the file can be left at 0 bytes, destroying the noise key, pairing ephemeral key, signed identity key, and registration ID — requiring a full re-pair.

**Fix:** write to a `.tmp` file first, then `rename()` to the target. `rename()` is atomic on the same filesystem. Falls back to direct `writeFile` if rename fails (e.g. cross-device).

This is the same fix applied in downstream consumers that ship with patch-package (e.g. Hermes Agent), and mirrors the pattern recommended by the Node.js docs for atomic file writes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `creds.json` writes atomic in `useMultiFileAuthState` by writing to a temp file and renaming. Prevents zero-byte files and preserves existing permissions.

- **Bug Fixes**
  - Write to `${filePath}.tmp` then atomically `rename()`; fall back to direct `writeFile` if `rename` fails (e.g., cross-device).
  - Temp-file write happens outside the try/catch so ENOSPC/disk errors don’t trigger fallback that could truncate the original file.
  - Preserve restrictive permissions by copying the existing file’s mode when writing the temp file and in the fallback path.

<sup>Written for commit 4bdf4ff8bd91335bef1ac9227df3a2a9446ee5d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving authentication state by using an atomic temp-file write-and-replace approach.
  * Reduced the chance of corrupted or partially written auth data if a save is interrupted.
  * Added a fallback to ensure auth state is still persisted when replacing the temp file isn’t possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->