### PR TITLE
fix(media): forward download stream errors

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -7,7 +7,7 @@ import type { Agent } from 'https'
 import type { IAudioMetadata } from 'music-metadata'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { Readable, Transform } from 'stream'
+import { pipeline, Readable, Transform } from 'stream'
 import { URL } from 'url'
 import { proto } from '../../WAProto/index.js'
 import { DEFAULT_ORIGIN, MEDIA_HKDF_KEY_MAPPING, MEDIA_PATH_MAP, type MediaType } from '../Defaults'
@@ -649,7 +649,17 @@ export const downloadEncryptedContent = async (
 			}
 		}
 	})
-	return fetched.pipe(output, { end: true })
+
+	// Readable.pipe() does not forward source errors to the destination. Use
+	// pipeline so transport and decrypt failures tear down the entire chain and
+	// remain observable through the returned transform.
+	pipeline(fetched, output, error => {
+		if (error && !output.destroyed) {
+			output.destroy(error)
+		}
+	})
+
+	return output
 }
 
 export function extensionForMediaMessage(message: WAMessageContent) {

--- a/src/__tests__/Utils/messages-media.test.ts
+++ b/src/__tests__/Utils/messages-media.test.ts
@@ -1,3 +1,4 @@
+import { createCipheriv } from 'crypto'
 import * as fs from 'fs'
 import * as http from 'http'
 import { Agent } from 'https'
@@ -6,7 +7,14 @@ import * as path from 'path'
 import { Readable } from 'stream'
 import type { MediaConnInfo, SocketConfig } from '../../Types'
 import type { ILogger } from '../../Utils/logger'
-import { encryptedStream, getWAUploadToServer, type UploadParams, uploadWithNodeHttp } from '../../Utils/messages-media'
+import {
+	downloadEncryptedContent,
+	encryptedStream,
+	getWAUploadToServer,
+	toBuffer,
+	type UploadParams,
+	uploadWithNodeHttp
+} from '../../Utils/messages-media'
 
 const createTempFile = async (content: string): Promise<string> => {
 	const filePath = path.join(os.tmpdir(), `test-upload-${Date.now()}.txt`)
@@ -365,6 +373,84 @@ describe('getWAUploadToServer', () => {
 			ts: undefined
 		})
 		expect((fetchInit as (RequestInit & { dispatcher?: unknown }) | undefined)?.dispatcher).toBeUndefined()
+	})
+})
+
+describe('downloadEncryptedContent', () => {
+	let originalFetch: typeof globalThis.fetch
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch
+	})
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch
+	})
+
+	it('forwards response body errors to the returned decrypt stream', async () => {
+		let failResponseBody: ((reason: unknown) => void) | undefined
+		const response = new Response(
+			new ReadableStream<Uint8Array>({
+				start(controller) {
+					failResponseBody = reason => controller.error(reason)
+				}
+			})
+		)
+		globalThis.fetch = (async () => response) as typeof fetch
+
+		const stream = await downloadEncryptedContent('https://mmg.whatsapp.net/media', {
+			cipherKey: Buffer.alloc(32),
+			iv: Buffer.alloc(16)
+		})
+		const consumption = toBuffer(stream)
+		const terminated = new TypeError('terminated')
+
+		if (!failResponseBody) {
+			throw new Error('response body controller was not initialized')
+		}
+
+		failResponseBody(terminated)
+
+		await expect(consumption).rejects.toBe(terminated)
+	})
+
+	it('continues to decrypt a complete response body', async () => {
+		const cipherKey = Buffer.alloc(32, 1)
+		const iv = Buffer.alloc(16, 2)
+		const plaintext = Buffer.from('media payload')
+		const cipher = createCipheriv('aes-256-cbc', cipherKey, iv)
+		const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()])
+		globalThis.fetch = (async () => new Response(encrypted)) as typeof fetch
+
+		const stream = await downloadEncryptedContent('https://mmg.whatsapp.net/media', { cipherKey, iv })
+
+		await expect(toBuffer(stream)).resolves.toEqual(plaintext)
+	})
+
+	it('destroys the response body when the returned stream is cancelled', async () => {
+		let markResponseCancelled: (() => void) | undefined
+		let cancelCount = 0
+		const responseCancelled = new Promise<void>(resolve => {
+			markResponseCancelled = resolve
+		})
+		const response = new Response(
+			new ReadableStream({
+				cancel() {
+					cancelCount += 1
+					markResponseCancelled?.()
+				}
+			})
+		)
+		globalThis.fetch = (async () => response) as typeof fetch
+		const stream = await downloadEncryptedContent('https://mmg.whatsapp.net/media', {
+			cipherKey: Buffer.alloc(32),
+			iv: Buffer.alloc(16)
+		})
+
+		stream.destroy()
+
+		await responseCancelled
+		expect(cancelCount).toBe(1)
 	})
 })
 


### PR DESCRIPTION
## Summary

`downloadEncryptedContent()` previously returned the destination of:

```ts
fetched.pipe(output, { end: true })
```

`Readable.pipe()` does not forward source errors to the destination. If an Undici response body failed after the HTTP headers were received, for example with `TypeError: terminated`, the source stream emitted an unhandled error while the returned decrypt stream remained pending.

So I replace the raw `Readable.pipe()` connection in `downloadEncryptedContent` with Node's managed `pipeline()`.

## Tests

Added deterministic coverage using a native `Response` and Web `ReadableStream` for:
- response body errors rejecting the returned decrypt stream
- successful media decryption
- caller cancellation propagating to the response body

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes media download error handling by replacing Readable.pipe with Node’s pipeline in downloadEncryptedContent so response body errors and cancellations propagate to the returned decrypt stream. Adds deterministic tests for body error propagation, successful decryption, and caller cancellation.

<sup>Written for commit bd99518737f4812d673f567df9d2ac9b1771285e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved encrypted media downloads by reliably reporting network and decryption errors.
  - Ensured interrupted or cancelled downloads properly stop the underlying data transfer.
  - Improved reliability when decrypting complete media responses, helping prevent stalled or incomplete downloads.

- **Tests**
  - Added coverage for successful decryption, error propagation, and download cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->