### PR TITLE
feat(socket): proactively capture tctoken from incoming messages

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -62,6 +62,7 @@ import {
 	readTcTokenIndex,
 	resolveIssuanceJid,
 	resolveTcTokenJid,
+	storeTcTokenFromMessageNode,
 	storeTcTokensFromIqResult,
 	TC_TOKEN_INDEX_KEY
 } from '../Utils/tc-token-utils'
@@ -1583,6 +1584,16 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	}
 
 	const handleMessage = async (node: BinaryNode) => {
+		// Opportunistically capture a tctoken riding along on this message, independent of
+		// whether the body itself decrypts — a later reply to this contact shouldn't have to
+		// hit a 463 and reactively recover a token we should already have had. Fire-and-forget:
+		// non-critical background bookkeeping, doesn't gate message processing/ack.
+		void storeTcTokenFromMessageNode({ node, keys: authState.keys, getLIDForPN })
+			.then(storedJid => {
+				if (storedJid) trackTcTokenJid(storedJid)
+			})
+			.catch(err => logger.debug({ err: err?.message }, 'failed to store tctoken from incoming message'))
+
 		const encNode = getBinaryNodeChild(node, 'enc')
 		// TODO: temporary fix for crashes and issues resulting of failed msmsg decryption
 		if (encNode?.attrs.type === 'msmsg') {

--- a/src/Utils/tc-token-utils.ts
+++ b/src/Utils/tc-token-utils.ts
@@ -216,3 +216,59 @@ export async function storeTcTokensFromIqResult({
 		onNewJidStored?.(storageJid)
 	}
 }
+
+type StoreTcTokenFromMessageParams = {
+	node: BinaryNode
+	keys: SignalKeyStoreWithTransaction
+	getLIDForPN: (pn: string) => Promise<string | null>
+}
+
+/**
+ * Opportunistically captures a `<tctoken>` child riding along on an incoming `<message>`
+ * stanza — mirrors WA Web's `WAWebSetTcTokenChatAction.handleIncomingTcToken`. Distinct from
+ * `storeTcTokensFromIqResult` (which handles `<tokens>` wrappers from IQ results / privacy_token
+ * notifications): this is the proactive path, so a later reply to an already-warm contact
+ * doesn't need to hit a 463 and reactively recover a token we should already have had.
+ *
+ * Returns the storage JID written, or `undefined` if nothing was stored (no token present,
+ * stale timestamp, or the sender isn't a regular user).
+ */
+export async function storeTcTokenFromMessageNode({
+	node,
+	keys,
+	getLIDForPN
+}: StoreTcTokenFromMessageParams): Promise<string | undefined> {
+	const tcTokenNode = getBinaryNodeChild(node, 'tctoken')
+	if (!tcTokenNode || !(tcTokenNode.content instanceof Uint8Array)) return undefined
+
+	const rawJid = jidNormalizedUser(node.attrs.from)
+	if (!isRegularUser(rawJid)) return undefined
+
+	// WA Web uses: senderLid ?? toLid(from) for the storage key — same as handlePrivacyTokenNotification
+	const senderLid =
+		node.attrs.sender_lid && isLidUser(jidNormalizedUser(node.attrs.sender_lid))
+			? jidNormalizedUser(node.attrs.sender_lid)
+			: undefined
+	const storageJid = senderLid ?? (await resolveTcTokenJid(rawJid, getLIDForPN))
+
+	const existingTcData = await keys.get('tctoken', [storageJid])
+	const existingEntry = existingTcData[storageJid]
+
+	const existingTs = existingEntry?.timestamp ? Number(existingEntry.timestamp) : 0
+	const incomingTs = tcTokenNode.attrs.t ? Number(tcTokenNode.attrs.t) : 0
+	// timestamp-less tokens would be immediately expired
+	if (!incomingTs) return undefined
+	if (existingTs > 0 && existingTs >= incomingTs) return undefined
+
+	await keys.set({
+		tctoken: {
+			[storageJid]: {
+				...existingEntry,
+				token: Buffer.from(tcTokenNode.content),
+				timestamp: tcTokenNode.attrs.t
+			}
+		}
+	})
+
+	return storageJid
+}

--- a/src/__tests__/Socket/messages-recv.test.ts
+++ b/src/__tests__/Socket/messages-recv.test.ts
@@ -1,0 +1,76 @@
+import { jest } from '@jest/globals'
+import { DEFAULT_CONNECTION_CONFIG } from '../../Defaults'
+import type { AuthenticationState } from '../../Types'
+import { type BinaryNode } from '../../WABinary'
+
+const sendNode = jest.fn(async () => undefined)
+const authState = {
+	creds: {},
+	keys: {
+		get: jest.fn(async () => ({})),
+		set: jest.fn(async () => undefined)
+	}
+}
+
+jest.unstable_mockModule('../../Socket/messages-send', () => ({
+	makeMessagesSocket: jest.fn(() => ({
+		authState,
+		sendNode,
+		ws: { on: jest.fn(), isOpen: true },
+		ev: { on: jest.fn(), buffer: jest.fn(), flush: jest.fn(), emit: jest.fn() },
+		registerSocketEndHandler: jest.fn(),
+		onUnexpectedError: jest.fn(),
+		signalRepository: {
+			lidMapping: {
+				getLIDForPN: jest.fn()
+			}
+		}
+	}))
+}))
+
+const { makeMessagesRecvSocket } = await import('../../Socket/messages-recv')
+
+describe('incoming message tctoken capture (Baileys#2698/#2707)', () => {
+	beforeEach(() => {
+		authState.keys.get.mockClear()
+		authState.keys.set.mockClear()
+		sendNode.mockClear()
+	})
+
+	it('stores a tctoken riding along on an incoming message, wired through the real CB:message handler', async () => {
+		const sock = makeMessagesRecvSocket({
+			...DEFAULT_CONNECTION_CONFIG,
+			auth: authState as unknown as AuthenticationState
+		})
+
+		// Grab the handler messages-recv registered for incoming <message> stanzas
+		const onCalls = (sock.ws.on as jest.Mock).mock.calls as [string, (node: BinaryNode) => Promise<void>][]
+		const messageHandler = onCalls.find(([tag]) => tag === 'CB:message')?.[1]
+		expect(messageHandler).toBeDefined()
+
+		const node: BinaryNode = {
+			tag: 'message',
+			attrs: { from: 'contact@s.whatsapp.net', id: 'msg-1' },
+			content: [
+				{
+					tag: 'tctoken',
+					attrs: { t: '1700000000' },
+					content: new Uint8Array([1, 2, 3, 4])
+				}
+			]
+		}
+
+		await messageHandler!(node)
+		// Token capture is fire-and-forget (doesn't gate message processing) — flush microtasks
+		await new Promise(resolve => setTimeout(resolve, 0))
+
+		expect(authState.keys.set).toHaveBeenCalledWith({
+			tctoken: {
+				'contact@s.whatsapp.net': {
+					token: Buffer.from([1, 2, 3, 4]),
+					timestamp: '1700000000'
+				}
+			}
+		})
+	})
+})

--- a/src/__tests__/Utils/tc-token.test.ts
+++ b/src/__tests__/Utils/tc-token.test.ts
@@ -8,6 +8,7 @@ import {
 	readTcTokenIndex,
 	resolveIssuanceJid,
 	shouldSendNewTcToken,
+	storeTcTokenFromMessageNode,
 	storeTcTokensFromIqResult,
 	TC_TOKEN_INDEX_KEY
 } from '../../Utils/tc-token-utils'
@@ -1106,5 +1107,108 @@ describe('tctoken index helpers', () => {
 		const write = await buildMergedTcTokenIndexWrite(mockKeys, [TC_TOKEN_INDEX_KEY, '', 'a@lid'])
 		const merged = JSON.parse(write[TC_TOKEN_INDEX_KEY].token.toString())
 		expect(merged).toEqual(['a@lid'])
+	})
+})
+
+describe('storeTcTokenFromMessageNode', () => {
+	const CONTACT_JID = 'contact@s.whatsapp.net'
+	const CONTACT_LID = 'contact@lid'
+	const TOKEN_BYTES = new Uint8Array([4, 1, 33, 254, 110])
+	const RECENT_TS = String(nowSeconds() - 86400)
+
+	let mockKeys: jest.Mocked<SignalKeyStoreWithTransaction>
+	const noopGetLID = async (): Promise<string | null> => null
+
+	beforeEach(() => {
+		mockKeys = createMockKeys()
+		// @ts-ignore
+		mockKeys.get.mockResolvedValue({})
+	})
+
+	const makeMessageNode = (
+		from: string,
+		opts: { t?: string; senderLid?: string; noToken?: boolean } = {}
+	): BinaryNode => ({
+		tag: 'message',
+		attrs: { from, ...(opts.senderLid ? { sender_lid: opts.senderLid } : {}) },
+		content: opts.noToken
+			? []
+			: [
+					{
+						tag: 'tctoken',
+						attrs: opts.t ? { t: opts.t } : {},
+						content: TOKEN_BYTES
+					}
+				]
+	})
+
+	it('stores the token on first sight, keyed by the resolved storage JID', async () => {
+		const node = makeMessageNode(CONTACT_JID, { t: RECENT_TS })
+
+		const stored = await storeTcTokenFromMessageNode({ node, keys: mockKeys, getLIDForPN: noopGetLID })
+
+		expect(stored).toBe(CONTACT_JID)
+		expect(mockKeys.set).toHaveBeenCalledTimes(1)
+		const setCall = mockKeys.set.mock.calls[0]![0] as any
+		expect(Buffer.from(setCall.tctoken[CONTACT_JID].token)).toEqual(Buffer.from(TOKEN_BYTES))
+		expect(setCall.tctoken[CONTACT_JID].timestamp).toBe(RECENT_TS)
+	})
+
+	it('prefers sender_lid over resolving from attrs.from when present', async () => {
+		const node = makeMessageNode(CONTACT_JID, { t: RECENT_TS, senderLid: CONTACT_LID })
+		const getLIDForPN = jest.fn(noopGetLID)
+
+		const stored = await storeTcTokenFromMessageNode({ node, keys: mockKeys, getLIDForPN })
+
+		expect(stored).toBe(CONTACT_LID)
+		expect(getLIDForPN).not.toHaveBeenCalled()
+		const setCall = mockKeys.set.mock.calls[0]![0] as any
+		expect(setCall.tctoken[CONTACT_LID]).toBeDefined()
+	})
+
+	it('no-ops when there is no tctoken child', async () => {
+		const node = makeMessageNode(CONTACT_JID, { noToken: true })
+
+		const stored = await storeTcTokenFromMessageNode({ node, keys: mockKeys, getLIDForPN: noopGetLID })
+
+		expect(stored).toBeUndefined()
+		expect(mockKeys.set).not.toHaveBeenCalled()
+	})
+
+	it('no-ops when the token has no timestamp (would be immediately expired)', async () => {
+		const node = makeMessageNode(CONTACT_JID)
+
+		const stored = await storeTcTokenFromMessageNode({ node, keys: mockKeys, getLIDForPN: noopGetLID })
+
+		expect(stored).toBeUndefined()
+		expect(mockKeys.set).not.toHaveBeenCalled()
+	})
+
+	it('ignores an incoming token that is not strictly newer than the stored one', async () => {
+		const existingTs = String(nowSeconds() - 86400)
+		// @ts-ignore
+		mockKeys.get.mockResolvedValue({
+			[CONTACT_JID]: { token: Buffer.from([9, 9, 9]), timestamp: existingTs }
+		})
+		const node = makeMessageNode(CONTACT_JID, { t: existingTs })
+
+		const stored = await storeTcTokenFromMessageNode({ node, keys: mockKeys, getLIDForPN: noopGetLID })
+
+		expect(stored).toBeUndefined()
+		expect(mockKeys.set).not.toHaveBeenCalled()
+	})
+
+	it.each([
+		['PSA', '0@c.us'],
+		['bot', '13135550001@c.us'],
+		['MetaAI', '13135550002@bot'],
+		['group', 'abc-def@g.us']
+	])('skips storage for non-regular user (%s)', async (_label, from) => {
+		const node = makeMessageNode(from, { t: RECENT_TS })
+
+		const stored = await storeTcTokenFromMessageNode({ node, keys: mockKeys, getLIDForPN: noopGetLID })
+
+		expect(stored).toBeUndefined()
+		expect(mockKeys.set).not.toHaveBeenCalled()
 	})
 })


### PR DESCRIPTION
Fixes WhiskeySockets/Baileys#2698, #2707

The existing tc-token subsystem (tc-token-utils.ts, handlePrivacyTokenNotification, the 463-recovery branch in messages-recv.ts) only ever obtained tokens reactively — via an explicit privacy_token notification, or by issuing a fresh one after already hitting a 463. Nothing read the <tctoken> child WhatsApp attaches directly to incoming <message> stanzas, which is how WA Web (WAWebSetTcTokenChatAction. handleIncomingTcToken) opportunistically keeps a token on hand for warm contacts before a reply is ever attempted — tc-token-utils.ts's own isRegularUser docstring already referenced this WA Web behavior 'for parity', but it was never wired up.

Adds storeTcTokenFromMessageNode (tc-token-utils.ts), following the same isRegularUser filtering, sender_lid-aware resolution, and timestamp-dedup storage shape as storeTcTokensFromIqResult. Wired into handleMessage, fire-and-forget, right after encNode is computed and before the msmsg early-return, so capture doesn't depend on the message body being decryptable.

Adds unit tests (tc-token.test.ts) and a socket-level wiring test (messages-recv.test.ts) proving an incoming message carrying a <tctoken> child results in a real authState.keys.set call through the actual CB:message handler.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proactively capture tc-tokens from incoming message stanzas so replies to warm contacts don’t hit 463 recovery. Fixes WhiskeySockets/Baileys#2698 and #2707.

- **New Features**
  - Added storeTcTokenFromMessageNode: saves the token only for regular users, prefers sender_lid, resolves LID when needed, and dedups by timestamp.
  - Hooked into handleMessage before decryption; fire-and-forget and tracks stored JID.
  - Added tests: unit coverage for edge cases and a socket-level test proving keys.set is called via CB:message.

<sup>Written for commit 6194870aef34aeb595dae38823d49e2645e3a261. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically captures valid tctoken data from incoming messages.
  * Stores tokens using the most accurate sender identifier available.
  * Preserves existing token information while updating newer values.

* **Bug Fixes**
  * Ignores invalid, outdated, incomplete, or unsupported token data without interrupting message processing.

* **Tests**
  * Added coverage for token storage, validation, timestamp handling, and sender identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->