### PR TITLE
fix: route pn sends to mapped lid

### DIFF
--- a/src/Signal/lid-mapping.ts
+++ b/src/Signal/lid-mapping.ts
@@ -5,7 +5,12 @@ import { isHostedPnUser, isLidUser, isPnUser, jidDecode, jidNormalizedUser, WAJI
 
 export class LIDMappingStore {
 	private readonly mappingCache = new LRUCache<string, string>({
-		ttl: 3 * 24 * 60 * 60 * 1000, // 7 days
+		ttl: 3 * 24 * 60 * 60 * 1000, // 3 days
+		ttlAutopurge: true,
+		updateAgeOnGet: true
+	})
+	private readonly missingPNMappingCache = new LRUCache<string, boolean>({
+		ttl: 3 * 24 * 60 * 60 * 1000,
 		ttlAutopurge: true,
 		updateAgeOnGet: true
 	})
@@ -28,20 +33,22 @@ export class LIDMappingStore {
 	}
 
 	private getDeviceSpecificLIDForPN(
-		pn: string,
 		decoded: NonNullable<ReturnType<typeof jidDecode>>,
 		lidUser: string
 	): string | null {
 		const normalizedLidUser = lidUser.toString()
-		if (!normalizedLidUser) {
-			this.logger.warn(`Invalid or empty LID user for PN ${pn}: lidUser = "${lidUser}"`)
+		const lidServer = decoded.server === 'hosted' ? 'hosted.lid' : 'lid'
+		const lidDecoded = jidDecode(`${normalizedLidUser}@${lidServer}`)
+		if (!normalizedLidUser || !lidDecoded || lidDecoded.user !== normalizedLidUser || lidDecoded.server !== lidServer) {
+			this.logger.warn(
+				{ pnServer: decoded.server, lidServer, hasLidUser: !!normalizedLidUser },
+				'Invalid or empty LID user for PN'
+			)
 			return null
 		}
 
 		const pnDevice = decoded.device !== undefined ? decoded.device : 0
-		return `${normalizedLidUser}${!!pnDevice ? `:${pnDevice}` : ``}@${
-			decoded.server === 'hosted' ? 'hosted.lid' : 'lid'
-		}`
+		return `${normalizedLidUser}${!!pnDevice ? `:${pnDevice}` : ``}@${lidServer}`
 	}
 
 	private async getStoredLIDUserForPNUser(pnUser: string): Promise<string | null> {
@@ -50,14 +57,20 @@ export class LIDMappingStore {
 			return cached
 		}
 
+		if (this.missingPNMappingCache.get(pnUser)) {
+			return null
+		}
+
 		const stored = await this.keys.get('lid-mapping', [pnUser])
 		const lidUser = stored[pnUser]
 		if (lidUser && typeof lidUser === 'string') {
 			this.mappingCache.set(`pn:${pnUser}`, lidUser)
 			this.mappingCache.set(`lid:${lidUser}`, pnUser)
+			this.missingPNMappingCache.delete(pnUser)
 			return lidUser
 		}
 
+		this.missingPNMappingCache.set(pnUser, true)
 		return null
 	}
 
@@ -87,6 +100,7 @@ export class LIDMappingStore {
 			const cached = this.mappingCache.get(`pn:${pnUser}`)
 			if (cached) {
 				existingMappings.set(pnUser, cached)
+				this.missingPNMappingCache.delete(pnUser)
 			} else {
 				cacheMissSet.add(pnUser)
 			}
@@ -103,6 +117,7 @@ export class LIDMappingStore {
 					existingMappings.set(pnUser, existingLidUser)
 					this.mappingCache.set(`pn:${pnUser}`, existingLidUser)
 					this.mappingCache.set(`lid:${existingLidUser}`, pnUser)
+					this.missingPNMappingCache.delete(pnUser)
 				}
 			}
 		}
@@ -112,6 +127,7 @@ export class LIDMappingStore {
 			const existingLidUser = existingMappings.get(pnUser)
 			if (existingLidUser === lidUser) {
 				this.logger.debug({ pnUser, lidUser }, 'LID mapping already exists, skipping')
+				this.missingPNMappingCache.delete(pnUser)
 				continue
 			}
 
@@ -136,6 +152,7 @@ export class LIDMappingStore {
 		for (const [pnUser, lidUser] of Object.entries(pairMap)) {
 			this.mappingCache.set(`pn:${pnUser}`, lidUser)
 			this.mappingCache.set(`lid:${lidUser}`, pnUser)
+			this.missingPNMappingCache.delete(pnUser)
 		}
 	}
 
@@ -152,7 +169,7 @@ export class LIDMappingStore {
 		const lidUser = await this.getStoredLIDUserForPNUser(decoded.user)
 		if (!lidUser) return null
 
-		const deviceSpecificLid = this.getDeviceSpecificLIDForPN(pn, decoded, lidUser)
+		const deviceSpecificLid = this.getDeviceSpecificLIDForPN(decoded, lidUser)
 		if (!deviceSpecificLid) return null
 
 		return deviceSpecificLid
@@ -186,7 +203,7 @@ export class LIDMappingStore {
 		const pending: Array<{ pn: string; pnUser: string; decoded: NonNullable<ReturnType<typeof jidDecode>> }> = []
 
 		const addResolvedPair = (pn: string, decoded: NonNullable<ReturnType<typeof jidDecode>>, lidUser: string) => {
-			const deviceSpecificLid = this.getDeviceSpecificLIDForPN(pn, decoded, lidUser)
+			const deviceSpecificLid = this.getDeviceSpecificLIDForPN(decoded, lidUser)
 			if (!deviceSpecificLid) return false
 
 			const pnDevice = decoded.device !== undefined ? decoded.device : 0
@@ -372,5 +389,6 @@ export class LIDMappingStore {
 	 */
 	close(): void {
 		this.mappingCache.clear()
+		this.missingPNMappingCache.clear()
 	}
 }

--- a/src/Signal/lid-mapping.ts
+++ b/src/Signal/lid-mapping.ts
@@ -27,6 +27,40 @@ export class LIDMappingStore {
 		this.logger = logger
 	}
 
+	private getDeviceSpecificLIDForPN(
+		pn: string,
+		decoded: NonNullable<ReturnType<typeof jidDecode>>,
+		lidUser: string
+	): string | null {
+		const normalizedLidUser = lidUser.toString()
+		if (!normalizedLidUser) {
+			this.logger.warn(`Invalid or empty LID user for PN ${pn}: lidUser = "${lidUser}"`)
+			return null
+		}
+
+		const pnDevice = decoded.device !== undefined ? decoded.device : 0
+		return `${normalizedLidUser}${!!pnDevice ? `:${pnDevice}` : ``}@${
+			decoded.server === 'hosted' ? 'hosted.lid' : 'lid'
+		}`
+	}
+
+	private async getStoredLIDUserForPNUser(pnUser: string): Promise<string | null> {
+		const cached = this.mappingCache.get(`pn:${pnUser}`)
+		if (cached && typeof cached === 'string') {
+			return cached
+		}
+
+		const stored = await this.keys.get('lid-mapping', [pnUser])
+		const lidUser = stored[pnUser]
+		if (lidUser && typeof lidUser === 'string') {
+			this.mappingCache.set(`pn:${pnUser}`, lidUser)
+			this.mappingCache.set(`lid:${lidUser}`, pnUser)
+			return lidUser
+		}
+
+		return null
+	}
+
 	async storeLIDPNMappings(pairs: LIDMapping[]): Promise<void> {
 		if (pairs.length === 0) return
 
@@ -109,6 +143,21 @@ export class LIDMappingStore {
 		return (await this.getLIDsForPNs([pn]))?.[0]?.lid || null
 	}
 
+	async getStoredLIDForPN(pn: string): Promise<string | null> {
+		if (!isPnUser(pn) && !isHostedPnUser(pn)) return null
+
+		const decoded = jidDecode(pn)
+		if (!decoded) return null
+
+		const lidUser = await this.getStoredLIDUserForPNUser(decoded.user)
+		if (!lidUser) return null
+
+		const deviceSpecificLid = this.getDeviceSpecificLIDForPN(pn, decoded, lidUser)
+		if (!deviceSpecificLid) return null
+
+		return deviceSpecificLid
+	}
+
 	async getLIDsForPNs(pns: string[]): Promise<LIDMapping[] | null> {
 		if (pns.length === 0) return null
 
@@ -134,21 +183,13 @@ export class LIDMappingStore {
 	private async _getLIDsForPNsImpl(pns: string[]): Promise<LIDMapping[] | null> {
 		const usyncFetch: { [_: string]: number[] } = {}
 		const successfulPairs: { [_: string]: LIDMapping } = {}
-		const pending: Array<{ pn: string; pnUser: string; decoded: ReturnType<typeof jidDecode> }> = []
+		const pending: Array<{ pn: string; pnUser: string; decoded: NonNullable<ReturnType<typeof jidDecode>> }> = []
 
-		const addResolvedPair = (pn: string, decoded: ReturnType<typeof jidDecode>, lidUser: string) => {
-			const normalizedLidUser = lidUser.toString()
-			if (!normalizedLidUser) {
-				this.logger.warn(`Invalid or empty LID user for PN ${pn}: lidUser = "${lidUser}"`)
-				return false
-			}
+		const addResolvedPair = (pn: string, decoded: NonNullable<ReturnType<typeof jidDecode>>, lidUser: string) => {
+			const deviceSpecificLid = this.getDeviceSpecificLIDForPN(pn, decoded, lidUser)
+			if (!deviceSpecificLid) return false
 
-			// Push the PN device ID to the LID to maintain device separation
-			const pnDevice = decoded!.device !== undefined ? decoded!.device : 0
-			const deviceSpecificLid = `${normalizedLidUser}${!!pnDevice ? `:${pnDevice}` : ``}@${
-				decoded!.server === 'hosted' ? 'hosted.lid' : 'lid'
-			}`
-
+			const pnDevice = decoded.device !== undefined ? decoded.device : 0
 			this.logger.trace(`getLIDForPN: ${pn} → ${deviceSpecificLid} (user mapping with device ${pnDevice})`)
 			successfulPairs[pn] = { lid: deviceSpecificLid, pn }
 			return true
@@ -194,7 +235,7 @@ export class LIDMappingStore {
 					}
 				} else {
 					this.logger.trace(`No LID mapping found for PN user ${pnUser}; batch getting from USync`)
-					const device = decoded!.device || 0
+					const device = decoded.device || 0
 					let normalizedPn = jidNormalizedUser(pn)
 					if (isHostedPnUser(normalizedPn)) {
 						normalizedPn = `${pnUser}@s.whatsapp.net`

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -36,6 +36,7 @@ import {
 	unixTimestampSeconds
 } from '../Utils'
 import { getUrlInfo } from '../Utils/link-preview'
+import type { ILogger } from '../Utils/logger'
 import { makeKeyedMutex, makeMutex } from '../Utils/make-mutex'
 import { getMessageReportingToken, shouldIncludeReportingToken } from '../Utils/reporting-utils'
 import {
@@ -79,13 +80,21 @@ export type MessageSendJid = {
 
 export const resolveMessageSendJid = async (
 	jid: string,
-	getStoredLIDForPN: (pn: string) => Promise<string | null>
+	getStoredLIDForPN: (pn: string) => Promise<string | null>,
+	logger?: ILogger
 ): Promise<MessageSendJid> => {
 	if (!isPnUser(jid) && !isHostedPnUser(jid)) {
 		return { jid }
 	}
 
-	const lid = await getStoredLIDForPN(jid)
+	let lid: string | null
+	try {
+		lid = await getStoredLIDForPN(jid)
+	} catch (err) {
+		logger?.debug({ err, jidServer: jidDecode(jid)?.server }, 'failed to resolve stored LID for PN send')
+		return { jid }
+	}
+
 	if (!lid || (!isLidUser(lid) && !isHostedLidUser(lid))) {
 		return { jid }
 	}
@@ -1375,7 +1384,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 						: disappearingMessagesInChat
 				await groupToggleEphemeral(jid, value)
 			} else {
-				const resolvedJid = await resolveMessageSendJid(jid, getStoredLIDForPN)
+				const resolvedJid = await resolveMessageSendJid(jid, getStoredLIDForPN, logger)
 				const fullMsg = await generateWAMessage(resolvedJid.jid, content, {
 					logger,
 					userJid,

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -70,6 +70,38 @@ import {
 import { USyncQuery, USyncUser } from '../WAUSync'
 import { makeNewsletterSocket } from './newsletter'
 
+export type MessageSendJid = {
+	jid: string
+	remoteJidAlt?: string
+	addressingMode?: 'lid'
+	additionalAttributes?: BinaryNodeAttributes
+}
+
+export const resolveMessageSendJid = async (
+	jid: string,
+	getStoredLIDForPN: (pn: string) => Promise<string | null>
+): Promise<MessageSendJid> => {
+	if (!isPnUser(jid) && !isHostedPnUser(jid)) {
+		return { jid }
+	}
+
+	const lid = await getStoredLIDForPN(jid)
+	if (!lid || (!isLidUser(lid) && !isHostedLidUser(lid))) {
+		return { jid }
+	}
+
+	const remoteJidAlt = jidNormalizedUser(jid)
+	return {
+		jid: lid,
+		remoteJidAlt,
+		addressingMode: 'lid',
+		additionalAttributes: {
+			addressing_mode: 'lid',
+			recipient_pn: remoteJidAlt
+		}
+	}
+}
+
 export const makeMessagesSocket = (config: SocketConfig) => {
 	const {
 		logger,
@@ -97,6 +129,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	} = sock
 
 	const getLIDForPN = signalRepository.lidMapping.getLIDForPN.bind(signalRepository.lidMapping)
+	const getStoredLIDForPN = signalRepository.lidMapping.getStoredLIDForPN.bind(signalRepository.lidMapping)
 
 	/**
 	 * Set of tctoken storage JIDs with a fire-and-forget `issuePrivacyTokens` IQ in flight.
@@ -1342,7 +1375,8 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 						: disappearingMessagesInChat
 				await groupToggleEphemeral(jid, value)
 			} else {
-				const fullMsg = await generateWAMessage(jid, content, {
+				const resolvedJid = await resolveMessageSendJid(jid, getStoredLIDForPN)
+				const fullMsg = await generateWAMessage(resolvedJid.jid, content, {
 					logger,
 					userJid,
 					getUrlInfo: text =>
@@ -1364,12 +1398,20 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 					messageId: generateMessageIDV2(sock.user?.id),
 					...options
 				})
+				if (resolvedJid.remoteJidAlt) {
+					fullMsg.key.remoteJidAlt = resolvedJid.remoteJidAlt
+				}
+
+				if (resolvedJid.addressingMode) {
+					fullMsg.key.addressingMode = resolvedJid.addressingMode
+				}
+
 				const isEventMsg = 'event' in content && !!content.event
 				const isDeleteMsg = 'delete' in content && !!content.delete
 				const isEditMsg = 'edit' in content && !!content.edit
 				const isPinMsg = 'pin' in content && !!content.pin
 				const isPollMessage = 'poll' in content && !!content.poll
-				const additionalAttributes: BinaryNodeAttributes = {}
+				const additionalAttributes: BinaryNodeAttributes = { ...(resolvedJid.additionalAttributes || {}) }
 				const additionalNodes: BinaryNode[] = []
 				// required for delete
 				if (isDeleteMsg) {
@@ -1399,7 +1441,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 					} as BinaryNode)
 				}
 
-				await relayMessage(jid, fullMsg.message!, {
+				await relayMessage(resolvedJid.jid, fullMsg.message!, {
 					messageId: fullMsg.key.id!,
 					useCachedGroupMetadata: options.useCachedGroupMetadata,
 					additionalAttributes,

--- a/src/__tests__/Signal/lid-mapping.test.ts
+++ b/src/__tests__/Signal/lid-mapping.test.ts
@@ -22,6 +22,39 @@ describe('LIDMappingStore', () => {
 		lidMappingStore = new LIDMappingStore(mockKeys, logger, mockPnToLIDFunc)
 	})
 
+	describe('getStoredLIDForPN', () => {
+		it('should return a locally stored LID without calling USync', async () => {
+			// @ts-ignore
+			mockKeys.get.mockResolvedValue({ '12345': '98765' } as SignalDataTypeMap['lid-mapping'])
+
+			const result = await lidMappingStore.getStoredLIDForPN('12345@s.whatsapp.net')
+
+			expect(result).toBe('98765@lid')
+			expect(mockKeys.get).toHaveBeenCalledWith('lid-mapping', ['12345'])
+			expect(mockPnToLIDFunc).not.toHaveBeenCalled()
+		})
+
+		it('should preserve the PN device on a locally stored LID', async () => {
+			// @ts-ignore
+			mockKeys.get.mockResolvedValue({ '12345': '98765' } as SignalDataTypeMap['lid-mapping'])
+
+			const result = await lidMappingStore.getStoredLIDForPN('12345:7@s.whatsapp.net')
+
+			expect(result).toBe('98765:7@lid')
+			expect(mockPnToLIDFunc).not.toHaveBeenCalled()
+		})
+
+		it('should return null when no local mapping is stored', async () => {
+			// @ts-ignore
+			mockKeys.get.mockResolvedValue({} as SignalDataTypeMap['lid-mapping'])
+
+			const result = await lidMappingStore.getStoredLIDForPN('12345@s.whatsapp.net')
+
+			expect(result).toBeNull()
+			expect(mockPnToLIDFunc).not.toHaveBeenCalled()
+		})
+	})
+
 	describe('getPNForLID', () => {
 		it('should correctly map a standard LID with a hosted device ID back to a standard PN with a hosted device', async () => {
 			const lidWithHostedDevice = `12345:${HOSTED_DEVICE_ID}@lid`

--- a/src/__tests__/Signal/lid-mapping.test.ts
+++ b/src/__tests__/Signal/lid-mapping.test.ts
@@ -1,15 +1,55 @@
 import { jest } from '@jest/globals'
 import P from 'pino'
 import { LIDMappingStore } from '../../Signal/lid-mapping'
-import type { LIDMapping, SignalDataTypeMap, SignalKeyStoreWithTransaction } from '../../Types'
+import type { LIDMapping, SignalDataSet, SignalDataTypeMap, SignalKeyStoreWithTransaction } from '../../Types'
 
 const HOSTED_DEVICE_ID = 99
 
-const mockKeys: jest.Mocked<SignalKeyStoreWithTransaction> = {
-	get: jest.fn<SignalKeyStoreWithTransaction['get']>() as any,
-	set: jest.fn<SignalKeyStoreWithTransaction['set']>(),
-	transaction: jest.fn<SignalKeyStoreWithTransaction['transaction']>(async (work: () => any) => await work()) as any,
-	isInTransaction: jest.fn<SignalKeyStoreWithTransaction['isInTransaction']>()
+let lidMappingRecords: Record<string, string> = {}
+let getCalls: Array<{ type: keyof SignalDataTypeMap; ids: string[] }> = []
+let setCalls: SignalDataSet[] = []
+let transactionKeys: string[] = []
+
+const setLidMappingRecords = (records: Record<string, string>) => {
+	lidMappingRecords = { ...records }
+}
+
+const mockKeys: SignalKeyStoreWithTransaction = {
+	async get<T extends keyof SignalDataTypeMap>(
+		type: T,
+		ids: string[]
+	): Promise<{ [id: string]: SignalDataTypeMap[T] }> {
+		getCalls.push({ type, ids })
+		const result: { [id: string]: SignalDataTypeMap[T] } = {}
+		if (type === 'lid-mapping') {
+			for (const id of ids) {
+				const value = lidMappingRecords[id]
+				if (value !== undefined) {
+					result[id] = value as SignalDataTypeMap[T]
+				}
+			}
+		}
+
+		return result
+	},
+	async set(data: SignalDataSet): Promise<void> {
+		setCalls.push(data)
+		const mappings = data['lid-mapping']
+		if (!mappings) return
+
+		for (const [id, value] of Object.entries(mappings)) {
+			if (value === null) {
+				delete lidMappingRecords[id]
+			} else {
+				lidMappingRecords[id] = value
+			}
+		}
+	},
+	async transaction<T>(work: () => Promise<T>, key: string): Promise<T> {
+		transactionKeys.push(key)
+		return work()
+	},
+	isInTransaction: () => false
 }
 const logger = P({ level: 'silent' })
 
@@ -19,24 +59,26 @@ describe('LIDMappingStore', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks()
+		setLidMappingRecords({})
+		getCalls = []
+		setCalls = []
+		transactionKeys = []
 		lidMappingStore = new LIDMappingStore(mockKeys, logger, mockPnToLIDFunc)
 	})
 
 	describe('getStoredLIDForPN', () => {
 		it('should return a locally stored LID without calling USync', async () => {
-			// @ts-ignore
-			mockKeys.get.mockResolvedValue({ '12345': '98765' } as SignalDataTypeMap['lid-mapping'])
+			setLidMappingRecords({ '12345': '98765' })
 
 			const result = await lidMappingStore.getStoredLIDForPN('12345@s.whatsapp.net')
 
 			expect(result).toBe('98765@lid')
-			expect(mockKeys.get).toHaveBeenCalledWith('lid-mapping', ['12345'])
+			expect(getCalls).toContainEqual({ type: 'lid-mapping', ids: ['12345'] })
 			expect(mockPnToLIDFunc).not.toHaveBeenCalled()
 		})
 
 		it('should preserve the PN device on a locally stored LID', async () => {
-			// @ts-ignore
-			mockKeys.get.mockResolvedValue({ '12345': '98765' } as SignalDataTypeMap['lid-mapping'])
+			setLidMappingRecords({ '12345': '98765' })
 
 			const result = await lidMappingStore.getStoredLIDForPN('12345:7@s.whatsapp.net')
 
@@ -44,14 +86,42 @@ describe('LIDMappingStore', () => {
 			expect(mockPnToLIDFunc).not.toHaveBeenCalled()
 		})
 
-		it('should return null when no local mapping is stored', async () => {
-			// @ts-ignore
-			mockKeys.get.mockResolvedValue({} as SignalDataTypeMap['lid-mapping'])
+		it('should return a hosted LID for a locally stored hosted PN mapping', async () => {
+			setLidMappingRecords({ '12345': '98765' })
+
+			const result = await lidMappingStore.getStoredLIDForPN('12345@hosted')
+
+			expect(result).toBe('98765@hosted.lid')
+			expect(getCalls).toContainEqual({ type: 'lid-mapping', ids: ['12345'] })
+			expect(mockPnToLIDFunc).not.toHaveBeenCalled()
+		})
+
+		it('should reject a malformed locally stored LID user', async () => {
+			setLidMappingRecords({ '12345': '98765:7' })
 
 			const result = await lidMappingStore.getStoredLIDForPN('12345@s.whatsapp.net')
 
 			expect(result).toBeNull()
 			expect(mockPnToLIDFunc).not.toHaveBeenCalled()
+		})
+
+		it('should return null when no local mapping is stored', async () => {
+			const result = await lidMappingStore.getStoredLIDForPN('12345@s.whatsapp.net')
+
+			expect(result).toBeNull()
+			expect(mockPnToLIDFunc).not.toHaveBeenCalled()
+		})
+
+		it('should cache local misses until a mapping is stored', async () => {
+			await expect(lidMappingStore.getStoredLIDForPN('12345@s.whatsapp.net')).resolves.toBeNull()
+			await expect(lidMappingStore.getStoredLIDForPN('12345@s.whatsapp.net')).resolves.toBeNull()
+			expect(getCalls).toHaveLength(1)
+
+			await lidMappingStore.storeLIDPNMappings([{ lid: '98765@lid', pn: '12345@s.whatsapp.net' }])
+			await expect(lidMappingStore.getStoredLIDForPN('12345@s.whatsapp.net')).resolves.toBe('98765@lid')
+			expect(getCalls).toHaveLength(2)
+			expect(setCalls).toHaveLength(1)
+			expect(transactionKeys).toEqual(['lid-mapping'])
 		})
 	})
 
@@ -60,8 +130,7 @@ describe('LIDMappingStore', () => {
 			const lidWithHostedDevice = `12345:${HOSTED_DEVICE_ID}@lid`
 			const pnUser = '54321'
 
-			// @ts-ignore
-			mockKeys.get.mockResolvedValue({ [`12345_reverse`]: pnUser } as SignalDataTypeMap['lid-mapping'])
+			setLidMappingRecords({ [`12345_reverse`]: pnUser })
 
 			const result = await lidMappingStore.getPNForLID(lidWithHostedDevice)
 			expect(result).toBe(`${pnUser}:${HOSTED_DEVICE_ID}@s.whatsapp.net`)
@@ -69,9 +138,6 @@ describe('LIDMappingStore', () => {
 
 		it('should return null if no reverse mapping is found', async () => {
 			const lid = 'nonexistent@lid'
-
-			// @ts-ignore
-			mockKeys.get.mockResolvedValue({} as SignalDataTypeMap['lid-mapping']) // Simulate not found in DB
 
 			const result = await lidMappingStore.getPNForLID(lid)
 			expect(result).toBeNull()

--- a/src/__tests__/Socket/messages-send.test.ts
+++ b/src/__tests__/Socket/messages-send.test.ts
@@ -27,6 +27,16 @@ describe('resolveMessageSendJid', () => {
 		expect(result).toEqual({ jid: '12345@s.whatsapp.net' })
 	})
 
+	it('should keep the PN destination when the local LID lookup fails', async () => {
+		const getStoredLIDForPN = jest.fn(async (): Promise<string | null> => {
+			throw new Error('key store unavailable')
+		})
+
+		const result = await resolveMessageSendJid('12345@s.whatsapp.net', getStoredLIDForPN)
+
+		expect(result).toEqual({ jid: '12345@s.whatsapp.net' })
+	})
+
 	it('should route a hosted PN send to its locally mapped hosted LID', async () => {
 		const getStoredLIDForPN = jest.fn(async (): Promise<string | null> => '98765@hosted.lid')
 

--- a/src/__tests__/Socket/messages-send.test.ts
+++ b/src/__tests__/Socket/messages-send.test.ts
@@ -1,0 +1,65 @@
+import { jest } from '@jest/globals'
+import { resolveMessageSendJid } from '../../Socket/messages-send'
+
+describe('resolveMessageSendJid', () => {
+	it('should route a PN send to its locally mapped LID', async () => {
+		const getStoredLIDForPN = jest.fn(async (): Promise<string | null> => '98765@lid')
+
+		const result = await resolveMessageSendJid('12345@s.whatsapp.net', getStoredLIDForPN)
+
+		expect(result).toEqual({
+			jid: '98765@lid',
+			remoteJidAlt: '12345@s.whatsapp.net',
+			addressingMode: 'lid',
+			additionalAttributes: {
+				addressing_mode: 'lid',
+				recipient_pn: '12345@s.whatsapp.net'
+			}
+		})
+		expect(getStoredLIDForPN).toHaveBeenCalledWith('12345@s.whatsapp.net')
+	})
+
+	it('should keep the PN destination when no local LID mapping exists', async () => {
+		const getStoredLIDForPN = jest.fn(async (): Promise<string | null> => null)
+
+		const result = await resolveMessageSendJid('12345@s.whatsapp.net', getStoredLIDForPN)
+
+		expect(result).toEqual({ jid: '12345@s.whatsapp.net' })
+	})
+
+	it('should route a hosted PN send to its locally mapped hosted LID', async () => {
+		const getStoredLIDForPN = jest.fn(async (): Promise<string | null> => '98765@hosted.lid')
+
+		const result = await resolveMessageSendJid('12345@hosted', getStoredLIDForPN)
+
+		expect(result).toEqual({
+			jid: '98765@hosted.lid',
+			remoteJidAlt: '12345@hosted',
+			addressingMode: 'lid',
+			additionalAttributes: {
+				addressing_mode: 'lid',
+				recipient_pn: '12345@hosted'
+			}
+		})
+		expect(getStoredLIDForPN).toHaveBeenCalledWith('12345@hosted')
+	})
+
+	it('should keep non-PN destinations unchanged without checking LID mappings', async () => {
+		const getStoredLIDForPN = jest.fn(async (): Promise<string | null> => {
+			throw new Error('unexpected LID lookup')
+		})
+
+		const result = await resolveMessageSendJid('98765@lid', getStoredLIDForPN)
+
+		expect(result).toEqual({ jid: '98765@lid' })
+		expect(getStoredLIDForPN).not.toHaveBeenCalled()
+	})
+
+	it('should keep the PN destination when the stored value is not a LID', async () => {
+		const getStoredLIDForPN = jest.fn(async (): Promise<string | null> => '98765@s.whatsapp.net')
+
+		const result = await resolveMessageSendJid('12345@s.whatsapp.net', getStoredLIDForPN)
+
+		expect(result).toEqual({ jid: '12345@s.whatsapp.net' })
+	})
+})


### PR DESCRIPTION
## Summary

- Route 1:1 PN sends to a locally mapped LID when the mapping is already stored.
- Preserve the original PN as alternate addressing metadata on the local message key and outgoing stanza.
- Add a local-only LID lookup so `sendMessage` does not trigger implicit USync for unmapped PN contacts.

## Protocol / behavior context

For warm contacts with an existing PN -> LID mapping, Baileys already resolves LID sessions during `assertSessions`, but the final 1:1 message stanza could still be addressed to the PN. That can produce server-side ERROR 463 for contacts that should be LID-addressed.

This keeps the scope narrow: it only routes sends when a local mapping already exists. Cold/unmapped PN sends keep the existing behavior.

## WA Web captured JS sanity

Ran:

```bash
./tools/wa-web-sanity.sh 'addressing_mode|recipient_pn|remoteJidAlt|participant_pn|sender_pn|peer_recipient_pn'
```

Relevant matches from the captured WA Web bundle:

- `WAWeb/Send/MsgCreateFanoutStanza.js`
- `WAWeb/Send/MsgCreateDeviceStanza.js`
- `WAWeb/Handle/MsgParser.js`
- `WAWeb/Send/MsgCommonApi.js`

Relevant excerpt:

```js
recipient_pn: ...,
addressing_mode: ...
```

WA Web emits alternate PN attrs alongside LID addressing, and parses those attrs back on receive.

## Live validation note

I attempted a live repro with the contribution test session. The external target checked during validation had no PN -> LID mapping locally or after a deliberate USync lookup, so it did not exercise the reported mapped-LID case. A self-send confirmed local PN -> LID mapping mechanics but did not reproduce ERROR 463, because the old PN path received `SERVER_ACK`.

So this PR is validated by deterministic tests and WA Web send/parser sanity, not by a confirmed live 463 repro.

## Tests

- `yarn lint` - 0 errors; existing `no-explicit-any` warnings remain
- `yarn test` - 29 suites / 415 tests passed

Related to #2683
Related to #2688

Drafted with Codex, reviewed and tested by me.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route PN-addressed 1:1 sends to the locally mapped LID when available, and include the PN as alternate addressing metadata. This prevents server 463 failures for warm contacts and avoids implicit USync on send, with added validation and cached-miss handling.

- **Bug Fixes**
  - Added local-only lookup `getStoredLIDForPN` and `resolveMessageSendJid` to switch PN → LID without USync when a mapping exists.
  - Preserved PN as `remoteJidAlt` and added stanza attrs `addressing_mode: 'lid'` and `recipient_pn`; keep device IDs and hosted vs standard domains.
  - Hardened resolution: validate stored LID users, cache local misses to avoid repeated store reads, and fall back to PN on errors or non-LID values; extended tests for mapped/unmapped, hosted, device-specific, and non-PN sends.

<sup>Written for commit 93e8ac6ac2049a8d8953d9abc64d083c510a3213. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outbound messages to PN and hosted-PN recipients now automatically resolve to the appropriate stored LID destination (when available), including LID addressing metadata.
  * Device-specific LID addressing is applied consistently when deriving LID destinations.
* **Bug Fixes**
  * Improved reuse of stored PN→LID lookup results and reduced repeated “missing mapping” checks; misses are cleared when mappings are later stored.
* **Tests**
  * Expanded LID-mapping coverage with an in-memory key store and new `getStoredLIDForPN` scenarios.
  * Added unit tests for `resolveMessageSendJid` covering success, fallback, and non-PN/LID cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->