### PR TITLE
fix: use active login for existing sessions

### DIFF
--- a/src/Utils/validate-connection.ts
+++ b/src/Utils/validate-connection.ts
@@ -75,7 +75,8 @@ export const generateLoginNode = (userJid: string, config: SocketConfig): proto.
 	const { user, device } = jidDecode(userJid)!
 	const payload: proto.IClientPayload = {
 		...getClientPayload(config),
-		passive: true,
+		// Existing companion sessions need an active login. Passive login can be rejected with 428.
+		passive: false,
 		pull: true,
 		username: +user,
 		device: device,


### PR DESCRIPTION
## Summary
- set `generateLoginNode` to send `passive: false`
- document why passive login is unsafe for existing companion sessions

## Why
Real reconnect/import testing has shown WhatsApp can terminate login-node flows with 428 when the existing companion session is sent as passive. Registration already uses `passive: false`; login should use the same active mode for an existing session.

## Checks
- `git diff --check`

I could not run the full project build in this clean worktree because dependencies are not installed and `yarn` is not available on the host.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use active login for existing companion sessions by setting passive: false in the login payload. Prevents 428 rejections during reconnect/import and aligns login with registration behavior.

<sup>Written for commit 680f61ae733f5b300bf093521e5d38ab826c557e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated login behavior so sign-in requests are sent in a more compatible mode, reducing the chance of rejection during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->