### PR TITLE
fix: use current desktop web subplatforms

### DIFF
--- a/src/Utils/validate-connection.ts
+++ b/src/Utils/validate-connection.ts
@@ -13,6 +13,20 @@ import { Curve, hmacSign } from './crypto'
 import { encodeBigEndian } from './generics'
 import { createSignalIdentity } from './signal'
 
+const isDesktop = (config: SocketConfig) => config.browser[1] === 'Desktop'
+
+const getUserAgentPlatform = (config: SocketConfig): proto.ClientPayload.UserAgent.Platform => {
+	if (config.browser[1].toLocaleLowerCase().includes('android')) {
+		return proto.ClientPayload.UserAgent.Platform.ANDROID
+	}
+
+	if (config.syncFullHistory && isDesktop(config) && config.browser[0] === 'Mac OS') {
+		return proto.ClientPayload.UserAgent.Platform.MACOS
+	}
+
+	return proto.ClientPayload.UserAgent.Platform.WEB
+}
+
 const getUserAgent = (config: SocketConfig): proto.ClientPayload.IUserAgent => {
 	return {
 		appVersion: {
@@ -20,9 +34,7 @@ const getUserAgent = (config: SocketConfig): proto.ClientPayload.IUserAgent => {
 			secondary: config.version[1],
 			tertiary: config.version[2]
 		},
-		platform: config.browser[1].toLocaleLowerCase().includes('android')
-			? proto.ClientPayload.UserAgent.Platform.ANDROID
-			: proto.ClientPayload.UserAgent.Platform.WEB,
+		platform: getUserAgentPlatform(config),
 		releaseChannel: proto.ClientPayload.UserAgent.ReleaseChannel.RELEASE,
 		osVersion: '0.1',
 		device: 'Desktop',
@@ -37,16 +49,12 @@ const getUserAgent = (config: SocketConfig): proto.ClientPayload.IUserAgent => {
 
 const PLATFORM_MAP = {
 	'Mac OS': proto.ClientPayload.WebInfo.WebSubPlatform.DARWIN,
-	Windows: proto.ClientPayload.WebInfo.WebSubPlatform.WIN32
+	Windows: proto.ClientPayload.WebInfo.WebSubPlatform.WIN_HYBRID
 }
 
 const getWebInfo = (config: SocketConfig): proto.ClientPayload.IWebInfo => {
 	let webSubPlatform = proto.ClientPayload.WebInfo.WebSubPlatform.WEB_BROWSER
-	if (
-		config.syncFullHistory &&
-		PLATFORM_MAP[config.browser[0] as keyof typeof PLATFORM_MAP] &&
-		config.browser[1] === 'Desktop'
-	) {
+	if (config.syncFullHistory && PLATFORM_MAP[config.browser[0] as keyof typeof PLATFORM_MAP] && isDesktop(config)) {
 		webSubPlatform = PLATFORM_MAP[config.browser[0] as keyof typeof PLATFORM_MAP]
 	}
 

--- a/src/Utils/validate-connection.ts
+++ b/src/Utils/validate-connection.ts
@@ -20,6 +20,7 @@ const getUserAgentPlatform = (config: SocketConfig): proto.ClientPayload.UserAge
 		return proto.ClientPayload.UserAgent.Platform.ANDROID
 	}
 
+	// WA rejects full-history Desktop pairing unless macOS uses its native platform.
 	if (config.syncFullHistory && isDesktop(config) && config.browser[0] === 'Mac OS') {
 		return proto.ClientPayload.UserAgent.Platform.MACOS
 	}
@@ -54,6 +55,7 @@ const PLATFORM_MAP = {
 
 const getWebInfo = (config: SocketConfig): proto.ClientPayload.IWebInfo => {
 	let webSubPlatform = proto.ClientPayload.WebInfo.WebSubPlatform.WEB_BROWSER
+	// WA accepts full-history Desktop pairing only with the native web sub-platforms.
 	if (config.syncFullHistory && PLATFORM_MAP[config.browser[0] as keyof typeof PLATFORM_MAP] && isDesktop(config)) {
 		webSubPlatform = PLATFORM_MAP[config.browser[0] as keyof typeof PLATFORM_MAP]
 	}

--- a/src/__tests__/Utils/validate-connection.test.ts
+++ b/src/__tests__/Utils/validate-connection.test.ts
@@ -1,0 +1,80 @@
+import { proto } from '../../../WAProto'
+import { DEFAULT_CONNECTION_CONFIG } from '../../Defaults'
+import type { SignalCreds, SocketConfig, WABrowserDescription } from '../../Types'
+import { Browsers } from '../../Utils/browser-utils'
+import { generateLoginNode, generateRegistrationNode } from '../../Utils/validate-connection'
+
+const signalCreds: SignalCreds = {
+	registrationId: 123,
+	signedIdentityKey: {
+		public: new Uint8Array(32).fill(1),
+		private: new Uint8Array(32).fill(2)
+	},
+	signedPreKey: {
+		keyId: 456,
+		keyPair: {
+			public: new Uint8Array(32).fill(3),
+			private: new Uint8Array(32).fill(4)
+		},
+		signature: new Uint8Array(64).fill(5)
+	}
+}
+
+const registrationPayload = (browser: WABrowserDescription, syncFullHistory: boolean) => {
+	const config: SocketConfig = {
+		...DEFAULT_CONNECTION_CONFIG,
+		browser,
+		syncFullHistory
+	}
+
+	return generateRegistrationNode(signalCreds, config)
+}
+
+const loginPayload = (browser: WABrowserDescription, syncFullHistory: boolean) => {
+	const config: SocketConfig = {
+		...DEFAULT_CONNECTION_CONFIG,
+		browser,
+		syncFullHistory
+	}
+
+	return generateLoginNode('1234567890:1@s.whatsapp.net', config)
+}
+
+describe('registration client payload', () => {
+	it('uses WIN_HYBRID for Windows Desktop full-history registration', () => {
+		const payload = registrationPayload(Browsers.windows('Desktop'), true)
+
+		expect(payload.userAgent?.platform).toBe(proto.ClientPayload.UserAgent.Platform.WEB)
+		expect(payload.webInfo?.webSubPlatform).toBe(proto.ClientPayload.WebInfo.WebSubPlatform.WIN_HYBRID)
+	})
+
+	it('uses MACOS + DARWIN for macOS Desktop full-history registration', () => {
+		const payload = registrationPayload(Browsers.macOS('Desktop'), true)
+
+		expect(payload.userAgent?.platform).toBe(proto.ClientPayload.UserAgent.Platform.MACOS)
+		expect(payload.webInfo?.webSubPlatform).toBe(proto.ClientPayload.WebInfo.WebSubPlatform.DARWIN)
+	})
+
+	it('keeps browser clients on WEB_BROWSER', () => {
+		const payload = registrationPayload(Browsers.ubuntu('Chrome'), true)
+
+		expect(payload.userAgent?.platform).toBe(proto.ClientPayload.UserAgent.Platform.WEB)
+		expect(payload.webInfo?.webSubPlatform).toBe(proto.ClientPayload.WebInfo.WebSubPlatform.WEB_BROWSER)
+	})
+
+	it('keeps Desktop clients without full history on WEB_BROWSER', () => {
+		const payload = registrationPayload(Browsers.windows('Desktop'), false)
+
+		expect(payload.userAgent?.platform).toBe(proto.ClientPayload.UserAgent.Platform.WEB)
+		expect(payload.webInfo?.webSubPlatform).toBe(proto.ClientPayload.WebInfo.WebSubPlatform.WEB_BROWSER)
+	})
+
+	it('uses the fixed Desktop web sub-platforms when logging in with existing creds', () => {
+		const windowsPayload = loginPayload(Browsers.windows('Desktop'), true)
+		const macPayload = loginPayload(Browsers.macOS('Desktop'), true)
+
+		expect(windowsPayload.webInfo?.webSubPlatform).toBe(proto.ClientPayload.WebInfo.WebSubPlatform.WIN_HYBRID)
+		expect(macPayload.userAgent?.platform).toBe(proto.ClientPayload.UserAgent.Platform.MACOS)
+		expect(macPayload.webInfo?.webSubPlatform).toBe(proto.ClientPayload.WebInfo.WebSubPlatform.DARWIN)
+	})
+})

--- a/src/__tests__/Utils/validate-connection.test.ts
+++ b/src/__tests__/Utils/validate-connection.test.ts
@@ -73,6 +73,7 @@ describe('registration client payload', () => {
 		const windowsPayload = loginPayload(Browsers.windows('Desktop'), true)
 		const macPayload = loginPayload(Browsers.macOS('Desktop'), true)
 
+		expect(windowsPayload.userAgent?.platform).toBe(proto.ClientPayload.UserAgent.Platform.WEB)
 		expect(windowsPayload.webInfo?.webSubPlatform).toBe(proto.ClientPayload.WebInfo.WebSubPlatform.WIN_HYBRID)
 		expect(macPayload.userAgent?.platform).toBe(proto.ClientPayload.UserAgent.Platform.MACOS)
 		expect(macPayload.webInfo?.webSubPlatform).toBe(proto.ClientPayload.WebInfo.WebSubPlatform.DARWIN)


### PR DESCRIPTION
## Summary

- Updates Desktop full-history client payloads so fresh pairing/reconnect no longer advertises the legacy rejected Desktop sub-platform combination.
- Maps `Windows/Desktop` full-history payloads to `WebSubPlatform.WIN_HYBRID`.
- Maps `Mac OS/Desktop` full-history payloads to `UserAgent.Platform.MACOS` with `WebSubPlatform.DARWIN`.
- Adds regression coverage for both registration and existing-creds login payloads, while keeping browser clients and Desktop without full-history on `WEB_BROWSER`.

## Protocol / behavior context

The WhatsApp-side trigger is the registration/login `ClientPayload` sent before QR/open. Recent server behavior rejects the old full-history Desktop payloads before QR with 428:

- `Windows/Desktop` + `syncFullHistory: true` previously emitted `WEB + WIN32`.
- `Mac OS/Desktop` + `syncFullHistory: true` previously emitted `WEB + DARWIN`.

With this change, the previously failing Desktop full-history cases now reach QR in a throwaway-auth live check. No real pairing or auth-state inspection was needed.

## WA Web captured JS sanity

Ran:

```bash
./tools/wa-web-sanity.sh 'WIN_HYBRID|WebSubPlatform|webSubPlatform|WAWebWamPlatform|CompanionRegClientUtils'
```

Relevant matches from the captured WA Web bundle:

- `WAWeb/Client/Payload.js`
- `WAWeb/Wam/Platform.js`
- `WAWeb/Protobufs/Wa6.pb.js`

Relevant excerpt:

```js
if (e === "WIN_HYBRID") return ...WIN_HYBRID
```

`WAWeb/Client/Payload.js` maps the runtime web platform to `webInfo.webSubPlatform`, and the protobuf bundle includes `WIN_HYBRID` as a valid `ClientPayload.WebInfo.WebSubPlatform`.

## Validation

- Focused unit test: `yarn test --runTestsByPath src/__tests__/Utils/validate-connection.test.ts --runInBand`
- Full lint: `yarn lint` — 0 errors, 103 pre-existing `no-explicit-any` warnings
- Full unit test suite: `yarn test` — 29 suites / 412 tests passing
- Live no-pairing repro with throwaway auth dirs and WA Web `2.3000.1042632189`:
  - `Browsers.windows('Desktop')` + `syncFullHistory: true` -> QR emitted
  - `Browsers.macOS('Desktop')` + `syncFullHistory: true` -> QR emitted
  - `Browsers.ubuntu('Chrome')` + `syncFullHistory: true` -> QR emitted
  - `Browsers.windows('Desktop')` + `syncFullHistory: false` -> QR emitted

Fixes #2677

Drafted with Codex, reviewed and tested by me.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Desktop full-history client payloads to the current web subplatforms so registration/login are no longer rejected before QR. Windows now uses WIN_HYBRID; macOS uses MACOS platform with DARWIN subplatform.

- **Bug Fixes**
  - Align Desktop full-history mapping: Windows -> WIN_HYBRID, macOS -> MACOS + DARWIN.
  - Keep WEB_BROWSER for browsers and Desktop without full history.
  - Add regression tests for registration and login payloads, including Desktop login user-agent.

<sup>Written for commit dab9e86aed495f56ef1e10c33f5c468dad793ee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection setup device/platform detection, including refined desktop handling.
  * Windows desktop now reports the correct hybrid web sub-platform mapping.
  * macOS desktop clients correctly use the full-history desktop platform when enabled; non–full-history and other clients keep web behavior.
  * Android detection behavior remains consistent.

* **Tests**
  * Added coverage for registration and login connection payloads across Windows, macOS, Ubuntu, and desktop clients with and without full-history syncing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->