### PR TITLE
fix(socket): ack nodes before login

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -544,7 +544,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	}
 
 	const sendMessageAck = async (node: BinaryNode, errorCode?: number) => {
-		const stanza = buildAckStanza(node, errorCode, authState.creds.me!.id)
+		const stanza = buildAckStanza(node, errorCode, authState.creds.me?.id)
 		logger.debug({ recv: { tag: node.tag, attrs: node.attrs }, sent: stanza.attrs }, 'sent ack')
 		await sendNode(stanza)
 	}

--- a/src/__tests__/Socket/messages-recv.test.ts
+++ b/src/__tests__/Socket/messages-recv.test.ts
@@ -1,0 +1,62 @@
+import { jest } from '@jest/globals'
+import { DEFAULT_CONNECTION_CONFIG } from '../../Defaults'
+import type { AuthenticationState } from '../../Types'
+import { type BinaryNode } from '../../WABinary'
+
+const sendNode = jest.fn(async () => undefined)
+const authState = {
+	creds: {},
+	keys: {
+		get: jest.fn(async () => ({})),
+		set: jest.fn(async () => undefined)
+	}
+}
+
+jest.unstable_mockModule('../../Socket/messages-send', () => ({
+	makeMessagesSocket: jest.fn(() => ({
+		authState,
+		sendNode,
+		ws: {
+			on: jest.fn()
+		},
+		ev: {
+			on: jest.fn()
+		},
+		registerSocketEndHandler: jest.fn(),
+		signalRepository: {
+			lidMapping: {
+				getLIDForPN: jest.fn()
+			}
+		}
+	}))
+}))
+
+const { makeMessagesRecvSocket } = await import('../../Socket/messages-recv')
+
+describe('sendMessageAck', () => {
+	it('acknowledges notifications before credentials identify the device', async () => {
+		const sock = makeMessagesRecvSocket({
+			...DEFAULT_CONNECTION_CONFIG,
+			auth: authState as unknown as AuthenticationState
+		})
+		const node: BinaryNode = {
+			tag: 'notification',
+			attrs: {
+				id: 'pre-login-notification',
+				from: 's.whatsapp.net',
+				type: 'companion_reg_refresh'
+			}
+		}
+
+		await expect(sock.sendMessageAck(node)).resolves.toBeUndefined()
+		expect(sendNode).toHaveBeenCalledWith({
+			tag: 'ack',
+			attrs: {
+				id: 'pre-login-notification',
+				to: 's.whatsapp.net',
+				class: 'notification',
+				type: 'companion_reg_refresh'
+			}
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- avoid dereferencing `creds.me` while pairing is still incomplete
- allow pre-login notification ACKs to use the existing no-`from` stanza path
- add deterministic coverage for the pre-login notification flow

## Validation
- TypeScript check: passed
- focused ESLint: 0 errors; 5 existing `no-explicit-any` warnings in `messages-recv.ts`
- focused Jest: 1/1 passed
- full Jest: 29 suites, 408 tests passed
- `git diff --check`: passed

AI-assisted with Codex; the diff and test results were reviewed against the issue and repository contribution rules.

Fixes #2738

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Acknowledge notification nodes before login without requiring `creds.me`. Prevents crashes during pairing and fixes #2738.

- **Bug Fixes**
  - Use `authState.creds.me?.id` when building ACK stanzas so pre-login notifications follow the existing no-`from` path.
  - Add a Jest test to verify ACK of `companion_reg_refresh` notifications before device identification.

<sup>Written for commit 38686677889a4db5356da51aa9517eb12c1e0866. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved acknowledgment handling for companion registration refresh notifications when device credentials are not yet identified.
  * Ensured these notifications receive the expected acknowledgment reliably.

* **Tests**
  * Added coverage for acknowledgment behavior during early connection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->