### PR TITLE
fix: do not announce presence on partial creds.update

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -1051,11 +1051,13 @@ export const makeSocket = (config: SocketConfig) => {
 	ev.on('creds.update', update => {
 		const name = update.me?.name
 		// if name has just been received
-		if (creds.me?.name !== name) {
+		// a partial update carries no `me`, which is not a name change: announcing it
+		// sends a typeless <presence /> that reads as "available" and marks the account online
+		if (typeof name === 'string' && name.length > 0 && creds.me?.name !== name) {
 			logger.debug({ name }, 'updated pushName')
 			sendNode({
 				tag: 'presence',
-				attrs: { name: name! }
+				attrs: { name }
 			}).catch(err => {
 				logger.warn({ trace: err.stack }, 'error in sending presence update on name change')
 			})


### PR DESCRIPTION
Fixes the root cause behind #2553. The same diagnosis and the same one-line fix were posted in
#2627 and acknowledged there, but that issue was closed by the stale bot rather than applied, so
`master` still carries the code.

### The bug

`Socket/socket.ts` announces the push name on every `creds.update`:

```ts
const name = update.me?.name
if (creds.me?.name !== name) {
  sendNode({ tag: 'presence', attrs: { name: name! } })
```

A partial update carries no `me` — pre-key churn, and the updates emitted while handling incoming
messages — so `name` is `undefined`, and `creds.me?.name !== undefined` is `true` for any session
that has a stored push name. The `name!` assertion is precisely the assumption that fails.

What then goes out is a **typeless `<presence />`**: `encodeBinaryNode` filters out `undefined`
attributes, so nothing is left. And a presence without a type means available — the inbound
handler in `Socket/chats.ts` applies exactly that rule:

```ts
lastKnownPresence: attrs.type === 'unavailable' ? 'unavailable' : 'available'
```

The result is an account marked **online on ordinary credential churn, including once per
incoming message**, whatever `markOnlineOnConnect` is set to. Nothing is logged, because the send
succeeds. While the account is online, WhatsApp stops pushing notifications to the primary phone
— which is the symptom people actually report.

### Reproducing it without sending anything

Read-only client, `markOnlineOnConnect: false`, already paired:

1. Leave the primary phone locked and untouched; confirm from a third account that the number
   reads as offline.
2. Send a message to it from a second account.
3. The number goes online for several minutes, with the phone never opened. Repeating step 2
   keeps it online.

### The change

Guard on a non-empty string. Genuine push-name updates are still announced; partial credential
patches are not. The `!` assertion goes with it, since the guard now proves the type.

### Verification

- `npm install` (which runs `prepare` → `tsc -P tsconfig.build.json`) compiles clean.
- `prettier --check src/Socket/socket.ts` passes.
- I did not add a test: exercising this path means standing up the whole `makeSocket` factory, and
  I did not want to bolt fragile scaffolding onto an unfamiliar suite for a two-condition guard.
  Happy to add one if you would like it, in whatever shape you prefer.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop announcing presence on partial `creds.update` to prevent unintended “online” status and missed phone notifications. Only send a presence update when the push name actually changes.

- **Bug Fixes**
  - Guard in `src/Socket/socket.ts`: send presence only if `update.me?.name` is a non-empty string and differs from `creds.me?.name`.
  - Remove the non-null assertion and pass `name` directly to `attrs`.
  - Avoids sending a typeless `<presence />` on partial updates, which previously marked accounts as online during pre-key churn or incoming message handling.

<sup>Written for commit c9d5b42c4099d4ad298bec565d674251d7b674bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved presence updates by ignoring incomplete or empty name changes.
  * Prevented unnecessary presence notifications when the displayed name has not changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->