### PR TITLE
fix(media): send reupload request on Boom errors and accept base64 mediaKey

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -898,14 +898,18 @@ export const getWAUploadToServer = (
 	}
 }
 
-const getMediaRetryKey = (mediaKey: Buffer | Uint8Array) => {
+const getMediaRetryKey = (mediaKey: Buffer | Uint8Array | string) => {
+	if (typeof mediaKey === 'string') {
+		mediaKey = Buffer.from(mediaKey.replace('data:;base64,', ''), 'base64')
+	}
+
 	return hkdf(mediaKey, 32, { info: 'WhatsApp Media Retry Notification' })
 }
 
 /**
  * Generate a binary node that will request the phone to re-upload the media & return the newly uploaded URL
  */
-export const encryptMediaRetryRequest = (key: WAMessageKey, mediaKey: Buffer | Uint8Array, meId: string) => {
+export const encryptMediaRetryRequest = (key: WAMessageKey, mediaKey: Buffer | Uint8Array | string, meId: string) => {
 	const recp: proto.IServerErrorReceipt = { stanzaId: key.id }
 	const recpBuffer = proto.ServerErrorReceipt.encode(recp).finish()
 
@@ -982,7 +986,7 @@ export const decodeMediaRetryNode = (node: BinaryNode) => {
 
 export const decryptMediaRetryData = (
 	{ ciphertext, iv }: { ciphertext: Uint8Array; iv: Uint8Array },
-	mediaKey: Uint8Array,
+	mediaKey: Uint8Array | string,
 	msgId: string
 ) => {
 	const retryKey = getMediaRetryKey(mediaKey)

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -1051,11 +1051,15 @@ export const downloadMediaMessage = async <Type extends 'buffer' | 'stream'>(
 	ctx?: DownloadMediaMessageContext
 ) => {
 	const result = await downloadMsg().catch(async error => {
-		if (
-			ctx &&
-			typeof error?.status === 'number' && // treat errors with status as HTTP failures requiring reupload
-			REUPLOAD_REQUIRED_STATUS.includes(error.status as number)
-		) {
+		// treat errors with status as HTTP failures requiring reupload
+		// getHttpStream throws a Boom, which exposes the HTTP status on output.statusCode
+		const errorStatus =
+			typeof error?.status === 'number'
+				? error.status
+				: typeof error?.output?.statusCode === 'number'
+					? error.output.statusCode
+					: undefined
+		if (ctx && typeof errorStatus === 'number' && REUPLOAD_REQUIRED_STATUS.includes(errorStatus)) {
 			ctx.logger.info({ key: message.key }, 'sending reupload media request...')
 			// request reupload
 			message = await ctx.reuploadRequest(message)


### PR DESCRIPTION
## Summary

Two independent bugs in the media re-upload path. Together they make media that has aged out of the CDN permanently unrecoverable, even when WhatsApp still holds it and WhatsApp Web can load it.

## Bug 1 — the reupload request is never sent

`downloadMediaMessage` gates the retry on `error?.status`:

```ts
typeof error?.status === 'number' &&
REUPLOAD_REQUIRED_STATUS.includes(error.status as number)
```

But the error originates in `getHttpStream`:

```ts
throw new Boom(`Failed to fetch stream from ${url}`, { statusCode: response.status, data: { url } })
```

A `Boom` exposes the status on `output.statusCode` and has **no `.status` property**, so the condition is never true and the whole branch is unreachable. Demonstrated:

```js
const e = new Boom('x', { statusCode: 404, data: {} })
typeof e.status        // 'undefined'
e.output.statusCode    // 404
```

A 404/410 from the media CDN therefore becomes a hard failure instead of triggering a retry.

## Bug 2 — the retry request is encrypted with the wrong key

`getMediaKeys` already normalises a base64-encoded key (`Uint8Array | string`), but `getMediaRetryKey` does not:

```ts
const getMediaRetryKey = (mediaKey: Buffer | Uint8Array) => {
	return hkdf(mediaKey, 32, { info: 'WhatsApp Media Retry Notification' })
}
```

Consumers that persist messages as JSON (a database, a cache) get `mediaKey` back as a base64 **string**. HKDF then runs over the 44 base64 characters instead of the 32 key bytes, producing a completely different key:

```
from Buffer: 1e04252bf9b97d50...
from string: 086b467b2d8d38d1...   // no match
```

WhatsApp cannot decrypt the request and replies with `MediaRetryNotification.ResultType.DECRYPTION_ERROR`, surfaced as `Failed to re-upload media (3)`.

## Fix

- Read the status from `output.statusCode` when `.status` is absent, so Boom errors reach the retry branch.
- Normalise a string `mediaKey` in `getMediaRetryKey`, mirroring `getMediaKeys` exactly.
- Widen the `mediaKey` types on `getMediaRetryKey`, `encryptMediaRetryRequest` and `decryptMediaRetryData` to include `string`, consistent with `getMediaKeys`.

## Verification

Against a live session with media that returned `404 Content not found` from the CDN (URL signature still valid — the blob had aged out):

- **Before:** every attempt failed. With debug logging, bug 1 meant no retry was sent at all; once that was fixed, bug 2 produced `Failed to re-upload media (3) 412` on every message.
- **After both fixes:** media within WhatsApp's retention window downloads again — 10/10 on a mixed test set (audio, image, document; both `fromMe` true and false). Output validated as genuine `Ogg data, Opus audio, 16000 Hz` with byte length exactly matching the declared `fileLength`.

Media older than roughly 30 days still fails, which is WhatsApp's own server-side retention and out of scope here.

Formatted with the repo's prettier config.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two bugs that blocked media re-upload for CDN-expired files. Reupload is now triggered on `Boom` HTTP errors, and base64 `mediaKey` values derive the correct retry key, restoring downloads within WhatsApp’s retention window.

- **Bug Fixes**
  - Trigger reupload by reading HTTP status from `error.output.statusCode` (fallback to `error.status`) in `downloadMediaMessage`.
  - Normalize base64 `mediaKey` in `getMediaRetryKey`, and accept `string` in `encryptMediaRetryRequest` and `decryptMediaRetryData` to match `getMediaKeys`.

<sup>Written for commit 867c3e1af5b9c7c4a35a0c5f240d1e929433b485. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media key handling for encryption and decryption when keys are provided as strings.
  * Fixed media download recovery for errors that report HTTP status codes through nested error details.
  * Media reupload and download retry behavior now works more reliably across additional error formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->