### PR TITLE
fix(deps): bump ws, protobufjs, and protobufjs-cli for 5 disclosed CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     "music-metadata": "^11.12.3",
     "p-queue": "^9.0.0",
     "pino": "^9.6",
-    "protobufjs": "^7.5.6",
+    "protobufjs": "^7.6.5",
     "whatsapp-rust-bridge": "0.5.4",
-    "ws": "^8.13.0"
+    "ws": "^8.21.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
@@ -77,7 +77,7 @@
     "open": "^8.4.2",
     "pino-pretty": "^13.1.1",
     "prettier": "^3.5.3",
-    "protobufjs-cli": "^1.1.3",
+    "protobufjs-cli": "^1.3.3",
     "release-it": "^20.0.1",
     "ts-jest": "^29.4.0",
     "tsc-esm-fix": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@ampproject/remapping@npm:^2.2.0":
@@ -2022,6 +2022,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@protobufjs/eventemitter@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/eventemitter@npm:1.1.1"
+  checksum: 10c0/8e06193d4629c5e7c09d4f8c2ddba8fc4dfa739f0149f33a1d901568d35bb7b8b5277a4e8452baf3bdd0b302fd599cf255d193267aa93a0a4747e23cd073c4ac
+  languageName: node
+  linkType: hard
+
 "@protobufjs/fetch@npm:^1.1.0":
   version: 1.1.0
   resolution: "@protobufjs/fetch@npm:1.1.0"
@@ -2029,6 +2036,15 @@ __metadata:
     "@protobufjs/aspromise": "npm:^1.1.1"
     "@protobufjs/inquire": "npm:^1.1.0"
   checksum: 10c0/cda6a3dc2d50a182c5865b160f72077aac197046600091dbb005dd0a66db9cce3c5eaed6d470ac8ed49d7bcbeef6ee5f0bc288db5ff9a70cbd003e5909065233
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/fetch@npm:1.1.1"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.1"
+  checksum: 10c0/a497ff5433854e8577f0427983ea39b9113b49a8120f94515291d763327061d2c3013e60e24ea436d091dafae01a0f6eb1867e3b1616045d96a31d8b3c646ed4
   languageName: node
   linkType: hard
 
@@ -3124,8 +3140,8 @@ __metadata:
     pino: "npm:^9.6"
     pino-pretty: "npm:^13.1.1"
     prettier: "npm:^3.5.3"
-    protobufjs: "npm:^7.5.6"
-    protobufjs-cli: "npm:^1.1.3"
+    protobufjs: "npm:^7.6.5"
+    protobufjs-cli: "npm:^1.3.3"
     release-it: "npm:^20.0.1"
     ts-jest: "npm:^29.4.0"
     tsc-esm-fix: "npm:^3.1.2"
@@ -3134,7 +3150,7 @@ __metadata:
     typedoc-plugin-markdown: "npm:4.4.2"
     typescript: "npm:^5.8.2"
     whatsapp-rust-bridge: "npm:0.5.4"
-    ws: "npm:^8.13.0"
+    ws: "npm:^8.21.1"
   peerDependencies:
     audio-decode: ^2.1.3
     jimp: ^1.6.1
@@ -6238,7 +6254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:^5.0.0":
+"long@npm:^5.0.0, long@npm:^5.3.2":
   version: 5.3.2
   resolution: "long@npm:5.3.2"
   checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
@@ -7348,9 +7364,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs-cli@npm:^1.1.3":
-  version: 1.2.0
-  resolution: "protobufjs-cli@npm:1.2.0"
+"protobufjs-cli@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "protobufjs-cli@npm:1.3.3"
   dependencies:
     chalk: "npm:^4.0.0"
     escodegen: "npm:^1.13.0"
@@ -7363,11 +7379,11 @@ __metadata:
     tmp: "npm:^0.2.1"
     uglify-js: "npm:^3.7.7"
   peerDependencies:
-    protobufjs: ^7.0.0
+    protobufjs: ^7.6.2
   bin:
     pbjs: bin/pbjs
     pbts: bin/pbts
-  checksum: 10c0/23bff21695e34d92d19cb7f8115e157327af59b7a9154effd916aafefd8633d39e0ea8566c4f0d812193c5a83077448c20d4074aebb5924e0c96f2022a970aa5
+  checksum: 10c0/536300ee21005a231a2f7fe16f6f844da9288b15ef462832b93ba2471e6277501f76fa644be41b917363f89be6a1716022ae8fac4e57831b3d5b799159c00ce0
   languageName: node
   linkType: hard
 
@@ -7391,23 +7407,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.5.6":
-  version: 7.5.6
-  resolution: "protobufjs@npm:7.5.6"
+"protobufjs@npm:^7.6.5":
+  version: 7.6.5
+  resolution: "protobufjs@npm:7.6.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
     "@protobufjs/codegen": "npm:^2.0.5"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
-    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/eventemitter": "npm:^1.1.1"
+    "@protobufjs/fetch": "npm:^1.1.1"
     "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.1"
     "@protobufjs/path": "npm:^1.1.2"
     "@protobufjs/pool": "npm:^1.1.0"
     "@protobufjs/utf8": "npm:^1.1.1"
     "@types/node": "npm:>=13.7.0"
-    long: "npm:^5.0.0"
-  checksum: 10c0/220df6c3cf6d2346748639a9b0b688fecc994bff9fee7018a93167e8cd45ab0ee3b4270d9eaa6be33a11adb46514ef9dce7e8217fd578c36726a9e70b96327cd
+    long: "npm:^5.3.2"
+  checksum: 10c0/863eaca9c6f45bfcfb8787c545f53e9c6696507e328e3981b4643c12d35df7f2826021c10e3fd30bef342c13a8e9d306547bac9c0849ee3bf50f770a12f01dc5
   languageName: node
   linkType: hard
 
@@ -8688,9 +8703,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.13.0":
-  version: 8.18.3
-  resolution: "ws@npm:8.18.3"
+"ws@npm:^8.21.1":
+  version: 8.21.1
+  resolution: "ws@npm:8.21.1"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -8699,7 +8714,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
+  checksum: 10c0/c4c6f1d95f6d465262de2037c57c715725d67e078dd49420ede4e19115668aba159cb64d85c5e89c06eb2826be599e62e5095860ad6cc54ff42e8bd7684e1db8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Automated dependency bump to address 5 disclosed CVEs across `ws`, `protobufjs`, and `protobufjs-cli`.

## What this PR fixes

| Package | From | To | Advisories closed |
|---|---|---|---|
| `ws` | `^8.13.0` | `^8.21.1` | GHSA-96hv-2xvq-fx4p (HIGH) + GHSA-58qx-3vcg-4xpx (MOD) |
| `protobufjs` | `^7.5.6` | `^7.6.5` | GHSA-wcpc-wj8m-hjx6 (HIGH) + GHSA-f38q-mgvj-vph7 (MOD) + GHSA-j3f2-48v5-ccww (MOD) |
| `protobufjs-cli` | `^1.1.3` | `^1.3.3` | GHSA-f38q-mgvj-vph7 (MOD) |

**OSV-confirmed clean:** `ws@8.21.1`, `protobufjs@7.6.5`, and `protobufjs-cli@1.3.3` all have zero remaining advisories in the OSV database.

## Advisory details

- **GHSA-96hv-2xvq-fx4p** (HIGH, CVE-2026-48779) — `ws`: Memory exhaustion DoS from tiny fragments and data chunks. Fixed in ws 8.21.0.
- **GHSA-58qx-3vcg-4xpx** (MODERATE, CVE-2026-45736) — `ws`: Uninitialized memory disclosure. Fixed in ws 8.20.1.
- **GHSA-wcpc-wj8m-hjx6** (HIGH, CVE-2026-48712) — `protobufjs`: Denial of service through unbounded `Any` expansion during JSON conversion. Fixed in 7.6.1.
- **GHSA-f38q-mgvj-vph7** (MODERATE, CVE-2026-54269) — `protobufjs` / `protobufjs-cli`: Schema-derived names can shadow runtime-significant properties. Fixed in protobufjs 7.6.3, protobufjs-cli 1.3.3.
- **GHSA-j3f2-48v5-ccww** (MODERATE, CVE-2026-59877) — `protobufjs`: Denial of service via infinite loop in `.proto` option parsing. Fixed in 7.6.5.

All bumps are within the current major version (`ws@8.x`, `protobufjs@7.x`, `protobufjs-cli@1.x`) and are lockfile + manifest updates only — no code changes.

## Residual — not fixed by this PR

**`protobufjs@7.5.8` (transitive via `libsignal@6.0.0`):** `libsignal` declares `protobufjs: "^7.5.5"`, which Yarn resolves to 7.5.8 in the lockfile. Since `libsignal@6.0.0` is the only published release and its protobufjs peer range can't be changed without a libsignal release, this transitive instance stays at 7.5.8 after this PR. Options: (a) add a `resolutions: { "protobufjs": "^7.6.5" }` override in `package.json` to force the transitive resolution, or (b) wait for a libsignal update. Happy to open a follow-up if (a) is preferred.

**`link-preview-js@3.2.0` (GHSA-4gp8-rjrq-ch6q, HIGH, CVE-2026-43897) — SSRF via IPv6 and internal loopback bypass:** The fix is only available in `link-preview-js@4.0.1+`, which is a breaking major release. This PR does **not** bump link-preview-js (a major bump would need API review). This PR closes 3 of 4 advisory classes; the link-preview-js SSRF is a separate follow-up.

## How this was detected

Detected by [osv-scanner 2.4.0](https://google.github.io/osv-scanner/) + manual OSV API version-query verification. Target versions confirmed clean before filing.

---
Filed by [Aeon](https://github.com/aeonframework/aeon).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `ws`, `protobufjs`, and `protobufjs-cli` to patched versions to close five CVEs and reduce DoS/memory disclosure risk. Manifest and lockfile only; no code changes.

- **Dependencies**
  - `ws` ^8.13.0 → ^8.21.1 (fixes GHSA-96hv-2xvq-fx4p, GHSA-58qx-3vcg-4xpx)
  - `protobufjs` ^7.5.6 → ^7.6.5 (fixes GHSA-wcpc-wj8m-hjx6, GHSA-f38q-mgvj-vph7, GHSA-j3f2-48v5-ccww)
  - `protobufjs-cli` ^1.1.3 → ^1.3.3 (fixes GHSA-f38q-mgvj-vph7)
  - Follow-ups: transitive `protobufjs@7.5.8` via `libsignal@6.0.0` remains (consider `resolutions: { "protobufjs": "^7.6.5" }`), and `link-preview-js@3.2.0` SSRF fix requires a major bump to `^4.0.1` in a separate PR.

<sup>Written for commit 7611d90193a72b29a30172a4a6afe00bbab4283a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supporting libraries to newer versions.
  * No user-facing features or behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->