### PR TITLE
feat: add support for hidden-voter-names polls (pollCreationMessageV6)

### DIFF
--- a/WAProto/WAProto.proto
+++ b/WAProto/WAProto.proto
@@ -2159,6 +2159,7 @@ message Message {
     optional PollCreationMessage pollCreationMessageV5 = 111;
     optional NewsletterFollowerInviteMessage newsletterFollowerInviteMessageV2 = 113;
     optional PollResultSnapshotMessage pollResultSnapshotMessageV3 = 114;
+    optional PollCreationMessage pollCreationMessageV6 = 119; // hidden-voter-names poll
     message AlbumMessage {
         optional uint32 expectedImageCount = 2;
         optional uint32 expectedVideoCount = 3;
@@ -3241,6 +3242,7 @@ message Message {
             optional string optionHash = 2;
         }
 
+        optional bool hideVoterNames = 10;
     }
 
     message PollEncValue {


### PR DESCRIPTION
## Support hidden-voter-names polls

Add `pollCreationMessageV6` message type and `hideVoterNames` field to support WhatsApp's poll anonymity feature.

### Live Proof ✓
Feature tested and verified on official WhatsApp client:
- Normal poll: Shows vote counts  
- Hidden poll: Shows 'Names hidden' badge

### Implementation Reference
- Working implementation: https://github.com/zeative/zaileys
- Patch: https://github.com/zeative/zaileys/blob/main/patches/baileys.patch
- Tests: All 2513 tests passing

Proto files updated for pollCreationMessageV6 with hideVoterNames support.

<img width="1084" height="1600" alt="image" src="https://github.com/user-attachments/assets/2073e01f-5462-4793-b9b4-d3a28c82251f" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for hidden-voter-names polls to match WhatsApp’s anonymity feature. Introduces `pollCreationMessageV6` and a `hideVoterNames` flag to create polls where voter identities are not shown.

- **New Features**
  - Add `Message.pollCreationMessageV6` (field 119).
  - Add `PollCreationMessage.hideVoterNames` (bool, field 10).

<sup>Written for commit a22d2fccc97fd6cbf286f18f88f37be012d051e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

