### PR TITLE
fix(messages-recv): recover alt JID from LID mapping store when server omits *_pn

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1622,18 +1622,25 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				// populated, so consumers still get the PN instead of only a bare LID.
 				const primaryJid = msg.key.participant || msg.key.remoteJid!
 				if (isLidUser(primaryJid)) {
-					const pn = await signalRepository.lidMapping.getPNForLID(primaryJid)
-					if (pn) {
-						// getPNForLID returns a device-scoped JID, while the stanza
-						// attributes carry it without the device — normalize to match.
-						const pnJid = jidNormalizedUser(pn)
-						if (isJidGroup(msg.key.remoteJid!)) {
-							msg.key.participantAlt = pnJid
-						} else {
-							msg.key.remoteJidAlt = pnJid
-						}
+					try {
+						const pn = await signalRepository.lidMapping.getPNForLID(primaryJid)
+						// getPNForLID returns a device-scoped JID, while the stanza attributes
+						// carry it without the device — normalize to match. jidNormalizedUser
+						// yields '' for an undecodable JID, so guard before assigning.
+						const pnJid = pn ? jidNormalizedUser(pn) : ''
+						if (pnJid) {
+							if (isJidGroup(msg.key.remoteJid!)) {
+								msg.key.participantAlt = pnJid
+							} else {
+								msg.key.remoteJidAlt = pnJid
+							}
 
-						logger.debug({ lid: primaryJid, pn: pnJid }, 'recovered alt JID from LID mapping store')
+							logger.debug({ lid: primaryJid, pn: pnJid }, 'recovered alt JID from LID mapping store')
+						}
+					} catch (err) {
+						// Best-effort: a mapping-store failure must not cost us the message.
+						// Without this the outer catch would NACK it and skip decryption.
+						logger.warn({ err, lid: primaryJid }, 'failed to recover alt JID from LID mapping store')
 					}
 				}
 			}

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1615,6 +1615,27 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 					await signalRepository.lidMapping.storeLIDPNMappings([{ lid: primaryJid, pn: alt }])
 					await signalRepository.migrateSession(alt, primaryJid)
 				}
+			} else if (msg.key.addressingMode === 'lid') {
+				// The server sent no participant_pn/sender_pn/peer_recipient_pn, so
+				// extractAddressingContext had nothing to derive the alt JID from. Recover
+				// it from the local LID->PN store, which outgoing sends and USync keep
+				// populated, so consumers still get the PN instead of only a bare LID.
+				const primaryJid = msg.key.participant || msg.key.remoteJid!
+				if (isLidUser(primaryJid)) {
+					const pn = await signalRepository.lidMapping.getPNForLID(primaryJid)
+					if (pn) {
+						// getPNForLID returns a device-scoped JID, while the stanza
+						// attributes carry it without the device — normalize to match.
+						const pnJid = jidNormalizedUser(pn)
+						if (isJidGroup(msg.key.remoteJid!)) {
+							msg.key.participantAlt = pnJid
+						} else {
+							msg.key.remoteJidAlt = pnJid
+						}
+
+						logger.debug({ lid: primaryJid, pn: pnJid }, 'recovered alt JID from LID mapping store')
+					}
+				}
 			}
 
 			await messageMutex.mutex(async () => {


### PR DESCRIPTION
## Problem

`extractAddressingContext()` derives `senderAlt` exclusively from stanza attributes:

```ts
senderAlt = stanza.attrs.participant_pn || stanza.attrs.sender_pn || stanza.attrs.peer_recipient_pn
```

For some LID-addressed contacts WhatsApp sends none of the three. `decodeMessageNode()` then leaves `key.remoteJidAlt` (or `key.participantAlt` for groups) `undefined`, and there is no fallback anywhere in the decode path — so consumers only ever see a bare `@lid` with no route to the phone number.

Observed in production against a real contact: `addressingMode: 'lid'`, `remoteJid: '25151362101280@lid'`, `remoteJidAlt: undefined`, on every inbound message. Other contacts on the same session did receive `sender_pn` and resolved normally, so this is per-contact server behaviour, not a session-wide failure.

This is currently unfixable from downstream: `getLIDForPN` can hit USync, but the reverse direction has no network path (`pnFromLIDUSync` skips LID users by design).

## Why it is recoverable

The mapping is usually already stored locally:

- `storeLIDPNMappings()` writes **both** directions — `pn -> lid` and `` `${lid}_reverse` -> pn ``
- every outgoing 1:1 send resolves PN -> LID through USync (`getLIDsForPNs` in `messages-send.ts`), which populates that reverse entry

So for any contact we have ever messaged, the phone number is already on disk. `getPNForLID()` reads it from cache/store and performs **no network call**, so the lookup is cheap and offline-safe.

## Change

One branch, added where the surrounding LID/PN bookkeeping already lives in `handleMessage` — the `alt`-present path right above it already calls `getPNForLID`:

```ts
} else if (msg.key.addressingMode === 'lid') {
    const primaryJid = msg.key.participant || msg.key.remoteJid!
    if (isLidUser(primaryJid)) {
        const pn = await signalRepository.lidMapping.getPNForLID(primaryJid)
        if (pn) {
            const pnJid = jidNormalizedUser(pn)
            if (isJidGroup(msg.key.remoteJid!)) {
                msg.key.participantAlt = pnJid
            } else {
                msg.key.remoteJidAlt = pnJid
            }
            ...
        }
    }
}
```

The group/1:1 split mirrors `decodeMessageNode`, which sets `remoteJidAlt` only when `!isJidGroup(chatId)` and `participantAlt` only when it is.

`jidNormalizedUser()` is required, not cosmetic: `getPNForLID()` returns a **device-scoped** JID (`${pnUser}:${device}@s.whatsapp.net`, asserted by the existing `getPNForLID` tests in `Signal/lid-mapping.test.ts`), while the stanza attributes carry it without the device. Normalizing keeps both paths producing the same shape.

## Behaviour

- No change when the server does send `*_pn` — the new branch is `else if`, only reached when the alt JID is absent.
- No change when no mapping exists — `getPNForLID` returns `null`, the key is left exactly as before.
- No network I/O added.

## Verification

- `tsc --noEmit` clean
- full suite green: **28 suites, 407 tests**
- added lines are prettier-conformant against the repo `.prettierrc` (verified by diffing a `prettier --write` copy; the file has pre-existing formatting drift on `master`, so it was deliberately **not** reformatted to keep this diff minimal)
- deployed against the reproducing contact: inbound messages that previously arrived as `25151362101280@lid` now carry the phone number, and the downstream "unresolvable JID" warning count stopped increasing

## Note on tests

The branch sits inside the `makeMessagesRecvSocket` closure, so it is not unit-testable in isolation as written. I noticed the repo's precedent for this — `handleIdentityChange` was extracted into `Utils/identity-change-handler.ts` with an explicit context object precisely so it could be covered by `Socket/identity-change-handling.test.ts`. Happy to extract this fallback the same way and add a test if you would prefer that over the minimal inline diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fallback added to recover the alt JID (phone-number JID) from the local LID→PN mapping when the server omits `*_pn`, so inbound LID messages expose the phone number instead of a bare `@lid`.

- **Bug Fixes**
  - Set `remoteJidAlt` or `participantAlt` using `getPNForLID()` for LID-addressed messages missing `*_pn`.
  - Normalize the returned device-scoped JID with `jidNormalizedUser()` for consistent shape.
  - No network calls added; no behavior change when `*_pn` is present or no mapping exists.

<sup>Written for commit d38a5cb48ae08989596114a47112c2df65daabcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of encrypted messages using LID addressing.
  * Correctly identifies associated contact addresses for direct and group messages when alternate addressing details are unavailable.
  * Message processing now continues even if contact-address mapping cannot be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->