### PR TITLE
fix(messages): decrypt encrypted message edits

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,11 @@
     "prepare": "npm run build",
     "preinstall": "node ./engine-requirements.js",
     "release": "release-it",
+    "smoke:live:edit": "tsx ./scripts/live-smoke/message-edit.ts",
     "test": "node --experimental-vm-modules ./node_modules/.bin/jest --testMatch '**/*.test.ts'",
+    "test:smoke:live:edit": "tsx --test ./scripts/live-smoke/*.test.ts",
     "test:e2e": "NODE_TLS_REJECT_UNAUTHORIZED=0 node --experimental-vm-modules ./node_modules/.bin/jest --runInBand --forceExit --testMatch '**/*.test-e2e.ts'",
+    "typecheck:smoke:live:edit": "tsc -p tsconfig.live-smoke.json",
     "update:version": "tsx ./scripts/update-version.ts"
   },
   "dependencies": {
@@ -58,6 +61,7 @@
     "@eslint/js": "^9.31.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^20.9.0",
+    "@types/qrcode-terminal": "^0.12.2",
     "@types/ws": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
@@ -78,6 +82,7 @@
     "pino-pretty": "^13.1.1",
     "prettier": "^3.5.3",
     "protobufjs-cli": "^1.1.3",
+    "qrcode-terminal": "^0.12.0",
     "release-it": "^20.0.1",
     "ts-jest": "^29.4.0",
     "tsc-esm-fix": "^3.1.2",

--- a/scripts/live-smoke/README.md
+++ b/scripts/live-smoke/README.md
@@ -1,0 +1,28 @@
+# Live message-edit smoke
+
+Run the manual message-edit smoke from an interactive terminal:
+
+```bash
+yarn smoke:live:edit
+```
+
+The command creates a linked-device session in an operating-system temporary directory and displays its QR code.
+The pairing is retained by default for eight hours after the last run, so repeated runs during one development
+session normally reconnect without another QR scan. After the connection opens, follow the two prompts:
+
+1. From your own WhatsApp number, type and send the exact synthetic message shown in the terminal, either in a
+   direct chat with the paired account or in a group containing both accounts.
+2. Edit that same message to different synthetic text and save it.
+
+The command reports the original and edited text, then exits successfully only if the encrypted edit path requested
+the original message and emitted a readable `messages.update` event for the same message ID.
+
+This command is manual, requires a TTY, and refuses to run in CI. It stores the original message only in memory.
+Authentication state is isolated per checkout outside the repository. Its directory is restricted to the current
+operating-system user, contained files are restricted to that user, symlinks are rejected, and concurrent runs are
+blocked. After eight idle hours the next run deletes the local state and requests a new pairing. The old linked-device
+entry may remain visible on the phone after local expiry and can be removed there.
+
+Use dedicated test accounts and synthetic text. Do not capture or share the QR code, authentication directory, phone
+numbers, message secrets, or protocol payloads. Filesystem permissions do not protect against malware or other
+processes already running as the same operating-system user, or against an administrator.

--- a/scripts/live-smoke/README.md
+++ b/scripts/live-smoke/README.md
@@ -10,8 +10,9 @@ The command creates a linked-device session in an operating-system temporary dir
 The pairing is retained by default for eight hours after the last run, so repeated runs during one development
 session normally reconnect without another QR scan. After the connection opens, follow the two prompts:
 
-1. From your own WhatsApp number, type and send the exact synthetic message shown in the terminal, either in a
-   direct chat with the paired account or in a group containing both accounts.
+1. From your phone's WhatsApp account, which must be separate from the account paired to the smoke client, type and
+   send the exact synthetic message shown in the terminal, either in a direct chat with the paired account or in a
+   group containing both accounts. Messages sent from the paired account itself are ignored.
 2. Edit that same message to different synthetic text and save it.
 
 The command reports the original and edited text, then exits successfully only if the encrypted edit path requested
@@ -22,6 +23,10 @@ Authentication state is isolated per checkout outside the repository. Its direct
 operating-system user, contained files are restricted to that user, symlinks are rejected, and concurrent runs are
 blocked. After eight idle hours the next run deletes the local state and requests a new pairing. The old linked-device
 entry may remain visible on the phone after local expiry and can be removed there.
+
+Socket protocol logging is disabled by default. Set `SMOKE_LOG_LEVEL` to a Pino level such as `debug` only when
+diagnosing a failed run. Protocol diagnostics can include account identifiers and payload metadata, so do not
+capture or share that output.
 
 Use dedicated test accounts and synthetic text. Do not capture or share the QR code, authentication directory, phone
 numbers, message secrets, or protocol payloads. Filesystem permissions do not protect against malware or other

--- a/scripts/live-smoke/auth-session.test.ts
+++ b/scripts/live-smoke/auth-session.test.ts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, readFile, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+import { AUTH_SESSION_RETENTION_MS, getRetainedAuthSessionRoot, openRetainedAuthSession } from './auth-session'
+
+const withTemporaryRoot = async (run: (root: string) => Promise<void>) => {
+	const root = await mkdtemp(join(tmpdir(), 'baileys-auth-session-test-'))
+	try {
+		await run(root)
+	} finally {
+		await rm(root, { recursive: true, force: true })
+	}
+}
+
+const permissions = async (path: string) => (await stat(path)).mode & 0o777
+
+describe('retained live-smoke authentication session', () => {
+	it('reuses recent credentials and restricts directory and file permissions', async () => {
+		await withTemporaryRoot(async tempRoot => {
+			let now = 1_725_000_000_000
+			const options = {
+				workspacePath: '/synthetic/worktree',
+				tempRoot,
+				now: () => now
+			}
+			const first = await openRetainedAuthSession(options)
+
+			assert.equal(first.reused, false)
+			assert.equal(first.expired, false)
+			assert.equal(await permissions(first.authDir), 0o700)
+
+			const credentialsPath = join(first.authDir, 'creds.json')
+			await writeFile(credentialsPath, '{}', { mode: 0o666 })
+			await first.secureAuthFiles()
+			await first.markUsed()
+			await first.release()
+
+			assert.equal(await permissions(credentialsPath), 0o600)
+			now += 60_000
+
+			const second = await openRetainedAuthSession(options)
+			assert.equal(second.reused, true)
+			assert.equal(second.expired, false)
+			assert.equal(await readFile(credentialsPath, 'utf8'), '{}')
+			await second.release()
+		})
+	})
+
+	it('expires credentials after eight idle hours', async () => {
+		await withTemporaryRoot(async tempRoot => {
+			let now = 1_725_000_000_000
+			const options = {
+				workspacePath: '/synthetic/expiring-worktree',
+				tempRoot,
+				now: () => now
+			}
+			const first = await openRetainedAuthSession(options)
+			const credentialsPath = join(first.authDir, 'creds.json')
+			await writeFile(credentialsPath, '{}')
+			await first.markUsed()
+			await first.release()
+
+			now += AUTH_SESSION_RETENTION_MS + 1
+			const second = await openRetainedAuthSession(options)
+			assert.equal(second.expired, true)
+			assert.equal(second.reused, false)
+			await assert.rejects(stat(credentialsPath), { code: 'ENOENT' })
+			await second.release()
+		})
+	})
+
+	it('expires credentials when the retained timestamp is in the future', async () => {
+		await withTemporaryRoot(async tempRoot => {
+			let now = 1_725_000_000_000
+			const options = {
+				workspacePath: '/synthetic/future-timestamp-worktree',
+				tempRoot,
+				now: () => now
+			}
+			const first = await openRetainedAuthSession(options)
+			await writeFile(join(first.authDir, 'creds.json'), '{}')
+			await first.markUsed()
+			await first.release()
+
+			now -= 1
+			const second = await openRetainedAuthSession(options)
+			assert.equal(second.expired, true)
+			await second.release()
+		})
+	})
+
+	it('blocks concurrent runs that target the same retained pairing', async () => {
+		await withTemporaryRoot(async tempRoot => {
+			const options = {
+				workspacePath: '/synthetic/locked-worktree',
+				tempRoot
+			}
+			const first = await openRetainedAuthSession(options)
+
+			await assert.rejects(openRetainedAuthSession(options), /already using the retained pairing/)
+			await first.release()
+
+			const next = await openRetainedAuthSession(options)
+			await next.release()
+		})
+	})
+
+	it('recovers a lock left by a process that is no longer running', async () => {
+		await withTemporaryRoot(async tempRoot => {
+			const workspacePath = '/synthetic/stale-lock-worktree'
+			const sessionRoot = getRetainedAuthSessionRoot(workspacePath, tempRoot)
+			await mkdir(sessionRoot, { mode: 0o700 })
+			await writeFile(
+				join(sessionRoot, 'active-run.lock'),
+				JSON.stringify({ pid: 2_147_483_647, token: 'stale-lock-token' }),
+				{ mode: 0o600 }
+			)
+
+			const session = await openRetainedAuthSession({ workspacePath, tempRoot })
+			await session.release()
+		})
+	})
+
+	it('recovers a malformed lock after its initialization grace period', async () => {
+		await withTemporaryRoot(async tempRoot => {
+			const workspacePath = '/synthetic/malformed-lock-worktree'
+			const sessionRoot = getRetainedAuthSessionRoot(workspacePath, tempRoot)
+			const lockPath = join(sessionRoot, 'active-run.lock')
+			await mkdir(sessionRoot, { mode: 0o700 })
+			await writeFile(lockPath, '')
+			await utimes(lockPath, new Date(0), new Date(0))
+
+			const session = await openRetainedAuthSession({ workspacePath, tempRoot })
+			await session.release()
+		})
+	})
+
+	it('refuses a retained-session root that is a symlink', async () => {
+		await withTemporaryRoot(async tempRoot => {
+			const workspacePath = '/synthetic/symlinked-worktree'
+			const target = join(tempRoot, 'attacker-controlled')
+			await mkdir(target)
+			await symlink(target, getRetainedAuthSessionRoot(workspacePath, tempRoot))
+
+			await assert.rejects(openRetainedAuthSession({ workspacePath, tempRoot }), /unsafe retained-auth directory/)
+		})
+	})
+})

--- a/scripts/live-smoke/auth-session.test.ts
+++ b/scripts/live-smoke/auth-session.test.ts
@@ -137,6 +137,19 @@ describe('retained live-smoke authentication session', () => {
 		})
 	})
 
+	it('does not remove a lock entry when reading it fails', async () => {
+		await withTemporaryRoot(async tempRoot => {
+			const workspacePath = '/synthetic/unreadable-lock-worktree'
+			const sessionRoot = getRetainedAuthSessionRoot(workspacePath, tempRoot)
+			const lockPath = join(sessionRoot, 'active-run.lock')
+			await mkdir(sessionRoot, { mode: 0o700 })
+			await mkdir(lockPath)
+
+			await assert.rejects(openRetainedAuthSession({ workspacePath, tempRoot }), { code: 'EISDIR' })
+			assert.equal((await stat(lockPath)).isDirectory(), true)
+		})
+	})
+
 	it('refuses a retained-session root that is a symlink', async () => {
 		await withTemporaryRoot(async tempRoot => {
 			const workspacePath = '/synthetic/symlinked-worktree'

--- a/scripts/live-smoke/auth-session.ts
+++ b/scripts/live-smoke/auth-session.ts
@@ -1,0 +1,270 @@
+import { createHash, randomBytes } from 'node:crypto'
+import { chmod, lstat, mkdir, open, readFile, readdir, rm, unlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+export const AUTH_SESSION_RETENTION_MS = 8 * 60 * 60 * 1000
+
+const AUTH_DIRECTORY_NAME = 'auth'
+const LAST_USED_FILE_NAME = 'last-used'
+const LOCK_FILE_NAME = 'active-run.lock'
+const SESSION_DIRECTORY_MODE = 0o700
+const SESSION_FILE_MODE = 0o600
+const LOCK_INITIALIZATION_GRACE_MS = 30_000
+
+type Clock = () => number
+
+type OpenRetainedAuthSessionOptions = {
+	workspacePath?: string
+	tempRoot?: string
+	retentionMs?: number
+	now?: Clock
+}
+
+type LockRecord = {
+	pid: number
+	token: string
+}
+
+export interface RetainedAuthSession {
+	authDir: string
+	expired: boolean
+	reused: boolean
+	markUsed: () => Promise<void>
+	reset: () => Promise<void>
+	secureAuthFiles: () => Promise<void>
+	release: () => Promise<void>
+}
+
+const isNodeError = (error: unknown): error is NodeJS.ErrnoException => error instanceof Error && 'code' in error
+
+const pathExists = async (path: string): Promise<boolean> => {
+	try {
+		await lstat(path)
+		return true
+	} catch (error) {
+		if (isNodeError(error) && error.code === 'ENOENT') {
+			return false
+		}
+
+		throw error
+	}
+}
+
+const ensureSecureDirectory = async (path: string): Promise<void> => {
+	try {
+		await mkdir(path, { mode: SESSION_DIRECTORY_MODE })
+	} catch (error) {
+		if (!(isNodeError(error) && error.code === 'EEXIST')) {
+			throw error
+		}
+	}
+
+	const info = await lstat(path)
+	if (info.isSymbolicLink() || !info.isDirectory()) {
+		throw new Error('Refusing to use an unsafe retained-auth directory')
+	}
+
+	await chmod(path, SESSION_DIRECTORY_MODE)
+}
+
+const secureTree = async (path: string): Promise<void> => {
+	const info = await lstat(path)
+	if (info.isSymbolicLink()) {
+		throw new Error('Refusing to follow a symlink in retained authentication state')
+	}
+
+	if (info.isDirectory()) {
+		await chmod(path, SESSION_DIRECTORY_MODE)
+		const entries = await readdir(path)
+		for (const entry of entries) {
+			try {
+				await secureTree(join(path, entry))
+			} catch (error) {
+				// Multi-file auth keys can be removed while another credentials update is being persisted.
+				if (!isNodeError(error) || error.code !== 'ENOENT') {
+					throw error
+				}
+			}
+		}
+		return
+	}
+
+	if (!info.isFile()) {
+		throw new Error('Refusing to retain an unsupported authentication-state entry')
+	}
+
+	await chmod(path, SESSION_FILE_MODE)
+}
+
+const processIsRunning = (pid: number): boolean => {
+	try {
+		process.kill(pid, 0)
+		return true
+	} catch (error) {
+		return !(isNodeError(error) && error.code === 'ESRCH')
+	}
+}
+
+const readLock = async (lockPath: string): Promise<LockRecord | undefined> => {
+	try {
+		const value = JSON.parse(await readFile(lockPath, 'utf8')) as Partial<LockRecord>
+		const pid = value.pid
+		return typeof pid === 'number' &&
+			Number.isSafeInteger(pid) &&
+			pid > 0 &&
+			typeof value.token === 'string' &&
+			value.token.length > 0
+			? { pid, token: value.token }
+			: undefined
+	} catch (error) {
+		if (isNodeError(error) && error.code === 'ENOENT') {
+			return
+		}
+
+		return
+	}
+}
+
+const acquireLock = async (lockPath: string): Promise<{ token: string; release: () => Promise<void> }> => {
+	const token = randomBytes(16).toString('hex')
+
+	for (let attempt = 0; attempt < 2; attempt++) {
+		try {
+			const handle = await open(lockPath, 'wx', SESSION_FILE_MODE)
+			try {
+				await handle.writeFile(JSON.stringify({ pid: process.pid, token }))
+			} finally {
+				await handle.close()
+			}
+
+			return {
+				token,
+				release: async () => {
+					const current = await readLock(lockPath)
+					if (current?.token === token) {
+						await unlink(lockPath).catch(error => {
+							if (!(isNodeError(error) && error.code === 'ENOENT')) {
+								throw error
+							}
+						})
+					}
+				}
+			}
+		} catch (error) {
+			if (!(isNodeError(error) && error.code === 'EEXIST')) {
+				throw error
+			}
+
+			const current = await readLock(lockPath)
+			if (!current) {
+				const lockInfo = await lstat(lockPath).catch(lockError => {
+					if (isNodeError(lockError) && lockError.code === 'ENOENT') {
+						return
+					}
+
+					throw lockError
+				})
+				if (!lockInfo) {
+					continue
+				}
+
+				if (Date.now() - lockInfo.mtimeMs <= LOCK_INITIALIZATION_GRACE_MS) {
+					throw new Error('Another message-edit smoke run is already using the retained pairing')
+				}
+			} else if (processIsRunning(current.pid)) {
+				throw new Error('Another message-edit smoke run is already using the retained pairing')
+			}
+
+			await unlink(lockPath).catch(unlinkError => {
+				if (!(isNodeError(unlinkError) && unlinkError.code === 'ENOENT')) {
+					throw unlinkError
+				}
+			})
+		}
+	}
+
+	throw new Error('Could not acquire the retained pairing lock')
+}
+
+const readLastUsed = async (path: string): Promise<number | undefined> => {
+	try {
+		const info = await lstat(path)
+		if (info.isSymbolicLink() || !info.isFile()) {
+			throw new Error('Refusing to read an unsafe retained-auth timestamp')
+		}
+
+		const value = Number(await readFile(path, 'utf8'))
+		return Number.isFinite(value) && value > 0 ? value : undefined
+	} catch (error) {
+		if (isNodeError(error) && error.code === 'ENOENT') {
+			return
+		}
+
+		throw error
+	}
+}
+
+export const getRetainedAuthSessionRoot = (workspacePath = process.cwd(), tempRoot = tmpdir()): string => {
+	const workspaceHash = createHash('sha256').update(workspacePath).digest('hex').slice(0, 16)
+	return join(tempRoot, `baileys-live-edit-${workspaceHash}`)
+}
+
+export const openRetainedAuthSession = async ({
+	workspacePath = process.cwd(),
+	tempRoot = tmpdir(),
+	retentionMs = AUTH_SESSION_RETENTION_MS,
+	now = Date.now
+}: OpenRetainedAuthSessionOptions = {}): Promise<RetainedAuthSession> => {
+	if (!Number.isFinite(retentionMs) || retentionMs <= 0) {
+		throw new Error('Retained pairing lifetime must be a positive number')
+	}
+
+	const sessionRoot = getRetainedAuthSessionRoot(workspacePath, tempRoot)
+	await ensureSecureDirectory(sessionRoot)
+	const lock = await acquireLock(join(sessionRoot, LOCK_FILE_NAME))
+
+	try {
+		const authDir = join(sessionRoot, AUTH_DIRECTORY_NAME)
+		const lastUsedPath = join(sessionRoot, LAST_USED_FILE_NAME)
+		await ensureSecureDirectory(authDir)
+		await secureTree(authDir)
+
+		const credentialsPath = join(authDir, 'creds.json')
+		const hasCredentials = await pathExists(credentialsPath)
+		const lastUsed = await readLastUsed(lastUsedPath)
+		const currentTime = now()
+		const expired = hasCredentials && (!lastUsed || lastUsed > currentTime || currentTime - lastUsed > retentionMs)
+
+		const reset = async () => {
+			await secureTree(authDir)
+			await rm(authDir, { recursive: true })
+			await ensureSecureDirectory(authDir)
+			await unlink(lastUsedPath).catch(error => {
+				if (!(isNodeError(error) && error.code === 'ENOENT')) {
+					throw error
+				}
+			})
+		}
+
+		if (expired) {
+			await reset()
+		}
+
+		return {
+			authDir,
+			expired,
+			reused: hasCredentials && !expired,
+			markUsed: async () => {
+				await writeFile(lastUsedPath, String(now()), { mode: SESSION_FILE_MODE })
+				await chmod(lastUsedPath, SESSION_FILE_MODE)
+			},
+			reset,
+			secureAuthFiles: () => secureTree(authDir),
+			release: lock.release
+		}
+	} catch (error) {
+		await lock.release()
+		throw error
+	}
+}

--- a/scripts/live-smoke/auth-session.ts
+++ b/scripts/live-smoke/auth-session.ts
@@ -107,8 +107,19 @@ const processIsRunning = (pid: number): boolean => {
 }
 
 const readLock = async (lockPath: string): Promise<LockRecord | undefined> => {
+	let raw: string
 	try {
-		const value = JSON.parse(await readFile(lockPath, 'utf8')) as Partial<LockRecord>
+		raw = await readFile(lockPath, 'utf8')
+	} catch (error) {
+		if (isNodeError(error) && error.code === 'ENOENT') {
+			return
+		}
+
+		throw error
+	}
+
+	try {
+		const value = JSON.parse(raw) as Partial<LockRecord>
 		const pid = value.pid
 		return typeof pid === 'number' &&
 			Number.isSafeInteger(pid) &&
@@ -117,11 +128,7 @@ const readLock = async (lockPath: string): Promise<LockRecord | undefined> => {
 			value.token.length > 0
 			? { pid, token: value.token }
 			: undefined
-	} catch (error) {
-		if (isNodeError(error) && error.code === 'ENOENT') {
-			return
-		}
-
+	} catch {
 		return
 	}
 }

--- a/scripts/live-smoke/message-edit-helpers.test.ts
+++ b/scripts/live-smoke/message-edit-helpers.test.ts
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { proto, type WAMessage, type WAMessageUpdate } from '../../src'
+import {
+	extractEditedText,
+	extractText,
+	findOriginalMessage,
+	hasUsableMessageSecret,
+	OriginalMessageLookup
+} from './message-edit-helpers'
+
+const originalText = '[EDIT-SMOKE-ABC123] before'
+const originalId = 'ORIGINAL-MESSAGE-ID'
+const originalMessage = (overrides: Partial<WAMessage> = {}): WAMessage =>
+	({
+		key: {
+			id: originalId,
+			remoteJid: '111111111111@s.whatsapp.net',
+			fromMe: false
+		},
+		message: {
+			conversation: originalText,
+			messageContextInfo: { messageSecret: Buffer.alloc(32, 7) }
+		},
+		...overrides
+	}) as WAMessage
+
+describe('message edit live-smoke helpers', () => {
+	it('extracts text through supported wrappers', () => {
+		assert.equal(extractText({ conversation: 'plain' }), 'plain')
+		assert.equal(
+			extractText({
+				ephemeralMessage: {
+					message: { extendedTextMessage: { text: 'wrapped' } }
+				}
+			}),
+			'wrapped'
+		)
+	})
+
+	it('selects the expected incoming direct message', () => {
+		assert.equal(
+			findOriginalMessage({ type: 'notify', messages: [originalMessage()] }, originalText)?.key.id,
+			originalId
+		)
+	})
+
+	it('selects the expected incoming group message', () => {
+		const groupMessage = originalMessage({
+			key: {
+				id: originalId,
+				remoteJid: '111111111111@g.us',
+				participant: '222222222222@s.whatsapp.net',
+				fromMe: false
+			}
+		})
+
+		assert.equal(findOriginalMessage({ type: 'notify', messages: [groupMessage] }, originalText), groupMessage)
+	})
+
+	it('ignores history, outgoing messages, broadcasts, newsletters, and different text', () => {
+		assert.equal(findOriginalMessage({ type: 'append', messages: [originalMessage()] }, originalText), undefined)
+		assert.equal(
+			findOriginalMessage(
+				{
+					type: 'notify',
+					messages: [
+						originalMessage({
+							key: { id: originalId, remoteJid: '111111111111@s.whatsapp.net', fromMe: true }
+						})
+					]
+				},
+				originalText
+			),
+			undefined
+		)
+		assert.equal(
+			findOriginalMessage(
+				{
+					type: 'notify',
+					messages: [
+						originalMessage({
+							key: { id: originalId, remoteJid: 'status@broadcast', fromMe: false }
+						}),
+						originalMessage({
+							key: { id: originalId, remoteJid: '111111111111@newsletter', fromMe: false }
+						})
+					]
+				},
+				originalText
+			),
+			undefined
+		)
+		assert.equal(findOriginalMessage({ type: 'notify', messages: [originalMessage()] }, 'different'), undefined)
+	})
+
+	it('requires a 32-byte original message secret', () => {
+		assert.equal(hasUsableMessageSecret(originalMessage()), true)
+		assert.equal(
+			hasUsableMessageSecret(
+				originalMessage({
+					message: {
+						conversation: originalText,
+						messageContextInfo: { messageSecret: Buffer.alloc(16) }
+					}
+				})
+			),
+			false
+		)
+	})
+
+	it('extracts readable edit text only for the original message id', () => {
+		const update: WAMessageUpdate = {
+			key: { id: originalId, remoteJid: '111111111111@s.whatsapp.net', fromMe: false },
+			update: {
+				message: {
+					editedMessage: {
+						message: { conversation: '[EDIT-SMOKE-ABC123] after' }
+					}
+				}
+			}
+		}
+
+		assert.equal(extractEditedText(update, originalId), '[EDIT-SMOKE-ABC123] after')
+		assert.equal(extractEditedText(update, 'OTHER-ID'), undefined)
+	})
+
+	it('returns the recorded original only for a matching getMessage key', async () => {
+		const lookup = new OriginalMessageLookup()
+		const original = originalMessage({
+			key: {
+				id: originalId,
+				remoteJid: '111111111111@g.us',
+				participant: '222222222222@s.whatsapp.net',
+				fromMe: false
+			}
+		})
+		lookup.record(original)
+
+		assert.equal(await lookup.getMessage({ id: 'OTHER-ID' }), undefined)
+		assert.equal(
+			await lookup.getMessage({
+				id: originalId,
+				remoteJid: '111111111111@g.us',
+				participant: '222222222222@s.whatsapp.net',
+				fromMe: false
+			}),
+			original.message
+		)
+		assert.equal(lookup.matchingLookupCount, 1)
+	})
+
+	it('accepts protobuf-created messages', () => {
+		const message = originalMessage({
+			message: proto.Message.create({
+				extendedTextMessage: { text: originalText },
+				messageContextInfo: { messageSecret: Buffer.alloc(32, 9) }
+			})
+		})
+
+		assert.equal(extractText(message.message), originalText)
+		assert.equal(hasUsableMessageSecret(message), true)
+	})
+})

--- a/scripts/live-smoke/message-edit-helpers.test.ts
+++ b/scripts/live-smoke/message-edit-helpers.test.ts
@@ -36,6 +36,14 @@ describe('message edit live-smoke helpers', () => {
 			}),
 			'wrapped'
 		)
+		assert.equal(
+			extractText({
+				associatedChildMessage: {
+					message: { conversation: 'shared helper wrapper' }
+				}
+			}),
+			'shared helper wrapper'
+		)
 	})
 
 	it('selects the expected incoming direct message', () => {

--- a/scripts/live-smoke/message-edit-helpers.ts
+++ b/scripts/live-smoke/message-edit-helpers.ts
@@ -1,0 +1,86 @@
+import type { proto, WAMessage, WAMessageKey, WAMessageUpdate } from '../../src'
+import { isJidBroadcast, isJidNewsletter } from '../../src'
+
+export interface MessageUpsert {
+	messages: WAMessage[]
+	type: 'append' | 'notify'
+}
+
+const innerMessage = (message: proto.IMessage): proto.IMessage | undefined =>
+	message.ephemeralMessage?.message ||
+	message.viewOnceMessage?.message ||
+	message.documentWithCaptionMessage?.message ||
+	message.viewOnceMessageV2?.message ||
+	message.viewOnceMessageV2Extension?.message ||
+	undefined
+
+export const extractText = (message: proto.IMessage | null | undefined): string | undefined => {
+	let content = message
+	for (let depth = 0; content && depth < 5; depth++) {
+		if (typeof content.conversation === 'string') {
+			return content.conversation
+		}
+
+		if (typeof content.extendedTextMessage?.text === 'string') {
+			return content.extendedTextMessage.text
+		}
+
+		content = innerMessage(content)
+	}
+
+	return undefined
+}
+
+const isSupportedIncomingMessage = (message: WAMessage): boolean => {
+	const remoteJid = message.key.remoteJid
+	return !!remoteJid && !message.key.fromMe && !isJidBroadcast(remoteJid) && !isJidNewsletter(remoteJid)
+}
+
+export const findOriginalMessage = (upsert: MessageUpsert, expectedText: string): WAMessage | undefined => {
+	if (upsert.type !== 'notify') {
+		return undefined
+	}
+
+	return upsert.messages.find(
+		message => isSupportedIncomingMessage(message) && !!message.key.id && extractText(message.message) === expectedText
+	)
+}
+
+export const hasUsableMessageSecret = (message: WAMessage): boolean => {
+	const secret = message.message?.messageContextInfo?.messageSecret
+	return secret instanceof Uint8Array && secret.byteLength === 32
+}
+
+export const extractEditedText = (update: WAMessageUpdate, originalMessageId: string): string | undefined => {
+	if (update.key.id !== originalMessageId) {
+		return undefined
+	}
+
+	return extractText(update.update.message?.editedMessage?.message)
+}
+
+export class OriginalMessageLookup {
+	private original: { id: string; message: proto.IMessage } | undefined
+	private matchingLookups = 0
+
+	record(original: WAMessage): void {
+		if (!original.key.id || !original.message) {
+			throw new Error('Original message is missing its key or content')
+		}
+
+		this.original = { id: original.key.id, message: original.message }
+	}
+
+	async getMessage(key: WAMessageKey): Promise<proto.IMessage | undefined> {
+		if (!key.id || key.id !== this.original?.id) {
+			return undefined
+		}
+
+		this.matchingLookups++
+		return this.original.message
+	}
+
+	get matchingLookupCount(): number {
+		return this.matchingLookups
+	}
+}

--- a/scripts/live-smoke/message-edit-helpers.ts
+++ b/scripts/live-smoke/message-edit-helpers.ts
@@ -1,34 +1,19 @@
 import type { proto, WAMessage, WAMessageKey, WAMessageUpdate } from '../../src'
 import { isJidBroadcast, isJidNewsletter } from '../../src'
+import { normalizeMessageContent } from '../../src/Utils/messages'
 
 export interface MessageUpsert {
 	messages: WAMessage[]
 	type: 'append' | 'notify'
 }
 
-const innerMessage = (message: proto.IMessage): proto.IMessage | undefined =>
-	message.ephemeralMessage?.message ||
-	message.viewOnceMessage?.message ||
-	message.documentWithCaptionMessage?.message ||
-	message.viewOnceMessageV2?.message ||
-	message.viewOnceMessageV2Extension?.message ||
-	undefined
-
 export const extractText = (message: proto.IMessage | null | undefined): string | undefined => {
-	let content = message
-	for (let depth = 0; content && depth < 5; depth++) {
-		if (typeof content.conversation === 'string') {
-			return content.conversation
-		}
-
-		if (typeof content.extendedTextMessage?.text === 'string') {
-			return content.extendedTextMessage.text
-		}
-
-		content = innerMessage(content)
+	const content = normalizeMessageContent(message)
+	if (typeof content?.conversation === 'string') {
+		return content.conversation
 	}
 
-	return undefined
+	return typeof content?.extendedTextMessage?.text === 'string' ? content.extendedTextMessage.text : undefined
 }
 
 const isSupportedIncomingMessage = (message: WAMessage): boolean => {

--- a/scripts/live-smoke/message-edit.ts
+++ b/scripts/live-smoke/message-edit.ts
@@ -1,0 +1,386 @@
+import { Boom } from '@hapi/boom'
+import { randomBytes } from 'node:crypto'
+import P from 'pino'
+import qrcode from 'qrcode-terminal'
+import makeWASocket, {
+	type BaileysEventMap,
+	Browsers,
+	DisconnectReason,
+	type WASocket,
+	type WAMessage,
+	useMultiFileAuthState
+} from '../../src'
+import {
+	extractEditedText,
+	findOriginalMessage,
+	hasUsableMessageSecret,
+	OriginalMessageLookup
+} from './message-edit-helpers'
+import { openRetainedAuthSession, type RetainedAuthSession } from './auth-session'
+
+const PAIRING_TIMEOUT_MS = 5 * 60 * 1000
+const OPERATOR_TIMEOUT_MS = 5 * 60 * 1000
+const MAX_CONNECTION_ATTEMPTS = 5
+
+const writeLine = (message = ''): void => {
+	process.stdout.write(`${message}\n`)
+}
+
+const writeError = (message: string): void => {
+	process.stderr.write(`${message}\n`)
+}
+
+const toError = (value: unknown): Error => (value instanceof Error ? value : new Error(String(value)))
+
+type Subscribe<T> = (resolve: (value: T) => void, reject: (error: Error) => void) => () => void
+
+const waitFor = <T>(label: string, timeoutMs: number, signal: AbortSignal, subscribe: Subscribe<T>): Promise<T> => {
+	if (signal.aborted) {
+		return Promise.reject(toError(signal.reason || 'Interrupted'))
+	}
+
+	return new Promise<T>((resolve, reject) => {
+		let settled = false
+		let unsubscribe: () => void = () => {}
+
+		const cleanup = () => {
+			clearTimeout(timer)
+			signal.removeEventListener('abort', onAbort)
+			unsubscribe()
+		}
+
+		const resolveOnce = (value: T) => {
+			if (settled) return
+			settled = true
+			cleanup()
+			resolve(value)
+		}
+
+		const rejectOnce = (error: Error) => {
+			if (settled) return
+			settled = true
+			cleanup()
+			reject(error)
+		}
+
+		const onAbort = () => rejectOnce(toError(signal.reason || 'Interrupted'))
+		const timer = setTimeout(() => rejectOnce(new Error(`Timed out waiting for ${label}`)), timeoutMs)
+
+		signal.addEventListener('abort', onAbort, { once: true })
+		try {
+			unsubscribe = subscribe(resolveOnce, rejectOnce)
+		} catch (error) {
+			rejectOnce(toError(error))
+		}
+	})
+}
+
+const disconnectReason = (lastDisconnect: { error?: unknown } | undefined): DisconnectReason | undefined => {
+	const error = lastDisconnect?.error
+	return error instanceof Boom ? error.output?.statusCode : undefined
+}
+
+const safeEnd = async (sock: WASocket): Promise<void> => {
+	try {
+		await sock.end(undefined)
+	} catch {
+		// The socket may already be closed after the pairing handoff.
+	}
+}
+
+class PairingLoggedOutError extends Error {}
+
+type ConnectionAttemptResult = 'open' | 'reconnect'
+
+const waitForConnectionAttempt = (
+	sock: WASocket,
+	signal: AbortSignal,
+	renderedQrs: Set<string>
+): Promise<ConnectionAttemptResult> =>
+	waitFor<ConnectionAttemptResult>('pairing and connection', PAIRING_TIMEOUT_MS, signal, (resolve, reject) => {
+		const handler = (update: BaileysEventMap['connection.update']) => {
+			if (update.qr && !renderedQrs.has(update.qr)) {
+				renderedQrs.add(update.qr)
+				writeLine()
+				writeLine('[PAIR] Scan this QR code with the WhatsApp account the smoke client will hold.')
+				qrcode.generate(update.qr, { small: true }, rendered => writeLine(rendered))
+			}
+
+			if (update.connection === 'open') {
+				resolve('open')
+				return
+			}
+
+			if (update.connection === 'close') {
+				const reason = disconnectReason(update.lastDisconnect)
+				if (reason === DisconnectReason.loggedOut) {
+					reject(new PairingLoggedOutError('The paired account logged out while connecting'))
+					return
+				}
+
+				resolve('reconnect')
+			}
+		}
+
+		sock.ev.on('connection.update', handler)
+		return () => sock.ev.off('connection.update', handler)
+	})
+
+interface ConnectedSocket {
+	sock: WASocket
+	saveCreds: () => Promise<void>
+}
+
+const connect = async (
+	authDir: string,
+	lookup: OriginalMessageLookup,
+	signal: AbortSignal,
+	secureAuthFiles: () => Promise<void>
+): Promise<ConnectedSocket> => {
+	const renderedQrs = new Set<string>()
+	const logger = P({ level: 'silent' })
+
+	for (let attempt = 1; attempt <= MAX_CONNECTION_ATTEMPTS; attempt++) {
+		const { state, saveCreds } = await useMultiFileAuthState(authDir)
+		const persistCreds = async () => {
+			await saveCreds()
+			await secureAuthFiles()
+		}
+		const sock = makeWASocket({
+			auth: state,
+			browser: Browsers.macOS('Message edit smoke'),
+			getMessage: key => lookup.getMessage(key),
+			logger,
+			markOnlineOnConnect: false,
+			syncFullHistory: false
+		})
+		sock.ev.on('creds.update', persistCreds)
+
+		let result: ConnectionAttemptResult
+		try {
+			result = await waitForConnectionAttempt(sock, signal, renderedQrs)
+		} catch (error) {
+			sock.ev.off('creds.update', persistCreds)
+			try {
+				await persistCreds()
+			} finally {
+				await safeEnd(sock)
+			}
+			throw error
+		}
+
+		if (result === 'open') {
+			try {
+				await persistCreds()
+				return { sock, saveCreds: persistCreds }
+			} catch (error) {
+				sock.ev.off('creds.update', persistCreds)
+				await safeEnd(sock)
+				throw error
+			}
+		}
+
+		sock.ev.off('creds.update', persistCreds)
+		try {
+			await persistCreds()
+		} finally {
+			await safeEnd(sock)
+		}
+		writeLine('[PAIR] Pairing handoff received; reconnecting the smoke client.')
+	}
+
+	throw new Error(`Could not establish a connection after ${MAX_CONNECTION_ATTEMPTS} attempts`)
+}
+
+const waitForOriginal = (sock: WASocket, expectedText: string, signal: AbortSignal): Promise<WAMessage> =>
+	waitFor<WAMessage>('your original message', OPERATOR_TIMEOUT_MS, signal, (resolve, reject) => {
+		const onUpsert = (upsert: BaileysEventMap['messages.upsert']) => {
+			const message = findOriginalMessage(upsert, expectedText)
+			if (!message) return
+
+			if (!hasUsableMessageSecret(message)) {
+				reject(new Error('The original message arrived without a usable 32-byte message secret'))
+				return
+			}
+
+			resolve(message)
+		}
+
+		const onConnection = (update: BaileysEventMap['connection.update']) => {
+			if (update.connection === 'close') {
+				reject(new Error('The connection closed while waiting for your original message'))
+			}
+		}
+
+		sock.ev.on('messages.upsert', onUpsert)
+		sock.ev.on('connection.update', onConnection)
+		return () => {
+			sock.ev.off('messages.upsert', onUpsert)
+			sock.ev.off('connection.update', onConnection)
+		}
+	})
+
+interface ReadableEdit {
+	text: string
+}
+
+const waitForEdit = (
+	sock: WASocket,
+	originalMessageId: string,
+	originalText: string,
+	signal: AbortSignal
+): Promise<ReadableEdit> =>
+	waitFor<ReadableEdit>('your readable message edit', OPERATOR_TIMEOUT_MS, signal, (resolve, reject) => {
+		const onUpdate = (updates: BaileysEventMap['messages.update']) => {
+			for (const update of updates) {
+				const text = extractEditedText(update, originalMessageId)
+				if (text === undefined) continue
+
+				if (text === originalText) {
+					reject(new Error('The edit event contained the original text unchanged'))
+					return
+				}
+
+				resolve({ text })
+				return
+			}
+		}
+
+		const onConnection = (update: BaileysEventMap['connection.update']) => {
+			if (update.connection === 'close') {
+				reject(new Error('The connection closed while waiting for your edit'))
+			}
+		}
+
+		sock.ev.on('messages.update', onUpdate)
+		sock.ev.on('connection.update', onConnection)
+		return () => {
+			sock.ev.off('messages.update', onUpdate)
+			sock.ev.off('connection.update', onConnection)
+		}
+	})
+
+const disconnect = async (connection: ConnectedSocket, session: RetainedAuthSession): Promise<void> => {
+	connection.sock.ev.off('creds.update', connection.saveCreds)
+	try {
+		await connection.saveCreds()
+	} finally {
+		await safeEnd(connection.sock)
+		await session.secureAuthFiles()
+	}
+}
+
+const assertInteractiveTerminal = (): void => {
+	if (process.env.CI && process.env.CI !== 'false') {
+		throw new Error('This manual live smoke refuses to run in CI')
+	}
+
+	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		throw new Error('This manual live smoke requires an interactive terminal')
+	}
+}
+
+const run = async (): Promise<void> => {
+	assertInteractiveTerminal()
+
+	const previousUmask = process.umask(0o077)
+	const abortController = new AbortController()
+	let interruptedExitCode = 1
+	const onSigint = () => {
+		interruptedExitCode = 130
+		abortController.abort(new Error('Interrupted by SIGINT'))
+	}
+	const onSigterm = () => {
+		interruptedExitCode = 143
+		abortController.abort(new Error('Interrupted by SIGTERM'))
+	}
+	process.once('SIGINT', onSigint)
+	process.once('SIGTERM', onSigterm)
+
+	const marker = randomBytes(3).toString('hex').toUpperCase()
+	const originalText = `[EDIT-SMOKE-${marker}] before`
+	const lookup = new OriginalMessageLookup()
+	let session: RetainedAuthSession | undefined
+	let connection: ConnectedSocket | undefined
+	let editedText: string | undefined
+
+	try {
+		session = await openRetainedAuthSession()
+		if (session.expired) {
+			writeLine('[SESSION] The previous local pairing expired; a new QR scan is required.')
+		} else if (session.reused) {
+			writeLine('[SESSION] Reusing the retained pairing for this development session.')
+		}
+
+		writeLine('[START] Opening a live message-edit smoke session.')
+		try {
+			connection = await connect(session.authDir, lookup, abortController.signal, session.secureAuthFiles)
+		} catch (error) {
+			if (!(error instanceof PairingLoggedOutError) || !session.reused) {
+				throw error
+			}
+
+			writeLine('[SESSION] The retained pairing is no longer valid; requesting a new pairing.')
+			await session.reset()
+			connection = await connect(session.authDir, lookup, abortController.signal, session.secureAuthFiles)
+		}
+		await session.markUsed()
+
+		writeLine()
+		writeLine('[READY] Connected.')
+		writeLine(
+			'[ACTION] On your phone, open either a direct chat with the paired account or a group containing both accounts.'
+		)
+		writeLine('[ACTION] Type and send this exact synthetic message:')
+		writeLine()
+		writeLine(`  ${originalText}`)
+		writeLine()
+		writeLine('[WAIT] Waiting for you to type and send the original message.')
+
+		const original = await waitForOriginal(connection.sock, originalText, abortController.signal)
+		lookup.record(original)
+		writeLine(`[ORIGINAL] ${JSON.stringify(originalText)}`)
+		writeLine('[ACTION] On your phone, edit that same message to any different synthetic text and save it.')
+		writeLine('[WAIT] Waiting for you to type and save the edit.')
+
+		const edit = await waitForEdit(connection.sock, original.key.id!, originalText, abortController.signal)
+		if (lookup.matchingLookupCount === 0) {
+			throw new Error('A readable edit arrived, but the encrypted edit path did not request the original message')
+		}
+		editedText = edit.text
+	} catch (error) {
+		if (abortController.signal.aborted) {
+			process.exitCode = interruptedExitCode
+		}
+		throw error
+	} finally {
+		process.removeListener('SIGINT', onSigint)
+		process.removeListener('SIGTERM', onSigterm)
+		try {
+			if (connection && session) {
+				await disconnect(connection, session)
+				await session.markUsed()
+			}
+		} finally {
+			try {
+				await session?.release()
+			} finally {
+				process.umask(previousUmask)
+			}
+		}
+	}
+
+	writeLine()
+	writeLine('[EDIT]')
+	writeLine(`  from: ${JSON.stringify(originalText)}`)
+	writeLine(`  to:   ${JSON.stringify(editedText)}`)
+	writeLine()
+	writeLine('[PASS] Original lookup, edit decryption, and messages.update completed successfully.')
+}
+
+run().catch(error => {
+	writeError(`[FAIL] ${toError(error).message}`)
+	if (!process.exitCode) {
+		process.exitCode = 1
+	}
+})

--- a/scripts/live-smoke/message-edit.ts
+++ b/scripts/live-smoke/message-edit.ts
@@ -1,5 +1,6 @@
 import { Boom } from '@hapi/boom'
 import { randomBytes } from 'node:crypto'
+import { setTimeout as delay } from 'node:timers/promises'
 import P from 'pino'
 import qrcode from 'qrcode-terminal'
 import makeWASocket, {
@@ -21,6 +22,7 @@ import { openRetainedAuthSession, type RetainedAuthSession } from './auth-sessio
 const PAIRING_TIMEOUT_MS = 5 * 60 * 1000
 const OPERATOR_TIMEOUT_MS = 5 * 60 * 1000
 const MAX_CONNECTION_ATTEMPTS = 5
+const CONNECTION_RETRY_DELAY_MS = 1000
 
 const writeLine = (message = ''): void => {
 	process.stdout.write(`${message}\n`)
@@ -138,7 +140,8 @@ const connect = async (
 	secureAuthFiles: () => Promise<void>
 ): Promise<ConnectedSocket> => {
 	const renderedQrs = new Set<string>()
-	const logger = P({ level: 'silent' })
+	// Protocol logs stay off by default because they can contain identifiers and payload metadata.
+	const logger = P({ level: process.env.SMOKE_LOG_LEVEL?.trim() || 'silent' })
 
 	for (let attempt = 1; attempt <= MAX_CONNECTION_ATTEMPTS; attempt++) {
 		const { state, saveCreds } = await useMultiFileAuthState(authDir)
@@ -186,7 +189,11 @@ const connect = async (
 		} finally {
 			await safeEnd(sock)
 		}
-		writeLine('[PAIR] Pairing handoff received; reconnecting the smoke client.')
+		if (attempt < MAX_CONNECTION_ATTEMPTS) {
+			const retryDelayMs = CONNECTION_RETRY_DELAY_MS * attempt
+			writeLine(`[PAIR] Pairing handoff received; reconnecting the smoke client in ${retryDelayMs / 1000} second(s).`)
+			await delay(retryDelayMs, undefined, { signal })
+		}
 	}
 
 	throw new Error(`Could not establish a connection after ${MAX_CONNECTION_ATTEMPTS} attempts`)

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -136,9 +136,8 @@ export type SocketConfig = {
 	/** options for HTTP fetch requests */
 	options: RequestInit
 	/**
-	 * fetch a message from your store
-	 * implement this so that messages failed to send
-	 * (solves the "this message can take a while" issue) can be retried
+	 * Fetch a message from your store.
+	 * Used to retry failed sends and to retrieve message secrets for encrypted updates.
 	 * */
 	getMessage: (key: WAMessageKey) => Promise<proto.IMessage | undefined>
 

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -344,7 +344,18 @@ export const decryptMessageNode = (
 							const outerMessage = { ...msg }
 							delete outerMessage.deviceSentMessage
 							// Linked-device messages can keep the messageSecret on the outer wrapper.
-							msg = { ...outerMessage, ...innerMessage }
+							msg = {
+								...outerMessage,
+								...innerMessage,
+								...(outerMessage.messageContextInfo || innerMessage.messageContextInfo
+									? {
+											messageContextInfo: {
+												...outerMessage.messageContextInfo,
+												...innerMessage.messageContextInfo
+											}
+										}
+									: {})
+							}
 						}
 
 						if (msg.senderKeyDistributionMessage) {

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -339,7 +339,14 @@ export const decryptMessageNode = (
 						let msg: proto.IMessage = proto.Message.decode(
 							e2eType !== 'plaintext' ? unpadRandomMax16(msgBuffer) : msgBuffer
 						)
-						msg = msg.deviceSentMessage?.message || msg
+						if (msg.deviceSentMessage?.message) {
+							const innerMessage = msg.deviceSentMessage.message
+							const outerMessage = { ...msg }
+							delete outerMessage.deviceSentMessage
+							// Linked-device messages can keep the messageSecret on the outer wrapper.
+							msg = { ...outerMessage, ...innerMessage }
+						}
+
 						if (msg.senderKeyDistributionMessage) {
 							//eslint-disable-next-line max-depth
 							try {

--- a/src/Utils/decrypt-message-edit.ts
+++ b/src/Utils/decrypt-message-edit.ts
@@ -199,7 +199,13 @@ export const processEncryptedMessageEdit = async ({
 	const receivedEditorCandidates = uniqueNormalizedJids(envelopeAuthorJids)
 	const receivedOriginalSenderCandidates = uniqueNormalizedJids(originalSenderJids)
 	if (!receivedEditorCandidates.length || !receivedOriginalSenderCandidates.length) {
-		logger.warn('cannot decrypt message edit without sender addressing')
+		logger.warn(
+			{
+				editorCandidateCount: receivedEditorCandidates.length,
+				originalSenderCandidateCount: receivedOriginalSenderCandidates.length
+			},
+			'cannot decrypt message edit without sender addressing'
+		)
 		return
 	}
 
@@ -237,7 +243,14 @@ export const processEncryptedMessageEdit = async ({
 		!protocolMessage.editedMessage ||
 		(protocolMessage.key?.id && protocolMessage.key.id !== targetKey.id)
 	) {
-		logger.warn('decrypted message edit contained an invalid protocol message')
+		logger.warn(
+			{
+				protocolType: protocolMessage?.type,
+				hasEditedMessage: !!protocolMessage?.editedMessage,
+				hasMatchingTarget: !protocolMessage?.key?.id || protocolMessage.key.id === targetKey.id
+			},
+			'decrypted message edit contained an invalid protocol message'
+		)
 		return
 	}
 

--- a/src/Utils/decrypt-message-edit.ts
+++ b/src/Utils/decrypt-message-edit.ts
@@ -1,0 +1,257 @@
+import { proto } from '../../WAProto/index.js'
+import type { SocketConfig, WAMessage, WAMessageKey, WAMessageUpdate } from '../Types'
+import { isHostedLidUser, isHostedPnUser, isLidUser, isPnUser, jidNormalizedUser } from '../WABinary'
+import { aesDecryptGCM, hmacSign } from './crypto'
+import { toNumber } from './generics'
+import type { ILogger } from './logger'
+
+type MessageEditContext = {
+	originalSenderJid: string
+	originalMsgId: string
+	messageSecret: Uint8Array
+	editorJid: string
+}
+
+type MessageEditLIDMapping = {
+	getLIDForPN: (pn: string) => Promise<string | null>
+	getPNForLID: (lid: string) => Promise<string | null>
+}
+
+type ProcessEncryptedMessageEditOptions = {
+	message: WAMessage
+	secretEncryptedMessage: proto.Message.ISecretEncryptedMessage
+	getMessage: SocketConfig['getMessage']
+	lidMapping: MessageEditLIDMapping
+	logger: ILogger
+	meId: string
+	meLid?: string
+}
+
+const isUserJid = (jid: string | null | undefined): jid is string =>
+	!!jid && !!(isPnUser(jid) || isLidUser(jid) || isHostedPnUser(jid) || isHostedLidUser(jid))
+
+const uniqueNormalizedJids = (jids: Array<string | null | undefined>): string[] => [
+	...new Set(jids.filter(isUserJid).map(jidNormalizedUser))
+]
+
+const expandAddressingCandidates = async (
+	jids: Array<string | null | undefined>,
+	lidMapping: MessageEditLIDMapping,
+	logger: ILogger
+): Promise<string[]> => {
+	const candidates = uniqueNormalizedJids(jids)
+	for (const jid of [...candidates]) {
+		try {
+			const alternate =
+				isLidUser(jid) || isHostedLidUser(jid) ? await lidMapping.getPNForLID(jid) : await lidMapping.getLIDForPN(jid)
+			if (isUserJid(alternate)) {
+				const normalized = jidNormalizedUser(alternate)
+				if (!candidates.includes(normalized)) {
+					candidates.push(normalized)
+				}
+			}
+		} catch (err) {
+			logger.debug({ err }, 'failed to resolve alternate addressing for message edit')
+		}
+	}
+
+	return candidates
+}
+
+const getLocalOriginalKey = (messageKey: WAMessageKey, originalMsgId: string): WAMessageKey => ({
+	...messageKey,
+	id: originalMsgId
+})
+
+const getEnvelopeAuthorJids = (message: WAMessage, meId: string, meLid?: string) =>
+	message.key.fromMe
+		? [meId, meLid]
+		: [message.key.participant, message.key.participantAlt, message.key.remoteJid, message.key.remoteJidAlt]
+
+const getOriginalSenderJids = (
+	message: WAMessage,
+	targetKey: WAMessageKey,
+	envelopeAuthorJids: Array<string | null | undefined>
+) => {
+	if (targetKey.fromMe) {
+		return envelopeAuthorJids
+	}
+
+	return isUserJid(message.key.remoteJid) ? [targetKey.remoteJid] : [targetKey.participant]
+}
+
+const decryptWithJidCandidates = (
+	secretEncryptedMessage: proto.Message.ISecretEncryptedMessage,
+	originalMsgId: string,
+	messageSecret: Uint8Array,
+	originalSenderCandidates: string[],
+	editorCandidates: string[]
+): { decoded?: proto.Message; lastError?: unknown } => {
+	let lastError: unknown
+	for (const originalSenderJid of originalSenderCandidates) {
+		for (const editorJid of editorCandidates) {
+			try {
+				return {
+					decoded: decryptMessageEdit(secretEncryptedMessage, {
+						originalSenderJid,
+						originalMsgId,
+						messageSecret,
+						editorJid
+					})
+				}
+			} catch (err) {
+				lastError = err
+			}
+		}
+	}
+
+	return { lastError }
+}
+
+export const isEncryptedMessageEdit = (
+	content: proto.IMessage | null | undefined
+): content is proto.IMessage & { secretEncryptedMessage: proto.Message.ISecretEncryptedMessage } =>
+	content?.secretEncryptedMessage?.secretEncType === proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT
+
+/**
+ * MESSAGE_EDIT uses the same single-block HKDF-SHA256 construction as other
+ * encrypted add-ons, but binds the edit identities in the info and uses empty AAD.
+ */
+export const decryptMessageEdit = (
+	{ encPayload, encIv }: proto.Message.ISecretEncryptedMessage,
+	{ originalSenderJid, originalMsgId, messageSecret, editorJid }: MessageEditContext
+): proto.Message => {
+	if (messageSecret.byteLength !== 32) {
+		throw new Error(`Invalid MESSAGE_EDIT message secret length: expected 32, got ${messageSecret.byteLength}`)
+	}
+
+	if (!encPayload?.length) {
+		throw new Error('Invalid MESSAGE_EDIT payload: missing encrypted content')
+	}
+
+	if (encIv?.length !== 12) {
+		throw new Error(`Invalid MESSAGE_EDIT IV length: expected 12, got ${encIv?.length ?? 0}`)
+	}
+
+	const info = Buffer.concat([
+		Buffer.from(originalMsgId),
+		Buffer.from(originalSenderJid),
+		Buffer.from(editorJid),
+		Buffer.from('Message Edit'),
+		new Uint8Array([1])
+	])
+	const extractedKey = hmacSign(messageSecret, new Uint8Array(32), 'sha256')
+	const decryptionKey = hmacSign(info, extractedKey, 'sha256')
+	const plaintext = aesDecryptGCM(encPayload, decryptionKey, encIv, new Uint8Array(0))
+
+	return proto.Message.decode(plaintext)
+}
+
+export const processEncryptedMessageEdit = async ({
+	message,
+	secretEncryptedMessage,
+	getMessage,
+	lidMapping,
+	logger,
+	meId,
+	meLid
+}: ProcessEncryptedMessageEditOptions): Promise<WAMessageUpdate | undefined> => {
+	const targetKey = secretEncryptedMessage.targetMessageKey
+	if (
+		secretEncryptedMessage.secretEncType !== proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT ||
+		!targetKey?.id ||
+		!secretEncryptedMessage.encPayload?.length ||
+		secretEncryptedMessage.encIv?.length !== 12
+	) {
+		logger.warn(
+			{
+				hasExpectedType:
+					secretEncryptedMessage.secretEncType === proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT,
+				hasTargetId: !!targetKey?.id,
+				hasPayload: !!secretEncryptedMessage.encPayload?.length,
+				ivLength: secretEncryptedMessage.encIv?.length
+			},
+			'invalid encrypted message edit envelope'
+		)
+		return
+	}
+
+	const originalKey = getLocalOriginalKey(message.key, targetKey.id)
+	let originalMessage: proto.IMessage | undefined
+	try {
+		originalMessage = await getMessage(originalKey)
+	} catch (err) {
+		logger.warn({ err }, 'failed to retrieve the original message for edit decryption')
+		return
+	}
+
+	const messageSecret = originalMessage?.messageContextInfo?.messageSecret
+	if (!(messageSecret instanceof Uint8Array) || messageSecret.byteLength !== 32) {
+		logger.warn(
+			{ foundOriginal: !!originalMessage, secretLength: messageSecret?.byteLength },
+			'cannot decrypt message edit without the original message secret'
+		)
+		return
+	}
+
+	const envelopeAuthorJids = getEnvelopeAuthorJids(message, meId, meLid)
+	const originalSenderJids = getOriginalSenderJids(message, targetKey, envelopeAuthorJids)
+	const receivedEditorCandidates = uniqueNormalizedJids(envelopeAuthorJids)
+	const receivedOriginalSenderCandidates = uniqueNormalizedJids(originalSenderJids)
+	if (!receivedEditorCandidates.length || !receivedOriginalSenderCandidates.length) {
+		logger.warn('cannot decrypt message edit without sender addressing')
+		return
+	}
+
+	let { decoded, lastError } = decryptWithJidCandidates(
+		secretEncryptedMessage,
+		targetKey.id,
+		messageSecret,
+		receivedOriginalSenderCandidates,
+		receivedEditorCandidates
+	)
+	if (!decoded) {
+		const [expandedOriginalSenderCandidates, expandedEditorCandidates] = await Promise.all([
+			expandAddressingCandidates(originalSenderJids, lidMapping, logger),
+			expandAddressingCandidates(envelopeAuthorJids, lidMapping, logger)
+		])
+		const retry = decryptWithJidCandidates(
+			secretEncryptedMessage,
+			targetKey.id,
+			messageSecret,
+			expandedOriginalSenderCandidates,
+			expandedEditorCandidates
+		)
+		decoded = retry.decoded
+		lastError = retry.lastError
+	}
+
+	if (!decoded) {
+		logger.warn({ err: lastError }, 'failed to decrypt encrypted message edit')
+		return
+	}
+
+	const protocolMessage = decoded.protocolMessage
+	if (
+		protocolMessage?.type !== proto.Message.ProtocolMessage.Type.MESSAGE_EDIT ||
+		!protocolMessage.editedMessage ||
+		(protocolMessage.key?.id && protocolMessage.key.id !== targetKey.id)
+	) {
+		logger.warn('decrypted message edit contained an invalid protocol message')
+		return
+	}
+
+	return {
+		key: originalKey,
+		update: {
+			message: {
+				editedMessage: {
+					message: protocolMessage.editedMessage
+				}
+			},
+			messageTimestamp: protocolMessage.timestampMs
+				? Math.floor(toNumber(protocolMessage.timestampMs) / 1000)
+				: message.messageTimestamp
+		}
+	}
+}

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -31,6 +31,7 @@ import {
 	jidNormalizedUser
 } from '../WABinary'
 import { aesDecryptGCM, hmacSign } from './crypto'
+import { isEncryptedMessageEdit, processEncryptedMessageEdit } from './decrypt-message-edit'
 import { getKeyAuthor, toNumber } from './generics'
 import { downloadAndProcessHistorySyncNotification } from './history'
 import type { ILogger } from './logger'
@@ -42,7 +43,7 @@ type ProcessMessageContext = {
 	creds: AuthenticationCreds
 	keyStore: SignalKeyStoreWithTransaction
 	ev: BaileysEventEmitter
-	logger?: ILogger
+	logger: ILogger
 	options: RequestInit
 	signalRepository: SignalRepositoryWithLIDStore
 	getMessage: SocketConfig['getMessage']
@@ -178,7 +179,8 @@ export const isRealMessage = (message: WAMessage) => {
 		hasSomeContent &&
 		!normalizedContent?.protocolMessage &&
 		!normalizedContent?.reactionMessage &&
-		!normalizedContent?.pollUpdateMessage
+		!normalizedContent?.pollUpdateMessage &&
+		!isEncryptedMessageEdit(normalizedContent)
 	)
 }
 
@@ -623,6 +625,19 @@ const processMessage = async (
 			}
 		} else {
 			logger?.warn({ creationMsgKey }, 'event creation message not found, cannot decrypt response')
+		}
+	} else if (isEncryptedMessageEdit(content)) {
+		const update = await processEncryptedMessageEdit({
+			message,
+			secretEncryptedMessage: content.secretEncryptedMessage,
+			getMessage,
+			lidMapping: signalRepository.lidMapping,
+			logger,
+			meId,
+			meLid: creds.me?.lid
+		})
+		if (update) {
+			ev.emit('messages.update', [update])
 		}
 	} else if (message.messageStubType) {
 		const jid = message.key?.remoteJid!

--- a/src/Utils/process-message.ts
+++ b/src/Utils/process-message.ts
@@ -627,17 +627,21 @@ const processMessage = async (
 			logger?.warn({ creationMsgKey }, 'event creation message not found, cannot decrypt response')
 		}
 	} else if (isEncryptedMessageEdit(content)) {
-		const update = await processEncryptedMessageEdit({
-			message,
-			secretEncryptedMessage: content.secretEncryptedMessage,
-			getMessage,
-			lidMapping: signalRepository.lidMapping,
-			logger,
-			meId,
-			meLid: creds.me?.lid
-		})
-		if (update) {
-			ev.emit('messages.update', [update])
+		try {
+			const update = await processEncryptedMessageEdit({
+				message,
+				secretEncryptedMessage: content.secretEncryptedMessage,
+				getMessage,
+				lidMapping: signalRepository.lidMapping,
+				logger,
+				meId,
+				meLid: creds.me?.lid
+			})
+			if (update) {
+				ev.emit('messages.update', [update])
+			}
+		} catch (err) {
+			logger.warn({ err, msgId: message.key.id }, 'failed to process encrypted message edit')
 		}
 	} else if (message.messageStubType) {
 		const jid = message.key?.remoteJid!

--- a/src/__tests__/Utils/decode-wa-message.test.ts
+++ b/src/__tests__/Utils/decode-wa-message.test.ts
@@ -1,5 +1,8 @@
 import { Boom } from '@hapi/boom'
-import { decodeMessageNode } from '../../Utils/decode-wa-message'
+import { proto } from '../../../WAProto/index.js'
+import type { SignalRepositoryWithLIDStore } from '../../Types/Signal'
+import { decodeMessageNode, decryptMessageNode } from '../../Utils/decode-wa-message'
+import type { ILogger } from '../../Utils/logger'
 import type { BinaryNode } from '../../WABinary'
 
 const ME_ID = '5511999999999@s.whatsapp.net'
@@ -12,6 +15,27 @@ const message = (attrs: Record<string, string>): BinaryNode => ({
 	attrs: { t: '1700000000', ...attrs },
 	content: []
 })
+
+const plaintextMessage = (content: proto.IMessage): BinaryNode => ({
+	...message({ id: 'PLAINTEXT_MESSAGE', from: PEER_ID }),
+	content: [
+		{
+			tag: 'plaintext',
+			attrs: {},
+			content: proto.Message.encode(proto.Message.create(content)).finish()
+		}
+	]
+})
+
+const repository = {
+	lidMapping: {
+		getLIDForPN: async () => null
+	}
+} as unknown as SignalRepositoryWithLIDStore
+
+const logger = {
+	error: () => undefined
+} as unknown as ILogger
 
 const captureThrow = (fn: () => unknown): unknown => {
 	try {
@@ -82,5 +106,67 @@ describe('decodeMessageNode', () => {
 			expect(result.fullMessage.key.participant).toBe(PEER_ID)
 			expect(result.author).toBe(PEER_ID)
 		})
+	})
+})
+
+describe('decryptMessageNode', () => {
+	it('preserves an outer message secret when unwrapping a device-sent message', async () => {
+		const messageSecret = Buffer.alloc(32, 7)
+		const result = decryptMessageNode(
+			plaintextMessage({
+				deviceSentMessage: {
+					message: { conversation: 'linked-device message' }
+				},
+				messageContextInfo: { messageSecret }
+			}),
+			ME_ID,
+			ME_LID,
+			repository,
+			logger
+		)
+
+		await result.decrypt()
+
+		expect(result.fullMessage.message?.conversation).toBe('linked-device message')
+		expect(result.fullMessage.message?.messageContextInfo?.messageSecret).toEqual(messageSecret)
+		expect(result.fullMessage.message?.deviceSentMessage).toBeUndefined()
+	})
+
+	it('prefers inner fields when both device-sent layers provide message context', async () => {
+		const outerSecret = Buffer.alloc(32, 7)
+		const innerSecret = Buffer.alloc(32, 9)
+		const result = decryptMessageNode(
+			plaintextMessage({
+				deviceSentMessage: {
+					message: {
+						conversation: 'linked-device message',
+						messageContextInfo: { messageSecret: innerSecret }
+					}
+				},
+				messageContextInfo: { messageSecret: outerSecret }
+			}),
+			ME_ID,
+			ME_LID,
+			repository,
+			logger
+		)
+
+		await result.decrypt()
+
+		expect(result.fullMessage.message?.messageContextInfo?.messageSecret).toEqual(innerSecret)
+	})
+
+	it('leaves messages without a device-sent wrapper unchanged', async () => {
+		const messageSecret = Buffer.alloc(32, 5)
+		const originalMessage = {
+			conversation: 'ordinary message',
+			messageContextInfo: { messageSecret }
+		}
+		const decodedMessage = proto.Message.decode(proto.Message.encode(proto.Message.create(originalMessage)).finish())
+		const result = decryptMessageNode(plaintextMessage(originalMessage), ME_ID, ME_LID, repository, logger)
+
+		await result.decrypt()
+
+		expect(result.fullMessage.message).toEqual(decodedMessage)
 	})
 })

--- a/src/__tests__/Utils/decode-wa-message.test.ts
+++ b/src/__tests__/Utils/decode-wa-message.test.ts
@@ -132,6 +132,30 @@ describe('decryptMessageNode', () => {
 		expect(result.fullMessage.message?.deviceSentMessage).toBeUndefined()
 	})
 
+	it('merges an outer message secret with inner message context fields', async () => {
+		const messageSecret = Buffer.alloc(32, 7)
+		const result = decryptMessageNode(
+			plaintextMessage({
+				deviceSentMessage: {
+					message: {
+						conversation: 'linked-device message',
+						messageContextInfo: { messageAddOnDurationInSecs: 900 }
+					}
+				},
+				messageContextInfo: { messageSecret }
+			}),
+			ME_ID,
+			ME_LID,
+			repository,
+			logger
+		)
+
+		await result.decrypt()
+
+		expect(result.fullMessage.message?.messageContextInfo?.messageSecret).toEqual(messageSecret)
+		expect(result.fullMessage.message?.messageContextInfo?.messageAddOnDurationInSecs).toBe(900)
+	})
+
 	it('prefers inner fields when both device-sent layers provide message context', async () => {
 		const outerSecret = Buffer.alloc(32, 7)
 		const innerSecret = Buffer.alloc(32, 9)

--- a/src/__tests__/Utils/decrypt-message-edit.test.ts
+++ b/src/__tests__/Utils/decrypt-message-edit.test.ts
@@ -1,0 +1,664 @@
+import { jest } from '@jest/globals'
+import { createCipheriv, hkdfSync } from 'node:crypto'
+import { proto } from '../../../WAProto/index.js'
+import type {
+	AuthenticationCreds,
+	BaileysEventEmitter,
+	SignalKeyStoreWithTransaction,
+	SignalRepositoryWithLIDStore,
+	SocketConfig,
+	WAMessage,
+	WAMessageKey,
+	WAMessageUpdate
+} from '../../Types'
+import { decryptMessageEdit, processEncryptedMessageEdit } from '../../Utils/decrypt-message-edit'
+import type { ILogger } from '../../Utils/logger'
+import processMessage from '../../Utils/process-message'
+
+const ORIGINAL_ID = 'ORIGINAL-MESSAGE-ID'
+const ENVELOPE_ID = 'EDIT-ENVELOPE-ID'
+const DIRECT_AUTHOR_PN = '111111111111@s.whatsapp.net'
+const DIRECT_AUTHOR_LID = '222222222222@lid'
+const LOCAL_PN = '333333333333@s.whatsapp.net'
+const LOCAL_LID = '444444444444@lid'
+const GROUP_JID = '120363000000000000@g.us'
+const MESSAGE_SECRET = Buffer.from(Array.from({ length: 32 }, (_, index) => index + 1))
+const EDIT_IV = Buffer.from('000102030405060708090a0b', 'hex')
+
+const createMockLogger = (): ILogger =>
+	({
+		warn: jest.fn(),
+		info: jest.fn(),
+		debug: jest.fn(),
+		error: jest.fn(),
+		trace: jest.fn(),
+		child: jest.fn(function (this: ILogger) {
+			return this
+		}),
+		level: 'silent'
+	}) as unknown as ILogger
+
+const createLidMapping = (mappings: Record<string, string> = {}) => ({
+	getLIDForPN: jest.fn<(jid: string) => Promise<string | null>>(async jid => mappings[jid] || null),
+	getPNForLID: jest.fn<(jid: string) => Promise<string | null>>(async jid => mappings[jid] || null)
+})
+
+const encryptWithNodeHkdf = (
+	plaintext: Uint8Array,
+	originalSenderJid: string,
+	editorJid: string,
+	messageSecret: Uint8Array = MESSAGE_SECRET,
+	iv: Uint8Array = EDIT_IV
+) => {
+	const info = Buffer.concat([
+		Buffer.from(ORIGINAL_ID),
+		Buffer.from(originalSenderJid),
+		Buffer.from(editorJid),
+		Buffer.from('Message Edit')
+	])
+	const key = Buffer.from(hkdfSync('sha256', messageSecret, Buffer.alloc(32), info, 32))
+	const cipher = createCipheriv('aes-256-gcm', key, iv)
+	cipher.setAAD(Buffer.alloc(0))
+
+	return Buffer.concat([cipher.update(plaintext), cipher.final(), cipher.getAuthTag()])
+}
+
+const sealProtocolMessage = ({
+	originalSenderJid,
+	editorJid,
+	editedText,
+	targetKey,
+	protocolType = proto.Message.ProtocolMessage.Type.MESSAGE_EDIT,
+	embeddedTargetId = ORIGINAL_ID,
+	messageSecret = MESSAGE_SECRET,
+	timestampMs = 1_725_000_000_000
+}: {
+	originalSenderJid: string
+	editorJid: string
+	editedText: string
+	targetKey: WAMessageKey
+	protocolType?: proto.Message.ProtocolMessage.Type
+	embeddedTargetId?: string
+	messageSecret?: Uint8Array
+	timestampMs?: number
+}): proto.Message.ISecretEncryptedMessage => {
+	const plaintext = proto.Message.encode(
+		proto.Message.create({
+			protocolMessage: {
+				key: { ...targetKey, id: embeddedTargetId },
+				type: protocolType,
+				editedMessage: { conversation: editedText },
+				timestampMs
+			}
+		})
+	).finish()
+
+	return proto.Message.SecretEncryptedMessage.create({
+		targetMessageKey: targetKey,
+		encPayload: encryptWithNodeHkdf(plaintext, originalSenderJid, editorJid, messageSecret),
+		encIv: EDIT_IV,
+		secretEncType: proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT
+	})
+}
+
+const createEnvelope = (
+	key: WAMessageKey,
+	secretEncryptedMessage: proto.Message.ISecretEncryptedMessage
+): WAMessage => ({
+	key: { ...key, id: ENVELOPE_ID },
+	message: { secretEncryptedMessage },
+	messageTimestamp: 1_725_000_001
+})
+
+const originalMessage = (messageSecret: Uint8Array = MESSAGE_SECRET): proto.IMessage => ({
+	conversation: 'before',
+	messageContextInfo: { messageSecret }
+})
+
+const getEditedText = (update: WAMessageUpdate | undefined) =>
+	update?.update.message?.editedMessage?.message?.conversation
+
+describe('decryptMessageEdit', () => {
+	it('decrypts a protocol message encrypted with an independent HKDF implementation', () => {
+		const targetKey = { id: ORIGINAL_ID, remoteJid: LOCAL_PN, fromMe: true }
+		const encrypted = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_PN,
+			editorJid: DIRECT_AUTHOR_PN,
+			editedText: 'after',
+			targetKey
+		})
+
+		const decoded = decryptMessageEdit(encrypted, {
+			originalSenderJid: DIRECT_AUTHOR_PN,
+			originalMsgId: ORIGINAL_ID,
+			messageSecret: MESSAGE_SECRET,
+			editorJid: DIRECT_AUTHOR_PN
+		})
+
+		expect(decoded.protocolMessage?.type).toBe(proto.Message.ProtocolMessage.Type.MESSAGE_EDIT)
+		expect(decoded.protocolMessage?.editedMessage?.conversation).toBe('after')
+	})
+
+	it('rejects an incorrect editor identity', () => {
+		const targetKey = { id: ORIGINAL_ID, remoteJid: LOCAL_PN, fromMe: true }
+		const encrypted = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_PN,
+			editorJid: DIRECT_AUTHOR_PN,
+			editedText: 'after',
+			targetKey
+		})
+
+		expect(() =>
+			decryptMessageEdit(encrypted, {
+				originalSenderJid: DIRECT_AUTHOR_PN,
+				originalMsgId: ORIGINAL_ID,
+				messageSecret: MESSAGE_SECRET,
+				editorJid: '555555555555@s.whatsapp.net'
+			})
+		).toThrow()
+	})
+
+	it('rejects malformed IV and message-secret lengths before decryption', () => {
+		const targetKey = { id: ORIGINAL_ID, remoteJid: LOCAL_PN, fromMe: true }
+		const encrypted = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_PN,
+			editorJid: DIRECT_AUTHOR_PN,
+			editedText: 'after',
+			targetKey
+		})
+
+		expect(() =>
+			decryptMessageEdit(
+				{ ...encrypted, encIv: Buffer.alloc(11) },
+				{
+					originalSenderJid: DIRECT_AUTHOR_PN,
+					originalMsgId: ORIGINAL_ID,
+					messageSecret: MESSAGE_SECRET,
+					editorJid: DIRECT_AUTHOR_PN
+				}
+			)
+		).toThrow(/IV length/)
+		expect(() =>
+			decryptMessageEdit(encrypted, {
+				originalSenderJid: DIRECT_AUTHOR_PN,
+				originalMsgId: ORIGINAL_ID,
+				messageSecret: Buffer.alloc(31),
+				editorJid: DIRECT_AUTHOR_PN
+			})
+		).toThrow(/secret length/)
+	})
+})
+
+describe('processEncryptedMessageEdit', () => {
+	it('decrypts a direct-message edit and looks up the original from the local perspective', async () => {
+		const targetKey = { id: ORIGINAL_ID, remoteJid: LOCAL_PN, fromMe: true }
+		const encrypted = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_PN,
+			editorJid: DIRECT_AUTHOR_PN,
+			editedText: 'direct after',
+			targetKey
+		})
+		const message = createEnvelope(
+			{
+				remoteJid: DIRECT_AUTHOR_PN,
+				remoteJidAlt: DIRECT_AUTHOR_LID,
+				fromMe: false,
+				id: ENVELOPE_ID
+			},
+			encrypted
+		)
+		const getMessage = jest.fn<SocketConfig['getMessage']>().mockResolvedValue(originalMessage())
+		const lidMapping = createLidMapping({
+			[DIRECT_AUTHOR_PN]: DIRECT_AUTHOR_LID,
+			[DIRECT_AUTHOR_LID]: DIRECT_AUTHOR_PN
+		})
+
+		const update = await processEncryptedMessageEdit({
+			message,
+			secretEncryptedMessage: encrypted,
+			getMessage,
+			lidMapping,
+			logger: createMockLogger(),
+			meId: LOCAL_PN,
+			meLid: LOCAL_LID
+		})
+
+		expect(getMessage).toHaveBeenCalledWith({
+			remoteJid: DIRECT_AUTHOR_PN,
+			remoteJidAlt: DIRECT_AUTHOR_LID,
+			fromMe: false,
+			id: ORIGINAL_ID
+		})
+		expect(update?.key).toEqual({
+			remoteJid: DIRECT_AUTHOR_PN,
+			remoteJidAlt: DIRECT_AUTHOR_LID,
+			fromMe: false,
+			id: ORIGINAL_ID
+		})
+		expect(getEditedText(update)).toBe('direct after')
+		expect(update?.update.messageTimestamp).toBe(1_725_000_000)
+		expect(lidMapping.getLIDForPN).not.toHaveBeenCalled()
+		expect(lidMapping.getPNForLID).not.toHaveBeenCalled()
+	})
+
+	it('decrypts a group edit using the participant identity', async () => {
+		const targetKey = {
+			id: ORIGINAL_ID,
+			remoteJid: GROUP_JID,
+			participant: DIRECT_AUTHOR_LID,
+			fromMe: true
+		}
+		const encrypted = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_LID,
+			editorJid: DIRECT_AUTHOR_LID,
+			editedText: 'group after',
+			targetKey
+		})
+		const message = createEnvelope(
+			{
+				remoteJid: GROUP_JID,
+				participant: DIRECT_AUTHOR_LID,
+				participantAlt: DIRECT_AUTHOR_PN,
+				fromMe: false,
+				id: ENVELOPE_ID
+			},
+			encrypted
+		)
+		const getMessage = jest.fn<SocketConfig['getMessage']>().mockResolvedValue(originalMessage())
+
+		const update = await processEncryptedMessageEdit({
+			message,
+			secretEncryptedMessage: encrypted,
+			getMessage,
+			lidMapping: createLidMapping({
+				[DIRECT_AUTHOR_PN]: DIRECT_AUTHOR_LID,
+				[DIRECT_AUTHOR_LID]: DIRECT_AUTHOR_PN
+			}),
+			logger: createMockLogger(),
+			meId: LOCAL_PN,
+			meLid: LOCAL_LID
+		})
+
+		expect(getMessage).toHaveBeenCalledWith({
+			remoteJid: GROUP_JID,
+			participant: DIRECT_AUTHOR_LID,
+			participantAlt: DIRECT_AUTHOR_PN,
+			fromMe: false,
+			id: ORIGINAL_ID
+		})
+		expect(update?.key.remoteJid).toBe(GROUP_JID)
+		expect(update?.key.participant).toBe(DIRECT_AUTHOR_LID)
+		expect(getEditedText(update)).toBe('group after')
+	})
+
+	it('retries decryption with a mapped LID identity when only a PN arrives on the envelope', async () => {
+		const targetKey = { id: ORIGINAL_ID, remoteJid: GROUP_JID, fromMe: true }
+		const encrypted = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_LID,
+			editorJid: DIRECT_AUTHOR_LID,
+			editedText: 'mapped group after',
+			targetKey
+		})
+		const lidMapping = createLidMapping({
+			[DIRECT_AUTHOR_PN]: DIRECT_AUTHOR_LID,
+			[DIRECT_AUTHOR_LID]: DIRECT_AUTHOR_PN
+		})
+
+		const update = await processEncryptedMessageEdit({
+			message: createEnvelope(
+				{
+					remoteJid: GROUP_JID,
+					participant: DIRECT_AUTHOR_PN,
+					fromMe: false,
+					id: ENVELOPE_ID
+				},
+				encrypted
+			),
+			secretEncryptedMessage: encrypted,
+			getMessage: async () => originalMessage(),
+			lidMapping,
+			logger: createMockLogger(),
+			meId: LOCAL_PN,
+			meLid: LOCAL_LID
+		})
+
+		expect(getEditedText(update)).toBe('mapped group after')
+		expect(lidMapping.getLIDForPN).toHaveBeenCalledWith(DIRECT_AUTHOR_PN)
+	})
+
+	it('uses the target participant when the original key is not from the editor perspective', async () => {
+		const targetKey = {
+			id: ORIGINAL_ID,
+			remoteJid: GROUP_JID,
+			participant: DIRECT_AUTHOR_LID,
+			fromMe: false
+		}
+		const encrypted = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_LID,
+			editorJid: DIRECT_AUTHOR_PN,
+			editedText: 'cross-addressed group after',
+			targetKey
+		})
+		const lidMapping = createLidMapping()
+
+		const update = await processEncryptedMessageEdit({
+			message: createEnvelope(
+				{
+					remoteJid: GROUP_JID,
+					participant: DIRECT_AUTHOR_PN,
+					fromMe: false,
+					id: ENVELOPE_ID
+				},
+				encrypted
+			),
+			secretEncryptedMessage: encrypted,
+			getMessage: async () => originalMessage(),
+			lidMapping,
+			logger: createMockLogger(),
+			meId: LOCAL_PN,
+			meLid: LOCAL_LID
+		})
+
+		expect(getEditedText(update)).toBe('cross-addressed group after')
+		expect(lidMapping.getLIDForPN).not.toHaveBeenCalled()
+		expect(lidMapping.getPNForLID).not.toHaveBeenCalled()
+	})
+
+	it('decrypts repeated edits against the same original message secret', async () => {
+		const targetKey = { id: ORIGINAL_ID, remoteJid: LOCAL_PN, fromMe: true }
+		const messageKey = {
+			remoteJid: DIRECT_AUTHOR_PN,
+			remoteJidAlt: DIRECT_AUTHOR_LID,
+			fromMe: false,
+			id: ENVELOPE_ID
+		}
+		const getMessage = jest.fn<SocketConfig['getMessage']>().mockResolvedValue(originalMessage())
+		const options = {
+			getMessage,
+			lidMapping: createLidMapping(),
+			logger: createMockLogger(),
+			meId: LOCAL_PN,
+			meLid: LOCAL_LID
+		}
+		const firstEncrypted = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_PN,
+			editorJid: DIRECT_AUTHOR_PN,
+			editedText: 'first edit',
+			targetKey
+		})
+		const secondEncrypted = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_PN,
+			editorJid: DIRECT_AUTHOR_PN,
+			editedText: 'second edit',
+			targetKey,
+			timestampMs: 1_725_000_030_000
+		})
+
+		const first = await processEncryptedMessageEdit({
+			...options,
+			message: createEnvelope(messageKey, firstEncrypted),
+			secretEncryptedMessage: firstEncrypted
+		})
+		const second = await processEncryptedMessageEdit({
+			...options,
+			message: createEnvelope(messageKey, secondEncrypted),
+			secretEncryptedMessage: secondEncrypted
+		})
+
+		expect(getMessage).toHaveBeenCalledTimes(2)
+		expect(getMessage.mock.calls.map(([key]) => key.id)).toEqual([ORIGINAL_ID, ORIGINAL_ID])
+		expect(getEditedText(first)).toBe('first edit')
+		expect(getEditedText(second)).toBe('second edit')
+	})
+
+	it('does not emit an update when the original secret is unavailable', async () => {
+		const targetKey = { id: ORIGINAL_ID, remoteJid: LOCAL_PN, fromMe: true }
+		const encrypted = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_PN,
+			editorJid: DIRECT_AUTHOR_PN,
+			editedText: 'after',
+			targetKey
+		})
+		const logger = createMockLogger()
+
+		const update = await processEncryptedMessageEdit({
+			message: createEnvelope({ remoteJid: DIRECT_AUTHOR_PN, fromMe: false, id: ENVELOPE_ID }, encrypted),
+			secretEncryptedMessage: encrypted,
+			getMessage: async () => undefined,
+			lidMapping: createLidMapping(),
+			logger,
+			meId: LOCAL_PN,
+			meLid: LOCAL_LID
+		})
+
+		expect(update).toBeUndefined()
+		expect(logger.warn).toHaveBeenCalledWith(
+			{ foundOriginal: false, secretLength: undefined },
+			'cannot decrypt message edit without the original message secret'
+		)
+	})
+
+	it('contains getMessage failures without failing the receive path', async () => {
+		const targetKey = { id: ORIGINAL_ID, remoteJid: LOCAL_PN, fromMe: true }
+		const encrypted = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_PN,
+			editorJid: DIRECT_AUTHOR_PN,
+			editedText: 'after',
+			targetKey
+		})
+		const logger = createMockLogger()
+		const lookupError = new Error('synthetic lookup failure')
+
+		const update = await processEncryptedMessageEdit({
+			message: createEnvelope({ remoteJid: DIRECT_AUTHOR_PN, fromMe: false, id: ENVELOPE_ID }, encrypted),
+			secretEncryptedMessage: encrypted,
+			getMessage: async () => {
+				throw lookupError
+			},
+			lidMapping: createLidMapping(),
+			logger,
+			meId: LOCAL_PN,
+			meLid: LOCAL_LID
+		})
+
+		expect(update).toBeUndefined()
+		expect(logger.warn).toHaveBeenCalledWith(
+			{ err: lookupError },
+			'failed to retrieve the original message for edit decryption'
+		)
+	})
+
+	it('rejects an encrypted envelope with a different secret type', async () => {
+		const targetKey = { id: ORIGINAL_ID, remoteJid: LOCAL_PN, fromMe: true }
+		const encrypted = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_PN,
+			editorJid: DIRECT_AUTHOR_PN,
+			editedText: 'after',
+			targetKey
+		})
+		encrypted.secretEncType = proto.Message.SecretEncryptedMessage.SecretEncType.EVENT_EDIT
+		const getMessage = jest.fn<SocketConfig['getMessage']>().mockResolvedValue(originalMessage())
+
+		const update = await processEncryptedMessageEdit({
+			message: createEnvelope({ remoteJid: DIRECT_AUTHOR_PN, fromMe: false, id: ENVELOPE_ID }, encrypted),
+			secretEncryptedMessage: encrypted,
+			getMessage,
+			lidMapping: createLidMapping(),
+			logger: createMockLogger(),
+			meId: LOCAL_PN,
+			meLid: LOCAL_LID
+		})
+
+		expect(update).toBeUndefined()
+		expect(getMessage).not.toHaveBeenCalled()
+	})
+
+	it('rejects decrypted protocol messages that do not describe the targeted edit', async () => {
+		const targetKey = { id: ORIGINAL_ID, remoteJid: LOCAL_PN, fromMe: true }
+		const wrongType = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_PN,
+			editorJid: DIRECT_AUTHOR_PN,
+			editedText: 'after',
+			targetKey,
+			protocolType: proto.Message.ProtocolMessage.Type.REVOKE
+		})
+		const wrongTarget = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_PN,
+			editorJid: DIRECT_AUTHOR_PN,
+			editedText: 'after',
+			targetKey,
+			embeddedTargetId: 'DIFFERENT-ID'
+		})
+		const options = {
+			message: createEnvelope({ remoteJid: DIRECT_AUTHOR_PN, fromMe: false, id: ENVELOPE_ID }, wrongType),
+			getMessage: async () => originalMessage(),
+			lidMapping: createLidMapping(),
+			logger: createMockLogger(),
+			meId: LOCAL_PN,
+			meLid: LOCAL_LID
+		}
+
+		expect(
+			await processEncryptedMessageEdit({
+				...options,
+				secretEncryptedMessage: wrongType
+			})
+		).toBeUndefined()
+		expect(
+			await processEncryptedMessageEdit({
+				...options,
+				message: createEnvelope({ remoteJid: DIRECT_AUTHOR_PN, fromMe: false, id: ENVELOPE_ID }, wrongTarget),
+				secretEncryptedMessage: wrongTarget
+			})
+		).toBeUndefined()
+	})
+})
+
+describe('processMessage encrypted edit integration', () => {
+	const createMockEventEmitter = () => {
+		const emittedEvents: Array<{ event: string; data: unknown }> = []
+		return {
+			emittedEvents,
+			on: jest.fn(),
+			off: jest.fn(),
+			removeAllListeners: jest.fn(),
+			emit: jest.fn((event: string, data: unknown) => {
+				emittedEvents.push({ event, data })
+				return true
+			})
+		} as unknown as BaileysEventEmitter & { emittedEvents: typeof emittedEvents }
+	}
+
+	const processFixture = async ({
+		message,
+		getMessage
+	}: {
+		message: WAMessage
+		getMessage: SocketConfig['getMessage']
+	}) => {
+		const ev = createMockEventEmitter()
+		const logger = createMockLogger()
+		const lidMapping = createLidMapping({
+			[DIRECT_AUTHOR_PN]: DIRECT_AUTHOR_LID,
+			[DIRECT_AUTHOR_LID]: DIRECT_AUTHOR_PN
+		})
+
+		await processMessage(message, {
+			shouldProcessHistoryMsg: false,
+			ev,
+			creds: {
+				me: { id: LOCAL_PN, lid: LOCAL_LID },
+				accountSettings: { unarchiveChats: false }
+			} as unknown as AuthenticationCreds,
+			signalRepository: { lidMapping } as unknown as SignalRepositoryWithLIDStore,
+			keyStore: {} as SignalKeyStoreWithTransaction,
+			logger,
+			options: {},
+			getMessage
+		})
+
+		return ev.emittedEvents
+	}
+
+	it.each([
+		{
+			name: 'direct message',
+			messageKey: {
+				remoteJid: DIRECT_AUTHOR_PN,
+				remoteJidAlt: DIRECT_AUTHOR_LID,
+				fromMe: false,
+				id: ENVELOPE_ID
+			},
+			targetKey: { id: ORIGINAL_ID, remoteJid: LOCAL_PN, fromMe: true },
+			authorJid: DIRECT_AUTHOR_PN,
+			editedText: 'direct integration edit'
+		},
+		{
+			name: 'group message',
+			messageKey: {
+				remoteJid: GROUP_JID,
+				participant: DIRECT_AUTHOR_LID,
+				participantAlt: DIRECT_AUTHOR_PN,
+				fromMe: false,
+				id: ENVELOPE_ID
+			},
+			targetKey: {
+				id: ORIGINAL_ID,
+				remoteJid: GROUP_JID,
+				participant: DIRECT_AUTHOR_LID,
+				fromMe: true
+			},
+			authorJid: DIRECT_AUTHOR_LID,
+			editedText: 'group integration edit'
+		},
+		{
+			name: 'wrapped direct message',
+			messageKey: {
+				remoteJid: DIRECT_AUTHOR_PN,
+				remoteJidAlt: DIRECT_AUTHOR_LID,
+				fromMe: false,
+				id: ENVELOPE_ID
+			},
+			targetKey: { id: ORIGINAL_ID, remoteJid: LOCAL_PN, fromMe: true },
+			authorJid: DIRECT_AUTHOR_PN,
+			editedText: 'wrapped direct integration edit',
+			wrapped: true
+		}
+	])('emits the established messages.update contract for an incoming $name edit', async fixture => {
+		const encrypted = sealProtocolMessage({
+			originalSenderJid: fixture.authorJid,
+			editorJid: fixture.authorJid,
+			editedText: fixture.editedText,
+			targetKey: fixture.targetKey
+		})
+		const message = createEnvelope(fixture.messageKey, encrypted)
+		if ('wrapped' in fixture && fixture.wrapped) {
+			message.message = {
+				ephemeralMessage: {
+					message: message.message
+				}
+			}
+		}
+
+		const events = await processFixture({
+			message,
+			getMessage: async () => originalMessage()
+		})
+		const updateEvent = events.find(event => event.event === 'messages.update')
+
+		expect(updateEvent?.data).toEqual([
+			{
+				key: { ...fixture.messageKey, id: ORIGINAL_ID },
+				update: {
+					message: {
+						editedMessage: {
+							message: { conversation: fixture.editedText }
+						}
+					},
+					messageTimestamp: 1_725_000_000
+				}
+			}
+		])
+		expect(events.some(event => event.event === 'chats.update')).toBe(false)
+	})
+})

--- a/src/__tests__/Utils/decrypt-message-edit.test.ts
+++ b/src/__tests__/Utils/decrypt-message-edit.test.ts
@@ -577,7 +577,7 @@ describe('processMessage encrypted edit integration', () => {
 			getMessage
 		})
 
-		return ev.emittedEvents
+		return { events: ev.emittedEvents, logger }
 	}
 
 	it.each([
@@ -640,7 +640,7 @@ describe('processMessage encrypted edit integration', () => {
 			}
 		}
 
-		const events = await processFixture({
+		const { events } = await processFixture({
 			message,
 			getMessage: async () => originalMessage()
 		})
@@ -660,5 +660,41 @@ describe('processMessage encrypted edit integration', () => {
 			}
 		])
 		expect(events.some(event => event.event === 'chats.update')).toBe(false)
+	})
+
+	it('contains unexpected edit-processing errors in the receive path', async () => {
+		const targetKey = { id: ORIGINAL_ID, remoteJid: LOCAL_PN, fromMe: true }
+		const encrypted = sealProtocolMessage({
+			originalSenderJid: DIRECT_AUTHOR_PN,
+			editorJid: DIRECT_AUTHOR_PN,
+			editedText: 'after',
+			targetKey
+		})
+		const unexpectedError = new Error('synthetic original message failure')
+		const unreadableOriginal = {} as proto.IMessage
+		Object.defineProperty(unreadableOriginal, 'messageContextInfo', {
+			get: () => {
+				throw unexpectedError
+			}
+		})
+
+		const { events, logger } = await processFixture({
+			message: createEnvelope(
+				{
+					remoteJid: DIRECT_AUTHOR_PN,
+					remoteJidAlt: DIRECT_AUTHOR_LID,
+					fromMe: false,
+					id: ENVELOPE_ID
+				},
+				encrypted
+			),
+			getMessage: async () => unreadableOriginal
+		})
+
+		expect(events.some(event => event.event === 'messages.update')).toBe(false)
+		expect(logger.warn).toHaveBeenCalledWith(
+			{ err: unexpectedError, msgId: ENVELOPE_ID },
+			'failed to process encrypted message edit'
+		)
 	})
 })

--- a/src/__tests__/Utils/decrypt-message-edit.test.ts
+++ b/src/__tests__/Utils/decrypt-message-edit.test.ts
@@ -190,18 +190,21 @@ describe('decryptMessageEdit', () => {
 })
 
 describe('processEncryptedMessageEdit', () => {
-	it('decrypts a direct-message edit and looks up the original from the local perspective', async () => {
+	it.each([
+		{ addressingMode: 'PN', remoteJid: DIRECT_AUTHOR_PN, remoteJidAlt: DIRECT_AUTHOR_LID },
+		{ addressingMode: 'LID', remoteJid: DIRECT_AUTHOR_LID, remoteJidAlt: DIRECT_AUTHOR_PN }
+	])('decrypts a direct-message edit with $addressingMode-first addressing', async ({ remoteJid, remoteJidAlt }) => {
 		const targetKey = { id: ORIGINAL_ID, remoteJid: LOCAL_PN, fromMe: true }
 		const encrypted = sealProtocolMessage({
-			originalSenderJid: DIRECT_AUTHOR_PN,
-			editorJid: DIRECT_AUTHOR_PN,
+			originalSenderJid: remoteJid,
+			editorJid: remoteJid,
 			editedText: 'direct after',
 			targetKey
 		})
 		const message = createEnvelope(
 			{
-				remoteJid: DIRECT_AUTHOR_PN,
-				remoteJidAlt: DIRECT_AUTHOR_LID,
+				remoteJid,
+				remoteJidAlt,
 				fromMe: false,
 				id: ENVELOPE_ID
 			},
@@ -224,14 +227,14 @@ describe('processEncryptedMessageEdit', () => {
 		})
 
 		expect(getMessage).toHaveBeenCalledWith({
-			remoteJid: DIRECT_AUTHOR_PN,
-			remoteJidAlt: DIRECT_AUTHOR_LID,
+			remoteJid,
+			remoteJidAlt,
 			fromMe: false,
 			id: ORIGINAL_ID
 		})
 		expect(update?.key).toEqual({
-			remoteJid: DIRECT_AUTHOR_PN,
-			remoteJidAlt: DIRECT_AUTHOR_LID,
+			remoteJid,
+			remoteJidAlt,
 			fromMe: false,
 			id: ORIGINAL_ID
 		})

--- a/tsconfig.live-smoke.json
+++ b/tsconfig.live-smoke.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["scripts/live-smoke/**/*.ts", "src/Types/globals.d.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2351,6 +2351,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/qrcode-terminal@npm:^0.12.2":
+  version: 0.12.2
+  resolution: "@types/qrcode-terminal@npm:0.12.2"
+  checksum: 10c0/9d8d75f76ed2f75faaa2007850d884ce71ad25e05d8683a2b42e6b6cb6568d0d87a3ebb427e174fd77ab4264de40923806785fde2d97d81fce393f127d88931f
+  languageName: node
+  linkType: hard
+
 "@types/stack-utils@npm:^2.0.3":
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
@@ -3100,6 +3107,7 @@ __metadata:
     "@hapi/boom": "npm:^9.1.3"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^20.9.0"
+    "@types/qrcode-terminal": "npm:^0.12.2"
     "@types/ws": "npm:^8.0.0"
     "@typescript-eslint/eslint-plugin": "npm:^8"
     "@typescript-eslint/parser": "npm:^8"
@@ -3126,6 +3134,7 @@ __metadata:
     prettier: "npm:^3.5.3"
     protobufjs: "npm:^7.5.6"
     protobufjs-cli: "npm:^1.1.3"
+    qrcode-terminal: "npm:^0.12.0"
     release-it: "npm:^20.0.1"
     ts-jest: "npm:^29.4.0"
     tsc-esm-fix: "npm:^3.1.2"
@@ -7476,6 +7485,15 @@ __metadata:
   version: 7.0.1
   resolution: "pure-rand@npm:7.0.1"
   checksum: 10c0/9cade41030f5ec95f5d55a11a71404cd6f46b69becaad892097cd7f58e2c6248cd0a933349ca7d21336ab629f1da42ffe899699b671bc4651600eaf6e57f837e
+  languageName: node
+  linkType: hard
+
+"qrcode-terminal@npm:^0.12.0":
+  version: 0.12.0
+  resolution: "qrcode-terminal@npm:0.12.0"
+  bin:
+    qrcode-terminal: ./bin/qrcode-terminal.js
+  checksum: 10c0/1d8996a743d6c95e22056bd45fe958c306213adc97d7ef8cf1e03bc1aeeb6f27180a747ec3d761141921351eb1e3ca688f7b673ab54cdae9fa358dffaa49563c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- decrypt `MESSAGE_EDIT` secret-encrypted envelopes using the original message secret
- preserve the established `messages.update` event shape for direct and group chats
- retain outer message context when unwrapping linked-device messages
- add an opt-in live-phone smoke command with short-lived, user-only pairing state

## Integration notes

- Raw `secretEncryptedMessage` envelopes remain visible on `messages.upsert`, matching existing protocol-message behavior; the decrypted edit is emitted separately on `messages.update`.
- `getMessage` must return the stored original with its `messageContextInfo.messageSecret` intact for encrypted edits to be decrypted.

## Security

This is security-sensitive because it handles authenticated message decryption. It validates the envelope type, target, IV length, message-secret length, and decrypted protocol payload before emitting an update. Authentication state, message secrets, JIDs, ciphertext, and real message content are not included in fixtures or logs.

## Testing

- `yarn build`
- `yarn lint`
- `yarn test`
- `yarn typecheck:smoke:live:edit`
- `yarn test:smoke:live:edit`
- manual direct-message and group edit smoke using `yarn smoke:live:edit`

Drafted with Codex and reviewed by a human.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decrypts secret-encrypted `MESSAGE_EDIT` envelopes using the original message secret and emits standard `messages.update` events for direct and group chats. Also fixes linked-device unwrapping and adds an opt-in live phone smoke test with a safe, retained pairing.

- **Bug Fixes**
  - Decrypt `MESSAGE_EDIT` with the original 32-byte message secret; validate type/IV; fall back across PN/LID via mapping; retrieve the original via `getMessage`.
  - Emit `messages.update` for the original message key with the edited content in both direct and group chats.
  - When unwrapping `deviceSentMessage`, merge outer and inner `messageContextInfo`, preserving the outer `messageSecret` and preferring inner fields so linked-device edits decrypt correctly.
  - Exclude encrypted edit envelopes from "real message" detection to avoid double processing.

- **New Features**
  - Live smoke test for edits with retained, user-only linked-device pairing and terminal QR: run `yarn smoke:live:edit`, `yarn test:smoke:live:edit`, `yarn typecheck:smoke:live:edit` (uses `qrcode-terminal`). Refuses CI, stores auth in a temp dir with strict perms, retains for 8 idle hours, and locks to block concurrent runs.

<sup>Written for commit fb16e3efffccad3cbdf8202eadbdfa566a80a062. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for receiving and processing encrypted message edits in direct and group chats.
  * Added an interactive live smoke test for sending and verifying edited messages, with retained authentication sessions.

* **Bug Fixes**
  * Improved handling of wrapped device-sent messages while preserving metadata needed for encrypted edits.

* **Tests**
  * Expanded coverage for encrypted edits, message lookup, authentication sessions, and smoke-test workflows.

* **Documentation**
  * Documented live smoke-test setup, usage, security, and session lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
