### PR TITLE
fix: advertise WIN_HYBRID instead of retired WIN32 web sub-platform

### DIFF
--- a/src/Utils/validate-connection.ts
+++ b/src/Utils/validate-connection.ts
@@ -37,7 +37,10 @@ const getUserAgent = (config: SocketConfig): proto.ClientPayload.IUserAgent => {
 
 const PLATFORM_MAP = {
 	'Mac OS': proto.ClientPayload.WebInfo.WebSubPlatform.DARWIN,
-	Windows: proto.ClientPayload.WebInfo.WebSubPlatform.WIN32
+	// WIN32 is the legacy Electron WhatsApp Desktop. Since ~2026-06-30 the server
+	// rejects the handshake that advertises it, closing with 428 before any QR is
+	// emitted. The modern native Desktop advertises WIN_HYBRID. See #2677.
+	Windows: proto.ClientPayload.WebInfo.WebSubPlatform.WIN_HYBRID
 }
 
 const getWebInfo = (config: SocketConfig): proto.ClientPayload.IWebInfo => {

--- a/src/Utils/validate-connection.ts
+++ b/src/Utils/validate-connection.ts
@@ -37,9 +37,6 @@ const getUserAgent = (config: SocketConfig): proto.ClientPayload.IUserAgent => {
 
 const PLATFORM_MAP = {
 	'Mac OS': proto.ClientPayload.WebInfo.WebSubPlatform.DARWIN,
-	// WIN32 is the legacy Electron WhatsApp Desktop. Since ~2026-06-30 the server
-	// rejects the handshake that advertises it, closing with 428 before any QR is
-	// emitted. The modern native Desktop advertises WIN_HYBRID. See #2677.
 	Windows: proto.ClientPayload.WebInfo.WebSubPlatform.WIN_HYBRID
 }
 


### PR DESCRIPTION
Fixes the 428-before-QR reported in #2677.

## Problem

Since ~2026-06-30 the WhatsApp server rejects the handshake whenever the client advertises `webInfo.webSubPlatform = WIN32`, closing the socket with **428 ~200–600ms after connect, before any QR is emitted** (no `<stream:error>`).

`WIN32` is the identity of the legacy **Electron** WhatsApp Desktop. The modern native Desktop advertises **`WIN_HYBRID` (5)** — a value that already exists in the proto (`ClientPayload.WebInfo.WebSubPlatform.WIN_HYBRID`) but that `PLATFORM_MAP` never selects, and which cannot be chosen through the public config either.

## Why this matters beyond the crash

A Desktop sub-platform is the **only** way to request full history sync: `getWebInfo()` only upgrades away from `WEB_BROWSER` when `browser[0]` is in `PLATFORM_MAP` and `browser[1] === 'Desktop'`. With the sub-platform gone, `syncFullHistory: true` silently degrades to recent history only.

So today `Browsers.windows('Desktop')` is not merely suboptimal — it makes the connection fail outright, and the documented path to full history sync has no working option.

## Empirical matrix

From #2677 (fresh device, varying only the advertised sub-platform), independently reproduced:

| `platform` + `webSubPlatform` | Result |
|---|---|
| `WEB` + `WIN32` (current) | ❌ 428 before QR |
| `WEB` + `DARWIN` | ❌ 428 before QR |
| `WEB` + `WIN_HYBRID (5)` | ✅ pairs |
| `WEB` + `WEB_BROWSER` | ✅ pairs |

Isolation was confirmed on an already-paired account by reconnecting while changing only `webSubPlatform`.

## Scope

`Mac OS` is deliberately left mapped to `DARWIN`. Reports indicate `DARWIN` only passes together with `platform: MACOS`, while `getUserAgent` hardcodes `platform: WEB` — that is a larger change and I have not validated it end to end. This PR fixes the Windows path only, which restores a working route to Desktop pairing.

## Verification

- `npm run build` (tsc) passes
- `npm test` — 407 tests, 28 suites, all passing
- `npm run lint` — identical to baseline on `master` (126 problems, 9 errors, all pre-existing)
- Verified against the real payload builder that `Browsers.windows('Desktop')` + `syncFullHistory: true` now yields `webSubPlatform = 5`, and that `syncFullHistory: false` still yields `WEB_BROWSER` (0), so nothing changes for non-Desktop callers

To be explicit about what is **not** verified here: I have not completed a real pairing against the server with this build. The checks above are build, tests, lint and payload inspection; the behavioural evidence for `WIN_HYBRID` comes from the reports in #2677, not from my own end-to-end run. I am rolling it out to a deployment where every session with `syncFullHistory: true` currently fails this way, and will report back.

Note the fix is one line — the rest of the diff is an explanatory comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 428-before-QR handshake failures on Windows by advertising `WIN_HYBRID` instead of the retired `WIN32`. Restores Desktop pairing and allows full history sync when `syncFullHistory: true`.

- **Bug Fixes**
  - Map `PLATFORM_MAP.Windows` to `proto.ClientPayload.WebInfo.WebSubPlatform.WIN_HYBRID`.
  - macOS stays `DARWIN`; Windows only.

<sup>Written for commit d36a7e7597e572d987228a7bb19f42809227b662. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

