### PR TITLE
fix: ignore empty link-code companion registration notices

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1129,13 +1129,24 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				break
 			case 'link_code_companion_reg':
 				const linkCodeCompanionReg = getBinaryNodeChild(node, 'link_code_companion_reg')
-				const ref = toRequiredBuffer(getBinaryNodeChildBuffer(linkCodeCompanionReg, 'link_code_pairing_ref'))
-				const primaryIdentityPublicKey = toRequiredBuffer(
-					getBinaryNodeChildBuffer(linkCodeCompanionReg, 'primary_identity_pub')
+				const refBuffer = getBinaryNodeChildBuffer(linkCodeCompanionReg, 'link_code_pairing_ref')
+				const primaryIdentityPublicKeyBuffer = getBinaryNodeChildBuffer(linkCodeCompanionReg, 'primary_identity_pub')
+				const primaryEphemeralPublicKeyWrappedBuffer = getBinaryNodeChildBuffer(
+					linkCodeCompanionReg,
+					'link_code_pairing_wrapped_primary_ephemeral_pub'
 				)
-				const primaryEphemeralPublicKeyWrapped = toRequiredBuffer(
-					getBinaryNodeChildBuffer(linkCodeCompanionReg, 'link_code_pairing_wrapped_primary_ephemeral_pub')
-				)
+				if (
+					refBuffer === undefined ||
+					primaryIdentityPublicKeyBuffer === undefined ||
+					primaryEphemeralPublicKeyWrappedBuffer === undefined
+				) {
+					logger.debug({ id: node.attrs.id, type: node.attrs.type }, 'skipping empty link code companion registration')
+					break
+				}
+
+				const ref = toRequiredBuffer(refBuffer)
+				const primaryIdentityPublicKey = toRequiredBuffer(primaryIdentityPublicKeyBuffer)
+				const primaryEphemeralPublicKeyWrapped = toRequiredBuffer(primaryEphemeralPublicKeyWrappedBuffer)
 				const codePairingPublicKey = await decipherLinkPublicKey(primaryEphemeralPublicKeyWrapped)
 				const companionSharedKey = Curve.sharedKey(
 					authState.creds.pairingEphemeralKeyPair.private,


### PR DESCRIPTION
## Summary
- skip empty `link_code_companion_reg` notifications before required buffer conversion
- keep normal companion registration handling unchanged when all required payloads are present

## Why
Current WhatsApp link-code/passkey flows can emit a `link_code_companion_reg` notification without the pairing payload. The existing handler throws `Invalid buffer` in that case, aborting the flow. This treats the empty notice as non-actionable and waits for a complete registration payload.

## Checks
- `git diff --check`

I could not run the full project build in this clean worktree because dependencies are not installed and `yarn` is not available on the host.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip empty `link_code_companion_reg` notices to prevent Invalid buffer errors and keep link-code/passkey flows running.
Normal companion registration continues when all required payloads are present.

- **Bug Fixes**
  - Check for required buffers (`link_code_pairing_ref`, `primary_identity_pub`, `link_code_pairing_wrapped_primary_ephemeral_pub`); if any are missing, log a debug message and skip processing.

<sup>Written for commit a674ef82900aac270eaf98493b7fedcef29dcdd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete registration messages by skipping empty or missing pairing data instead of failing processing.
  * Added safer validation before continuing the registration flow, reducing unexpected errors during device linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->