### PR TITLE
fix: decrypt secretEncryptedMessage MESSAGE_EDIT envelopes

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -46,7 +46,7 @@ import {
 	processSyncAction
 } from '../Utils'
 import { makeMutex } from '../Utils/make-mutex'
-import processMessage from '../Utils/process-message'
+import processMessage, { unwrapSecretEncryptedMessage } from '../Utils/process-message'
 import { buildTcTokenFromJid } from '../Utils/tc-token-utils'
 import {
 	type BinaryNode,
@@ -1203,6 +1203,12 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	}
 
 	const upsertMessage = ev.createBufferedFunction(async (msg: WAMessage, type: MessageUpsertType) => {
+		if (msg.message?.secretEncryptedMessage || msg.message?.editedMessage?.message?.secretEncryptedMessage) {
+			// message edits from newer clients arrive sealed with the original
+			// message's secret — decrypt before anything downstream sees the message
+			await unwrapSecretEncryptedMessage(msg, { creds: authState.creds, getMessage, logger })
+		}
+
 		ev.emit('messages.upsert', { messages: [msg], type })
 
 		if (!!msg.pushName) {

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -178,7 +178,8 @@ export const isRealMessage = (message: WAMessage) => {
 		hasSomeContent &&
 		!normalizedContent?.protocolMessage &&
 		!normalizedContent?.reactionMessage &&
-		!normalizedContent?.pollUpdateMessage
+		!normalizedContent?.pollUpdateMessage &&
+		!normalizedContent?.secretEncryptedMessage
 	)
 }
 
@@ -287,6 +288,160 @@ export function decryptEventResponse(
 
 	function toBinary(txt: string) {
 		return Buffer.from(txt)
+	}
+}
+
+type MessageEditContext = {
+	/** ID of the message that was edited */
+	origMsgId: string
+	/** normalised jid of the author of the original message (only the author can edit it) */
+	origMsgSenderJid: string
+	/** normalised jid of the person that sent the edit (same as the author for message edits) */
+	editorJid: string
+	/** original message enc key (messageContextInfo.messageSecret of the edited message) */
+	msgEncKey: Uint8Array
+}
+
+/**
+ * Decrypt a message edit sealed inside a secretEncryptedMessage.
+ * Newer WhatsApp clients send edits end-to-end encrypted with the original
+ * message's messageSecret instead of a plaintext protocolMessage.
+ * @param edit the secretEncryptedMessage envelope (MESSAGE_EDIT type)
+ * @param ctx additional info about the original message required for decryption
+ * @returns the decrypted inner message
+ */
+export function decryptMessageEdit(
+	{ encPayload, encIv }: proto.Message.ISecretEncryptedMessage,
+	{ origMsgId, origMsgSenderJid, editorJid, msgEncKey }: MessageEditContext
+) {
+	const sign = Buffer.concat([
+		toBinary(origMsgId),
+		toBinary(origMsgSenderJid),
+		toBinary(editorJid),
+		toBinary('Message Edit'),
+		new Uint8Array([1])
+	])
+
+	const key0 = hmacSign(msgEncKey, new Uint8Array(32), 'sha256')
+	const decKey = hmacSign(sign, key0, 'sha256')
+
+	// unlike poll votes and event responses, message edits are sealed without AAD
+	const decrypted = aesDecryptGCM(encPayload!, decKey, encIv!, new Uint8Array(0))
+	return proto.Message.decode(decrypted)
+
+	function toBinary(txt: string) {
+		return Buffer.from(txt)
+	}
+}
+
+/**
+ * If the message carries a secretEncryptedMessage MESSAGE_EDIT envelope,
+ * decrypt it in place so the message looks like a regular plaintext
+ * protocolMessage edit to everything downstream (upsert consumers included).
+ * Failures are logged and leave the message untouched.
+ */
+export const unwrapSecretEncryptedMessage = async (
+	message: WAMessage,
+	{
+		creds,
+		getMessage,
+		logger
+	}: {
+		creds: AuthenticationCreds
+		getMessage: ProcessMessageContext['getMessage']
+		logger?: ILogger
+	}
+) => {
+	const content = normalizeMessageContent(message.message)
+	const secretEnc = content?.secretEncryptedMessage
+	if (
+		!secretEnc?.encPayload ||
+		!secretEnc.encIv ||
+		secretEnc.secretEncType !== proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT
+	) {
+		return
+	}
+
+	const targetKey = secretEnc.targetMessageKey
+	if (!targetKey?.id) {
+		return
+	}
+
+	try {
+		// the original message lives in our chat: address it from our perspective.
+		// only the author can edit a message, so fromMe mirrors the envelope's fromMe.
+		const origMsg = await getMessage({
+			...targetKey,
+			remoteJid: message.key.remoteJid,
+			fromMe: message.key.fromMe,
+			participant: message.key.participant
+		})
+		let msgEncKey = origMsg?.messageContextInfo?.messageSecret as Uint8Array | string | null | undefined
+		if (typeof msgEncKey === 'string') {
+			// stores that persist messages as JSON hand the secret back base64-encoded
+			msgEncKey = Buffer.from(msgEncKey, 'base64')
+		}
+
+		if (!msgEncKey?.length) {
+			logger?.warn({ targetKey }, 'message edit: missing messageSecret for decryption')
+			return
+		}
+
+		// the sender may have derived the key with either its LID or PN identity —
+		// try both (GCM authentication rejects the wrong one), like whatsmeow does
+		const meIdNormalised = jidNormalizedUser(creds.me!.id)
+		const candidates = [
+			...(message.key.fromMe
+				? [meIdNormalised, creds.me?.lid]
+				: [
+						message.key.participant || message.key.remoteJid,
+						message.key.participantAlt || message.key.remoteJidAlt
+					]),
+			targetKey.remoteJid
+		]
+			.filter((jid): jid is string => !!jid)
+			.map(jid => jidNormalizedUser(jid))
+			.filter((jid, i, arr) => arr.indexOf(jid) === i)
+
+		let decoded: proto.Message | undefined
+		let lastError: unknown
+		for (const authorJid of candidates) {
+			try {
+				decoded = decryptMessageEdit(secretEnc, {
+					origMsgId: targetKey.id,
+					origMsgSenderJid: authorJid,
+					editorJid: authorJid,
+					msgEncKey
+				})
+				break
+			} catch (err) {
+				lastError = err
+			}
+		}
+
+		if (!decoded) {
+			throw lastError
+		}
+
+		if (!decoded.protocolMessage) {
+			// normalise to the plaintext edit shape consumers already understand
+			decoded = proto.Message.fromObject({
+				protocolMessage: {
+					key: targetKey,
+					type: proto.Message.ProtocolMessage.Type.MESSAGE_EDIT,
+					editedMessage: decoded
+				}
+			})
+		}
+
+		if (!decoded.messageContextInfo && content?.messageContextInfo) {
+			decoded.messageContextInfo = content.messageContextInfo as proto.MessageContextInfo
+		}
+
+		message.message = decoded
+		logger?.debug({ targetKey }, 'decrypted secretEncryptedMessage edit')
+	} catch (err) {
+		logger?.warn({ err, targetKey }, 'failed to decrypt secretEncryptedMessage edit')
 	}
 }
 

--- a/src/__tests__/Utils/process-message.test.ts
+++ b/src/__tests__/Utils/process-message.test.ts
@@ -1,5 +1,13 @@
+import { randomBytes } from 'crypto'
+import { proto } from '../../../WAProto/index.js'
 import type { WAMessage } from '../../Types'
-import { cleanMessage, getChatId } from '../../Utils/process-message'
+import { aesEncryptGCM, hmacSign } from '../../Utils/crypto'
+import {
+	cleanMessage,
+	decryptMessageEdit,
+	getChatId,
+	unwrapSecretEncryptedMessage
+} from '../../Utils/process-message'
 
 const createBaseMessage = (key: Partial<WAMessage['key']>, message?: Partial<WAMessage['message']>): WAMessage => {
 	return {
@@ -185,5 +193,116 @@ describe('getChatId', () => {
 
 	it('throws when broadcast key has no participant', () => {
 		expect(() => getChatId({ remoteJid: '12345@broadcast', fromMe: false, id: 'X' })).toThrow(/missing participant/)
+	})
+})
+
+describe('secretEncryptedMessage edits', () => {
+	const origMsgId = '3EB0C8712CC1E53869085F'
+	const authorJid = '211459040641230@lid'
+	const msgEncKey = randomBytes(32)
+
+	const sealEdit = (innerMessage: any, jid = authorJid, key: Buffer = msgEncKey) => {
+		const sign = Buffer.concat([
+			Buffer.from(origMsgId),
+			Buffer.from(jid),
+			Buffer.from(jid),
+			Buffer.from('Message Edit'),
+			new Uint8Array([1])
+		])
+		const key0 = hmacSign(key, new Uint8Array(32), 'sha256')
+		const encKey = hmacSign(sign, key0, 'sha256')
+		const plaintext = proto.Message.encode(proto.Message.fromObject(innerMessage)).finish()
+		const encIv = randomBytes(12)
+		const encPayload = aesEncryptGCM(plaintext, encKey, encIv, new Uint8Array(0))
+		return { encPayload, encIv }
+	}
+
+	const innerEdit = {
+		protocolMessage: {
+			key: { remoteJid: authorJid, fromMe: true, id: origMsgId },
+			type: proto.Message.ProtocolMessage.Type.MESSAGE_EDIT,
+			editedMessage: { conversation: 'edited text' }
+		}
+	}
+
+	it('round-trips a sealed MESSAGE_EDIT payload', () => {
+		const { encPayload, encIv } = sealEdit(innerEdit)
+		const decoded = decryptMessageEdit(
+			{ encPayload, encIv },
+			{ origMsgId, origMsgSenderJid: authorJid, editorJid: authorJid, msgEncKey }
+		)
+		expect(decoded.protocolMessage?.editedMessage?.conversation).toBe('edited text')
+	})
+
+	it('fails on a wrong key', () => {
+		const { encPayload, encIv } = sealEdit(innerEdit)
+		expect(() =>
+			decryptMessageEdit(
+				{ encPayload, encIv },
+				{ origMsgId, origMsgSenderJid: authorJid, editorJid: authorJid, msgEncKey: randomBytes(32) }
+			)
+		).toThrow()
+	})
+
+	const makeEnvelope = (sealed: { encPayload: Uint8Array; encIv: Uint8Array }): WAMessage => ({
+		key: {
+			remoteJid: '5511999999999@s.whatsapp.net',
+			remoteJidAlt: authorJid,
+			fromMe: false,
+			id: 'ENVELOPE1'
+		},
+		message: {
+			secretEncryptedMessage: {
+				targetMessageKey: { remoteJid: authorJid, fromMe: true, id: origMsgId },
+				encPayload: sealed.encPayload,
+				encIv: sealed.encIv,
+				secretEncType: proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT
+			}
+		},
+		messageTimestamp: 1675888000
+	})
+
+	const creds: any = { me: { id: '5513900000000:3@s.whatsapp.net', lid: '999@lid' } }
+
+	it('unwraps in place, trying LID/PN identities', async () => {
+		const msg = makeEnvelope(sealEdit(innerEdit))
+		await unwrapSecretEncryptedMessage(msg, {
+			creds,
+			getMessage: async () => ({ messageContextInfo: { messageSecret: msgEncKey } })
+		})
+		expect(msg.message?.secretEncryptedMessage).toBeFalsy()
+		expect(msg.message?.protocolMessage?.editedMessage?.conversation).toBe('edited text')
+		expect(msg.message?.protocolMessage?.type).toBe(proto.Message.ProtocolMessage.Type.MESSAGE_EDIT)
+	})
+
+	it('accepts a base64 messageSecret from JSON-backed stores', async () => {
+		const msg = makeEnvelope(sealEdit(innerEdit))
+		await unwrapSecretEncryptedMessage(msg, {
+			creds,
+			// JSON-backed stores hand the secret back as a base64 string
+			getMessage: async () =>
+				({ messageContextInfo: { messageSecret: msgEncKey.toString('base64') } }) as unknown as proto.IMessage
+		})
+		expect(msg.message?.protocolMessage?.editedMessage?.conversation).toBe('edited text')
+	})
+
+	it('wraps a bare inner message into a MESSAGE_EDIT protocolMessage', async () => {
+		const msg = makeEnvelope(sealEdit({ conversation: 'bare edited text' }))
+		await unwrapSecretEncryptedMessage(msg, {
+			creds,
+			getMessage: async () => ({ messageContextInfo: { messageSecret: msgEncKey } })
+		})
+		expect(msg.message?.protocolMessage?.type).toBe(proto.Message.ProtocolMessage.Type.MESSAGE_EDIT)
+		expect(msg.message?.protocolMessage?.editedMessage?.conversation).toBe('bare edited text')
+		expect(msg.message?.protocolMessage?.key?.id).toBe(origMsgId)
+	})
+
+	it('leaves the message untouched when the secret is unavailable', async () => {
+		const msg = makeEnvelope(sealEdit(innerEdit))
+		await unwrapSecretEncryptedMessage(msg, {
+			creds,
+			getMessage: async () => undefined
+		})
+		expect(msg.message?.secretEncryptedMessage).toBeTruthy()
 	})
 })


### PR DESCRIPTION
## Problem

Newer WhatsApp clients no longer send message edits as a plaintext `protocolMessage`. The edit arrives sealed inside a `secretEncryptedMessage` envelope (`secretEncType: MESSAGE_EDIT`), encrypted with the original message's `messageSecret`:

```json
{
  "secretEncryptedMessage": {
    "targetMessageKey": { "remoteJid": "211459040641230@lid", "fromMe": true, "id": "3EB0C8712CC1E53869085F" },
    "encPayload": "...",
    "encIv": "...",
    "secretEncType": 2
  }
}
```

Baileys currently passes the opaque envelope through to consumers, so edits are impossible to read downstream — they surface as phantom empty messages and the edited content is lost. Downstream projects are hitting this too (e.g. evolution-api, where edits stopped producing any usable event).

## Solution

Decrypt the envelope in `upsertMessage` before it is emitted, deriving the key the same way poll votes and event responses already do (HKDF via double HMAC-SHA256), with the `Message Edit` use-case label. Two differences from the existing decrypt paths, cross-checked against the reference implementation in whatsmeow (`msgsecret.go`):

- message edits are sealed **without AAD**;
- the sender may have derived the key with either its **LID or PN identity**, so both are tried — GCM authentication cleanly rejects the wrong one.

On success the message is rewritten in place to the plaintext `protocolMessage` `MESSAGE_EDIT` shape every consumer already understands, so `messages.upsert` payloads and the existing `messages.update` emission keep working unchanged. Undecryptable envelopes are left untouched but no longer count as real messages (`isRealMessage`), so they stop surfacing as phantom empty messages.

The `messageSecret` handed back by `getMessage` is also accepted as a base64 string, which is how JSON-backed stores commonly persist it.

## Testing

- 6 new unit tests in `src/__tests__/Utils/process-message.test.ts`: round-trip seal/decrypt, wrong-key rejection, LID/PN candidate fallback, base64 `messageSecret`, bare inner message wrapping, and missing-secret no-op (22/22 passing in the suite).
- Validated against the live protocol: deployed on a production Evolution API v2.3.7 instance (baileys 7.0.0-rc.9 with this patch applied). Real edits from a phone were decrypted on the first candidate (LID identity), recognized as `MESSAGE_EDIT`, and flowed through to the consumer webhook with the edited text — previously the same edits arrived as undecryptable envelopes.

## Related issues

Downstream reports of this exact behavior (edits arriving only as an opaque `secretEncryptedMessage`, with no way to recover the edited content):

- https://github.com/evolution-foundation/evolution-api/issues/2545
- https://github.com/evolution-foundation/evolution-api/issues/2617


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secret-encrypted message edits are now automatically decrypted before processing, improving support for hidden message updates.
  * Message edits can be resolved in-place when the original message secret is available, including fallback handling for alternate identities.

* **Bug Fixes**
  * Messages containing secret-encrypted content are no longer treated as regular messages until they are properly unwrapped.
  * Decryption failures are handled gracefully, leaving the message unchanged when it can’t be decoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->