### PR TITLE
fix(messages): use phone-generated link previews

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -502,7 +502,8 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	}
 
 	const sendPeerDataOperationMessage = async (
-		pdoMessage: proto.Message.IPeerDataOperationRequestMessage
+		pdoMessage: proto.Message.IPeerDataOperationRequestMessage,
+		messageId?: string
 	): Promise<string> => {
 		//TODO: for later, abstract the logic to send a Peer Message instead of just PDO - useful for App State Key Resync with phone
 		if (!authState.creds.me?.id) {
@@ -519,6 +520,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		const meJid = jidNormalizedUser(authState.creds.me.id)
 
 		const msgId = await relayMessage(meJid, protocolMessage, {
+			messageId,
 			additionalAttributes: {
 				category: 'peer',
 
@@ -1262,9 +1264,9 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 			]
 		}
 
-		const stanzaId = await sendPeerDataOperationMessage(pdoMessage)
+		const stanzaId = generateMessageIDV2(authState.creds.me?.id)
 		let urlInfo: WAUrlInfo | undefined
-		await waitForLinkPreviewUpdate(async update => {
+		const response = waitForLinkPreviewUpdate(async update => {
 			if (update.stanzaId !== stanzaId) {
 				return false
 			}
@@ -1272,6 +1274,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 			urlInfo = linkPreviewResponseToUrlInfo(text, update.linkPreview)
 			return true
 		}, LINK_PREVIEW_PHONE_TIMEOUT_MS)
+		await Promise.all([sendPeerDataOperationMessage(pdoMessage, stanzaId), response])
 
 		return urlInfo
 	}

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -10,7 +10,8 @@ import type {
 	MiscMessageGenerationOptions,
 	SocketConfig,
 	WAMessage,
-	WAMessageKey
+	WAMessageKey,
+	WAUrlInfo
 } from '../Types'
 import {
 	aggregateMessageKeysNotFromMe,
@@ -35,7 +36,7 @@ import {
 	parseAndInjectE2ESessions,
 	unixTimestampSeconds
 } from '../Utils'
-import { getUrlInfo } from '../Utils/link-preview'
+import { getUrlInfo, linkPreviewResponseToUrlInfo } from '../Utils/link-preview'
 import { makeKeyedMutex, makeMutex } from '../Utils/make-mutex'
 import { getMessageReportingToken, shouldIncludeReportingToken } from '../Utils/reporting-utils'
 import {
@@ -69,6 +70,8 @@ import {
 } from '../WABinary'
 import { USyncQuery, USyncUser } from '../WAUSync'
 import { makeNewsletterSocket } from './newsletter'
+
+const LINK_PREVIEW_PHONE_TIMEOUT_MS = 10_000
 
 export const makeMessagesSocket = (config: SocketConfig) => {
 	const {
@@ -1246,6 +1249,55 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	const waUploadToServer = getWAUploadToServer(config, refreshMediaConn)
 
 	const waitForMsgMediaUpdate = bindWaitForEvent(ev, 'messages.media-update')
+	const waitForLinkPreviewUpdate = bindWaitForEvent(ev, 'link-preview.update')
+
+	const requestPhoneLinkPreview = async (text: string): Promise<WAUrlInfo | undefined> => {
+		const pdoMessage: proto.Message.IPeerDataOperationRequestMessage = {
+			peerDataOperationRequestType: proto.Message.PeerDataOperationRequestType.GENERATE_LINK_PREVIEW,
+			requestUrlPreview: [
+				{
+					url: text,
+					includeHqThumbnail: generateHighQualityLinkPreview
+				}
+			]
+		}
+
+		const stanzaId = await sendPeerDataOperationMessage(pdoMessage)
+		let urlInfo: WAUrlInfo | undefined
+		await waitForLinkPreviewUpdate(async update => {
+			if (update.stanzaId !== stanzaId) {
+				return false
+			}
+
+			urlInfo = linkPreviewResponseToUrlInfo(text, update.linkPreview)
+			return true
+		}, LINK_PREVIEW_PHONE_TIMEOUT_MS)
+
+		return urlInfo
+	}
+
+	const getUrlInfoForMessage = async (text: string) => {
+		if (generateHighQualityLinkPreview) {
+			try {
+				const urlInfo = await requestPhoneLinkPreview(text)
+				if (urlInfo) {
+					return urlInfo
+				}
+			} catch (err) {
+				logger.debug({ err, url: text }, 'failed to generate link preview via phone')
+			}
+		}
+
+		return getUrlInfo(text, {
+			thumbnailWidth: linkPreviewImageThumbnailWidth,
+			fetchOpts: {
+				timeout: 3_000,
+				...(httpRequestOptions || {})
+			},
+			logger,
+			uploadImage: generateHighQualityLinkPreview ? waUploadToServer : undefined
+		})
+	}
 
 	registerSocketEndHandler(() => {
 		if (!config.userDevicesCache && userDevicesCache.close) {
@@ -1345,16 +1397,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				const fullMsg = await generateWAMessage(jid, content, {
 					logger,
 					userJid,
-					getUrlInfo: text =>
-						getUrlInfo(text, {
-							thumbnailWidth: linkPreviewImageThumbnailWidth,
-							fetchOpts: {
-								timeout: 3_000,
-								...(httpRequestOptions || {})
-							},
-							logger,
-							uploadImage: generateHighQualityLinkPreview ? waUploadToServer : undefined
-						}),
+					getUrlInfo: getUrlInfoForMessage,
 					//TODO: CACHE
 					getProfilePicUrl: sock.profilePictureUrl,
 					getCallLink: sock.createCallLink,

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -4,6 +4,7 @@ import { proto } from '../../WAProto/index.js'
 import { DEFAULT_CACHE_TTLS, WA_DEFAULT_EPHEMERAL } from '../Defaults'
 import type {
 	AnyMessageContent,
+	BaileysEventMap,
 	MediaConnInfo,
 	MessageReceiptType,
 	MessageRelayOptions,
@@ -13,6 +14,7 @@ import type {
 	WAMessageKey,
 	WAUrlInfo
 } from '../Types'
+import { DisconnectReason } from '../Types'
 import {
 	aggregateMessageKeysNotFromMe,
 	assertMediaContent,
@@ -34,6 +36,7 @@ import {
 	MessageRetryManager,
 	normalizeMessageContent,
 	parseAndInjectE2ESessions,
+	promiseTimeout,
 	unixTimestampSeconds
 } from '../Utils'
 import { getUrlInfo, linkPreviewResponseToUrlInfo } from '../Utils/link-preview'
@@ -1251,7 +1254,63 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 	const waUploadToServer = getWAUploadToServer(config, refreshMediaConn)
 
 	const waitForMsgMediaUpdate = bindWaitForEvent(ev, 'messages.media-update')
-	const waitForLinkPreviewUpdate = bindWaitForEvent(ev, 'link-preview.update')
+
+	const armLinkPreviewWait = (stanzaId: string, text: string) => {
+		let listener: ((update: BaileysEventMap['link-preview.update']) => void) | undefined
+		let closeListener: ((update: BaileysEventMap['connection.update']) => void) | undefined
+		const cleanup = () => {
+			if (listener) {
+				ev.off('link-preview.update', listener)
+				listener = undefined
+			}
+
+			if (closeListener) {
+				ev.off('connection.update', closeListener)
+				closeListener = undefined
+			}
+		}
+
+		const response = new Promise<WAUrlInfo | undefined>((resolve, reject) => {
+			closeListener = ({ connection, lastDisconnect }) => {
+				if (connection === 'close') {
+					cleanup()
+					reject(
+						lastDisconnect?.error || new Boom('Connection Closed', { statusCode: DisconnectReason.connectionClosed })
+					)
+				}
+			}
+
+			listener = update => {
+				if (update.stanzaId === stanzaId) {
+					cleanup()
+					resolve(linkPreviewResponseToUrlInfo(text, update.linkPreview))
+				}
+			}
+
+			ev.on('connection.update', closeListener)
+			ev.on('link-preview.update', listener)
+		})
+
+		const settledResponse = response.then(
+			value => ({ status: 'fulfilled' as const, value }),
+			reason => ({ status: 'rejected' as const, reason })
+		)
+
+		return {
+			cleanup,
+			wait: async (timeoutMs: number) => {
+				const result = await promiseTimeout<PromiseSettledResult<WAUrlInfo | undefined>>(timeoutMs, resolve => {
+					void settledResponse.then(resolve)
+				})
+
+				if (result.status === 'rejected') {
+					throw result.reason
+				}
+
+				return result.value
+			}
+		}
+	}
 
 	const requestPhoneLinkPreview = async (text: string): Promise<WAUrlInfo | undefined> => {
 		const pdoMessage: proto.Message.IPeerDataOperationRequestMessage = {
@@ -1265,18 +1324,13 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		}
 
 		const stanzaId = generateMessageIDV2(authState.creds.me?.id)
-		let urlInfo: WAUrlInfo | undefined
-		const response = waitForLinkPreviewUpdate(async update => {
-			if (update.stanzaId !== stanzaId) {
-				return false
-			}
-
-			urlInfo = linkPreviewResponseToUrlInfo(text, update.linkPreview)
-			return true
-		}, LINK_PREVIEW_PHONE_TIMEOUT_MS)
-		await Promise.all([sendPeerDataOperationMessage(pdoMessage, stanzaId), response])
-
-		return urlInfo
+		const response = armLinkPreviewWait(stanzaId, text)
+		try {
+			await sendPeerDataOperationMessage(pdoMessage, stanzaId)
+			return await response.wait(LINK_PREVIEW_PHONE_TIMEOUT_MS)
+		} finally {
+			response.cleanup()
+		}
 	}
 
 	const getUrlInfoForMessage = async (text: string) => {

--- a/src/Types/Events.ts
+++ b/src/Types/Events.ts
@@ -63,6 +63,10 @@ export type BaileysEventMap = {
 	'messages.delete': { keys: WAMessageKey[] } | { jid: string; all: true }
 	'messages.update': WAMessageUpdate[]
 	'messages.media-update': { key: WAMessageKey; media?: { ciphertext: Uint8Array; iv: Uint8Array }; error?: Boom }[]
+	'link-preview.update': {
+		stanzaId?: string | null
+		linkPreview: proto.Message.PeerDataOperationRequestResponseMessage.PeerDataOperationResult.ILinkPreviewResponse
+	}
 	/**
 	 * add/update the given messages. If they were received while the connection was online,
 	 * the update will have type: "notify"

--- a/src/Utils/link-preview.ts
+++ b/src/Utils/link-preview.ts
@@ -7,7 +7,7 @@ import { prepareWAMessageMedia } from './messages'
 import { extractImageThumb, getHttpStream } from './messages-media'
 
 const THUMBNAIL_WIDTH_PX = 192
-type LinkPreviewResponse =
+export type LinkPreviewResponse =
 	proto.Message.PeerDataOperationRequestResponseMessage.PeerDataOperationResult.ILinkPreviewResponse
 
 /** Fetches an image and generates a thumbnail for it */
@@ -34,9 +34,7 @@ const bufferFromStringHash = (hash?: string | null) => {
 		return undefined
 	}
 
-	const normalized = hash.replace(/-/g, '+').replace(/_/g, '/')
-	const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=')
-	const buffer = Buffer.from(padded, 'base64')
+	const buffer = Buffer.from(hash, 'base64url')
 	return buffer.length ? buffer : undefined
 }
 
@@ -46,6 +44,7 @@ const mediaKeyTimestampFromMs = (timestampMs: Long | number | null | undefined) 
 		return undefined
 	}
 
+	// The field is named in milliseconds, but phone responses can already carry seconds.
 	return timestamp > 9_999_999_999 ? Math.floor(timestamp / 1000) : timestamp
 }
 
@@ -66,11 +65,13 @@ export const linkPreviewResponseToUrlInfo = (
 	}
 
 	const hqThumbnail = response.hqThumbnail
-	if (hqThumbnail?.directPath && hqThumbnail.mediaKey) {
+	const fileSha256 = bufferFromStringHash(hqThumbnail?.thumbHash)
+	const fileEncSha256 = bufferFromStringHash(hqThumbnail?.encThumbHash)
+	if (hqThumbnail?.directPath && hqThumbnail.mediaKey && fileSha256 && fileEncSha256) {
 		urlInfo.highQualityThumbnail = {
 			directPath: hqThumbnail.directPath,
-			fileSha256: bufferFromStringHash(hqThumbnail.thumbHash),
-			fileEncSha256: bufferFromStringHash(hqThumbnail.encThumbHash),
+			fileSha256,
+			fileEncSha256,
 			jpegThumbnail: urlInfo.jpegThumbnail,
 			mediaKey: Buffer.from(hqThumbnail.mediaKey),
 			mediaKeyTimestamp: mediaKeyTimestampFromMs(hqThumbnail.mediaKeyTimestampMs),

--- a/src/Utils/link-preview.ts
+++ b/src/Utils/link-preview.ts
@@ -1,9 +1,14 @@
+import type Long from 'long'
+import type { proto } from '../../WAProto/index.js'
 import type { WAMediaUploadFunction, WAUrlInfo } from '../Types'
+import { toNumber } from './generics'
 import type { ILogger } from './logger'
 import { prepareWAMessageMedia } from './messages'
 import { extractImageThumb, getHttpStream } from './messages-media'
 
 const THUMBNAIL_WIDTH_PX = 192
+type LinkPreviewResponse =
+	proto.Message.PeerDataOperationRequestResponseMessage.PeerDataOperationResult.ILinkPreviewResponse
 
 /** Fetches an image and generates a thumbnail for it */
 const getCompressedJpegThumbnail = async (url: string, { thumbnailWidth, fetchOpts }: URLGenerationOptions) => {
@@ -22,6 +27,60 @@ export type URLGenerationOptions = {
 	}
 	uploadImage?: WAMediaUploadFunction
 	logger?: ILogger
+}
+
+const bufferFromStringHash = (hash?: string | null) => {
+	if (!hash) {
+		return undefined
+	}
+
+	const normalized = hash.replace(/-/g, '+').replace(/_/g, '/')
+	const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=')
+	const buffer = Buffer.from(padded, 'base64')
+	return buffer.length ? buffer : undefined
+}
+
+const mediaKeyTimestampFromMs = (timestampMs: Long | number | null | undefined) => {
+	const timestamp = toNumber(timestampMs)
+	if (!timestamp) {
+		return undefined
+	}
+
+	return timestamp > 9_999_999_999 ? Math.floor(timestamp / 1000) : timestamp
+}
+
+export const linkPreviewResponseToUrlInfo = (
+	matchedText: string,
+	response: LinkPreviewResponse | null | undefined
+): WAUrlInfo | undefined => {
+	if (!response?.url || !response.title) {
+		return undefined
+	}
+
+	const urlInfo: WAUrlInfo = {
+		'canonical-url': response.url,
+		'matched-text': response.matchText || matchedText,
+		title: response.title,
+		description: response.description || undefined,
+		jpegThumbnail: response.thumbData ? Buffer.from(response.thumbData) : undefined
+	}
+
+	const hqThumbnail = response.hqThumbnail
+	if (hqThumbnail?.directPath && hqThumbnail.mediaKey) {
+		urlInfo.highQualityThumbnail = {
+			directPath: hqThumbnail.directPath,
+			fileSha256: bufferFromStringHash(hqThumbnail.thumbHash),
+			fileEncSha256: bufferFromStringHash(hqThumbnail.encThumbHash),
+			jpegThumbnail: urlInfo.jpegThumbnail,
+			mediaKey: Buffer.from(hqThumbnail.mediaKey),
+			mediaKeyTimestamp: mediaKeyTimestampFromMs(hqThumbnail.mediaKeyTimestampMs),
+			mimetype: 'image/jpeg',
+			width: hqThumbnail.thumbWidth || undefined,
+			height: hqThumbnail.thumbHeight || undefined
+		}
+	}
+
+	return urlInfo
 }
 
 /**

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -48,6 +48,21 @@ type ProcessMessageContext = {
 	getMessage: SocketConfig['getMessage']
 }
 
+const emitLinkPreviewResponses = (
+	response: proto.Message.IPeerDataOperationRequestResponseMessage,
+	ev: BaileysEventEmitter
+) => {
+	for (const result of response.peerDataOperationResult || []) {
+		const linkPreview = result?.linkPreviewResponse
+		if (linkPreview) {
+			ev.emit('link-preview.update', {
+				stanzaId: response.stanzaId,
+				linkPreview
+			})
+		}
+	}
+}
+
 const REAL_MSG_STUB_TYPES = new Set([
 	WAMessageStubType.CALL_MISSED_GROUP_VIDEO,
 	WAMessageStubType.CALL_MISSED_GROUP_VOICE,
@@ -461,6 +476,7 @@ const processMessage = async (
 				const response = protocolMsg.peerDataOperationRequestResponseMessage!
 				if (response) {
 					// TODO: IMPLEMENT HISTORY SYNC ETC (sticker uploads etc.).
+					emitLinkPreviewResponses(response, ev)
 					const peerDataOperationResult = response.peerDataOperationResult || []
 					for (const result of peerDataOperationResult) {
 						const retryResponse = result?.placeholderMessageResendResponse

--- a/src/__tests__/Utils/link-preview.test.ts
+++ b/src/__tests__/Utils/link-preview.test.ts
@@ -1,0 +1,52 @@
+import Long from 'long'
+import { linkPreviewResponseToUrlInfo } from '../../Utils/link-preview'
+
+describe('linkPreviewResponseToUrlInfo', () => {
+	it('maps phone-generated link previews to WAUrlInfo', () => {
+		const thumbData = Buffer.from([1, 2, 3])
+		const thumbHash = Buffer.from('thumb-hash').toString('base64')
+		const encThumbHash = Buffer.from('enc-thumb-hash').toString('base64url')
+		const mediaKey = Buffer.from('media-key')
+
+		const urlInfo = linkPreviewResponseToUrlInfo('https://example.com/path', {
+			url: 'https://example.com/',
+			title: 'Example',
+			description: 'Example description',
+			thumbData,
+			matchText: 'https://example.com/path',
+			hqThumbnail: {
+				directPath: '/o1/v/t62.7118-24/link-preview',
+				thumbHash,
+				encThumbHash,
+				mediaKey,
+				mediaKeyTimestampMs: Long.fromNumber(1_692_895_570_000),
+				thumbWidth: 1200,
+				thumbHeight: 630
+			}
+		})
+
+		expect(urlInfo).toMatchObject({
+			'canonical-url': 'https://example.com/',
+			'matched-text': 'https://example.com/path',
+			title: 'Example',
+			description: 'Example description',
+			jpegThumbnail: thumbData,
+			highQualityThumbnail: {
+				directPath: '/o1/v/t62.7118-24/link-preview',
+				fileSha256: Buffer.from('thumb-hash'),
+				fileEncSha256: Buffer.from('enc-thumb-hash'),
+				jpegThumbnail: thumbData,
+				mediaKey,
+				mediaKeyTimestamp: 1_692_895_570,
+				mimetype: 'image/jpeg',
+				width: 1200,
+				height: 630
+			}
+		})
+	})
+
+	it('returns undefined for incomplete responses', () => {
+		expect(linkPreviewResponseToUrlInfo('https://example.com', { url: 'https://example.com' })).toBeUndefined()
+		expect(linkPreviewResponseToUrlInfo('https://example.com', { title: 'Example' })).toBeUndefined()
+	})
+})

--- a/src/__tests__/Utils/link-preview.test.ts
+++ b/src/__tests__/Utils/link-preview.test.ts
@@ -49,4 +49,22 @@ describe('linkPreviewResponseToUrlInfo', () => {
 		expect(linkPreviewResponseToUrlInfo('https://example.com', { url: 'https://example.com' })).toBeUndefined()
 		expect(linkPreviewResponseToUrlInfo('https://example.com', { title: 'Example' })).toBeUndefined()
 	})
+
+	it('does not emit high-quality thumbnails without integrity hashes', () => {
+		const urlInfo = linkPreviewResponseToUrlInfo('https://example.com/path', {
+			url: 'https://example.com/',
+			title: 'Example',
+			hqThumbnail: {
+				directPath: '/o1/v/t62.7118-24/link-preview',
+				mediaKey: Buffer.from('media-key')
+			}
+		})
+
+		expect(urlInfo).toMatchObject({
+			'canonical-url': 'https://example.com/',
+			'matched-text': 'https://example.com/path',
+			title: 'Example'
+		})
+		expect(urlInfo?.highQualityThumbnail).toBeUndefined()
+	})
 })

--- a/src/__tests__/Utils/process-message.test.ts
+++ b/src/__tests__/Utils/process-message.test.ts
@@ -1,5 +1,9 @@
-import type { WAMessage } from '../../Types'
-import { cleanMessage, getChatId } from '../../Utils/process-message'
+import { EventEmitter } from 'events'
+import { proto } from '../../../WAProto'
+import type { BaileysEventEmitter, BaileysEventMap, WAMessage } from '../../Types'
+import processMessage, { cleanMessage, getChatId } from '../../Utils/process-message'
+
+const ME_ID = 'me@s.whatsapp.net'
 
 const createBaseMessage = (key: Partial<WAMessage['key']>, message?: Partial<WAMessage['message']>): WAMessage => {
 	return {
@@ -133,6 +137,62 @@ describe('cleanMessage', () => {
 		it('should not crash on an empty message object', () => {
 			const message = createBaseMessage({}, {})
 			expect(() => cleanMessage(message, meId, meLid)).not.toThrow()
+		})
+	})
+})
+
+describe('processMessage', () => {
+	it('emits link-preview.update for phone-generated link preview responses', async () => {
+		const ev = new EventEmitter() as unknown as BaileysEventEmitter
+		let emitted: BaileysEventMap['link-preview.update'] | undefined
+		ev.on('link-preview.update', update => {
+			emitted = update
+		})
+
+		const linkPreview = {
+			url: 'https://example.com/',
+			title: 'Example',
+			thumbData: Buffer.from([1, 2, 3]),
+			hqThumbnail: {
+				directPath: '/o1/v/t62.7118-24/link-preview',
+				thumbHash: Buffer.from('thumb-hash').toString('base64'),
+				encThumbHash: Buffer.from('enc-thumb-hash').toString('base64'),
+				mediaKey: Buffer.from('media-key'),
+				mediaKeyTimestampMs: 1_692_895_570_000,
+				thumbWidth: 1200,
+				thumbHeight: 630
+			}
+		}
+
+		const message = createBaseMessage(
+			{ remoteJid: ME_ID, fromMe: true },
+			{
+				protocolMessage: {
+					type: proto.Message.ProtocolMessage.Type.PEER_DATA_OPERATION_REQUEST_RESPONSE_MESSAGE,
+					peerDataOperationRequestResponseMessage: {
+						stanzaId: 'PDO_REQUEST_ID',
+						peerDataOperationRequestType: proto.Message.PeerDataOperationRequestType.GENERATE_LINK_PREVIEW,
+						peerDataOperationResult: [{ linkPreviewResponse: linkPreview }]
+					}
+				}
+			}
+		)
+
+		type ProcessMessageContext = Parameters<typeof processMessage>[1]
+		await processMessage(message, {
+			shouldProcessHistoryMsg: false,
+			ev,
+			creds: { me: { id: ME_ID } } as ProcessMessageContext['creds'],
+			keyStore: {} as ProcessMessageContext['keyStore'],
+			logger: undefined,
+			options: {},
+			signalRepository: {} as ProcessMessageContext['signalRepository'],
+			getMessage: async () => undefined
+		})
+
+		expect(emitted).toEqual({
+			stanzaId: 'PDO_REQUEST_ID',
+			linkPreview
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- request phone-generated URL previews with `PeerDataOperationRequestType.GENERATE_LINK_PREVIEW` when `generateHighQualityLinkPreview` is enabled
- emit a typed `link-preview.update` event from peer data operation responses
- map WhatsApp `LinkPreviewResponse` payloads, including high-quality thumbnail metadata, into `WAUrlInfo`
- keep the existing `link-preview-js`/upload flow as a fallback when the phone-generated preview is unavailable or times out
- add unit coverage for link preview response mapping and peer-data response event emission

## Testing

- `npm exec --yes corepack@latest -- yarn lint` (0 errors, existing warnings only)
- `npm exec --yes corepack@latest -- yarn test --runInBand` (29 suites, 410 tests)
- `npm exec --yes corepack@latest -- yarn build`
- Local WhatsApp session test via QR pairing: connected a local Baileys client and sent PDF document preview messages to a test subgroup inside a community; Android and iPhone clients both rendered document thumbnails. That live test validated the related document-preview behavior observed during investigation. The URL link-preview protocol path in this PR is covered by unit tests and preserves fallback behavior.

## Notes

- This is an additive public event: `link-preview.update`.
- AI authorship disclosure: generated entirely with GPT-5 Codex and locally tested before submission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use phone-generated URL previews when `generateHighQualityLinkPreview` is enabled to improve quality. Wait up to 10s after relaying the PDO for a phone response, then fall back to `link-preview-js`.

- **New Features**
  - Requests previews via `PeerDataOperationRequestType.GENERATE_LINK_PREVIEW` with a 10s post-relay timeout before fallback.
  - Emits `link-preview.update` with `stanzaId`; maps WhatsApp `LinkPreviewResponse` (incl. HQ thumbnail metadata) into `WAUrlInfo`.

- **Bug Fixes**
  - Correlates responses by `stanzaId` (PDO sent with matching `messageId`) and cancels waiting if the connection closes.
  - Only includes HQ thumbnails when `directPath`, `mediaKey`, and integrity hashes are present; normalizes timestamps to seconds.
  - Adds debug logging on phone preview errors before falling back.

<sup>Written for commit 5292d0470aff87520fa35e3b0f7f461bcec9bc84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for enhanced phone-based link preview generation when enabled.
  * Introduced a new `link-preview.update` event that delivers preview results as they arrive.

* **Bug Fixes**
  * Improved link preview response conversion to URL info, with stricter validation for high-quality thumbnails.
  * Added correlation and reliable fallback to the existing link preview flow when phone-based preview generation fails or times out.

* **Tests**
  * Expanded unit tests to cover high-quality thumbnail edge cases and event emission for phone-generated previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->