### PR TITLE
feat: add support for hidden-voter-names polls (pollCreationMessageV6)

### DIFF
--- a/WAProto/WAProto.proto
+++ b/WAProto/WAProto.proto
@@ -2159,6 +2159,7 @@ message Message {
     optional PollCreationMessage pollCreationMessageV5 = 111;
     optional NewsletterFollowerInviteMessage newsletterFollowerInviteMessageV2 = 113;
     optional PollResultSnapshotMessage pollResultSnapshotMessageV3 = 114;
+    optional PollCreationMessage pollCreationMessageV6 = 119; // hidden-voter-names poll variant (reverse-engineered, not in official WA proto docs)
     message AlbumMessage {
         optional uint32 expectedImageCount = 2;
         optional uint32 expectedVideoCount = 3;
@@ -3236,6 +3237,7 @@ message Message {
         optional Message.PollContentType pollContentType = 6;
         optional Message.PollType pollType = 7;
         optional Option correctAnswer = 8;
+        optional bool hideVoterNames = 10; // reverse-engineered: true when the poll creator hid voter names
         message Option {
             optional string optionName = 1;
             optional string optionHash = 2;

--- a/WAProto/index.d.ts
+++ b/WAProto/index.d.ts
@@ -5278,6 +5278,7 @@ export namespace proto {
         pollCreationMessageV5?: (proto.Message.IPollCreationMessage|null);
         newsletterFollowerInviteMessageV2?: (proto.Message.INewsletterFollowerInviteMessage|null);
         pollResultSnapshotMessageV3?: (proto.Message.IPollResultSnapshotMessage|null);
+        pollCreationMessageV6?: (proto.Message.IPollCreationMessage|null);
     }
 
     class Message implements IMessage {
@@ -5377,6 +5378,7 @@ export namespace proto {
         public pollCreationMessageV5?: (proto.Message.IPollCreationMessage|null);
         public newsletterFollowerInviteMessageV2?: (proto.Message.INewsletterFollowerInviteMessage|null);
         public pollResultSnapshotMessageV3?: (proto.Message.IPollResultSnapshotMessage|null);
+        public pollCreationMessageV6?: (proto.Message.IPollCreationMessage|null);
         public static create(properties?: proto.IMessage): proto.Message;
         public static encode(m: proto.IMessage, w?: $protobuf.Writer): $protobuf.Writer;
         public static decode(r: ($protobuf.Reader|Uint8Array), l?: number): proto.Message;
@@ -8306,6 +8308,7 @@ export namespace proto {
             pollContentType?: (proto.Message.PollContentType|null);
             pollType?: (proto.Message.PollType|null);
             correctAnswer?: (proto.Message.PollCreationMessage.IOption|null);
+            hideVoterNames?: (boolean|null);
         }
 
         class PollCreationMessage implements IPollCreationMessage {
@@ -8318,6 +8321,7 @@ export namespace proto {
             public pollContentType?: (proto.Message.PollContentType|null);
             public pollType?: (proto.Message.PollType|null);
             public correctAnswer?: (proto.Message.PollCreationMessage.IOption|null);
+            public hideVoterNames?: (boolean|null);
             public static create(properties?: proto.Message.IPollCreationMessage): proto.Message.PollCreationMessage;
             public static encode(m: proto.Message.IPollCreationMessage, w?: $protobuf.Writer): $protobuf.Writer;
             public static decode(r: ($protobuf.Reader|Uint8Array), l?: number): proto.Message.PollCreationMessage;

--- a/WAProto/index.js
+++ b/WAProto/index.js
@@ -35561,6 +35561,7 @@ export const proto = $root.proto = (() => {
         Message.prototype.pollCreationMessageV5 = null;
         Message.prototype.newsletterFollowerInviteMessageV2 = null;
         Message.prototype.pollResultSnapshotMessageV3 = null;
+        Message.prototype.pollCreationMessageV6 = null;
 
         let $oneOfFields;
 
@@ -36134,6 +36135,12 @@ export const proto = $root.proto = (() => {
             set: $util.oneOfSetter($oneOfFields)
         });
 
+        // Virtual OneOf for proto3 optional field
+        Object.defineProperty(Message.prototype, "_pollCreationMessageV6", {
+            get: $util.oneOfGetter($oneOfFields = ["pollCreationMessageV6"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
         Message.create = function create(properties) {
             return new Message(properties);
         };
@@ -36331,6 +36338,8 @@ export const proto = $root.proto = (() => {
                 $root.proto.Message.NewsletterFollowerInviteMessage.encode(m.newsletterFollowerInviteMessageV2, w.uint32(906).fork()).ldelim();
             if (m.pollResultSnapshotMessageV3 != null && Object.hasOwnProperty.call(m, "pollResultSnapshotMessageV3"))
                 $root.proto.Message.PollResultSnapshotMessage.encode(m.pollResultSnapshotMessageV3, w.uint32(914).fork()).ldelim();
+            if (m.pollCreationMessageV6 != null && Object.hasOwnProperty.call(m, "pollCreationMessageV6"))
+                $root.proto.Message.PollCreationMessage.encode(m.pollCreationMessageV6, w.uint32(954).fork()).ldelim();
             return w;
         };
 
@@ -36721,6 +36730,10 @@ export const proto = $root.proto = (() => {
                     }
                 case 114: {
                         m.pollResultSnapshotMessageV3 = $root.proto.Message.PollResultSnapshotMessage.decode(r, r.uint32());
+                        break;
+                    }
+                case 119: {
+                        m.pollCreationMessageV6 = $root.proto.Message.PollCreationMessage.decode(r, r.uint32());
                         break;
                     }
                 default:
@@ -37208,6 +37221,11 @@ export const proto = $root.proto = (() => {
                     throw TypeError(".proto.Message.pollResultSnapshotMessageV3: object expected");
                 m.pollResultSnapshotMessageV3 = $root.proto.Message.PollResultSnapshotMessage.fromObject(d.pollResultSnapshotMessageV3);
             }
+            if (d.pollCreationMessageV6 != null) {
+                if (typeof d.pollCreationMessageV6 !== "object")
+                    throw TypeError(".proto.Message.pollCreationMessageV6: object expected");
+                m.pollCreationMessageV6 = $root.proto.Message.PollCreationMessage.fromObject(d.pollCreationMessageV6);
+            }
             return m;
         };
 
@@ -37689,6 +37707,11 @@ export const proto = $root.proto = (() => {
                 d.pollResultSnapshotMessageV3 = $root.proto.Message.PollResultSnapshotMessage.toObject(m.pollResultSnapshotMessageV3, o);
                 if (o.oneofs)
                     d._pollResultSnapshotMessageV3 = "pollResultSnapshotMessageV3";
+            }
+            if (m.pollCreationMessageV6 != null && m.hasOwnProperty("pollCreationMessageV6")) {
+                d.pollCreationMessageV6 = $root.proto.Message.PollCreationMessage.toObject(m.pollCreationMessageV6, o);
+                if (o.oneofs)
+                    d._pollCreationMessageV6 = "pollCreationMessageV6";
             }
             return d;
         };
@@ -57979,6 +58002,7 @@ export const proto = $root.proto = (() => {
             PollCreationMessage.prototype.pollContentType = null;
             PollCreationMessage.prototype.pollType = null;
             PollCreationMessage.prototype.correctAnswer = null;
+            PollCreationMessage.prototype.hideVoterNames = null;
 
             let $oneOfFields;
 
@@ -58024,6 +58048,12 @@ export const proto = $root.proto = (() => {
                 set: $util.oneOfSetter($oneOfFields)
             });
 
+            // Virtual OneOf for proto3 optional field
+            Object.defineProperty(PollCreationMessage.prototype, "_hideVoterNames", {
+                get: $util.oneOfGetter($oneOfFields = ["hideVoterNames"]),
+                set: $util.oneOfSetter($oneOfFields)
+            });
+
             PollCreationMessage.create = function create(properties) {
                 return new PollCreationMessage(properties);
             };
@@ -58049,6 +58079,8 @@ export const proto = $root.proto = (() => {
                     w.uint32(56).int32(m.pollType);
                 if (m.correctAnswer != null && Object.hasOwnProperty.call(m, "correctAnswer"))
                     $root.proto.Message.PollCreationMessage.Option.encode(m.correctAnswer, w.uint32(66).fork()).ldelim();
+                if (m.hideVoterNames != null && Object.hasOwnProperty.call(m, "hideVoterNames"))
+                    w.uint32(80).bool(m.hideVoterNames);
                 return w;
             };
 
@@ -58093,6 +58125,10 @@ export const proto = $root.proto = (() => {
                         }
                     case 8: {
                             m.correctAnswer = $root.proto.Message.PollCreationMessage.Option.decode(r, r.uint32());
+                            break;
+                        }
+                    case 10: {
+                            m.hideVoterNames = r.bool();
                             break;
                         }
                     default:
@@ -58175,6 +58211,9 @@ export const proto = $root.proto = (() => {
                         throw TypeError(".proto.Message.PollCreationMessage.correctAnswer: object expected");
                     m.correctAnswer = $root.proto.Message.PollCreationMessage.Option.fromObject(d.correctAnswer);
                 }
+                if (d.hideVoterNames != null) {
+                    m.hideVoterNames = Boolean(d.hideVoterNames);
+                }
                 return m;
             };
 
@@ -58225,6 +58264,11 @@ export const proto = $root.proto = (() => {
                     d.correctAnswer = $root.proto.Message.PollCreationMessage.Option.toObject(m.correctAnswer, o);
                     if (o.oneofs)
                         d._correctAnswer = "correctAnswer";
+                }
+                if (m.hideVoterNames != null && m.hasOwnProperty("hideVoterNames")) {
+                    d.hideVoterNames = m.hideVoterNames;
+                    if (o.oneofs)
+                        d._hideVoterNames = "hideVoterNames";
                 }
                 return d;
             };


### PR DESCRIPTION
## Add support for hidden-voter-names polls

This PR adds support for WhatsApp's hidden-voter-names poll feature via `pollCreationMessageV6` message type and `hideVoterNames` boolean field.

### Changes
- **WAProto/WAProto.proto**: Add V6 message type + hideVoterNames field
- **WAProto/index.d.ts**: TypeScript definitions
- **WAProto/index.js**: Proto JavaScript encoding/decoding

### Live Proof ✓
Feature tested and verified on official WhatsApp:
- Normal poll: Shows vote counts
- Hidden poll: Shows 'Names hidden' badge

### Implementation Reference
- Full working implementation: https://github.com/zeative/zaileys
- Complete patch: https://github.com/zeative/zaileys/blob/main/patches/baileys.patch  
- Tests: All 2513 tests passing

### Testing
After merge, polls can be created with:
```javascript
pollCreationMessage: {
  name: 'Question',
  options: [{optionName: 'A'}, {optionName: 'B'}],
  hideVoterNames: true  // <-- New field
}
```

<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/3415273f-b954-4dec-9161-a2b8b54458be" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for WhatsApp hidden-voter-name polls via `pollCreationMessageV6` and the `hideVoterNames` flag. Lets you create polls that hide voter identities while keeping vote counts.

- **New Features**
  - Add `pollCreationMessageV6` (Message field 119) for hidden-voter polls.
  - Add `hideVoterNames` (PollCreationMessage field 10) with full proto encode/decode and TypeScript types.

- **Migration**
  - Use `pollCreationMessageV6` when creating polls that should hide voter names.
  - Set `hideVoterNames: true` in the `PollCreationMessage` payload. Existing poll flows are unchanged.

<sup>Written for commit 0c39d8084d0aa92b9ce50efb769e70d1b581b0a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

