### PR TITLE
Fix: Enhance updateProfileStatus with emoji and duration

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -373,24 +373,35 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	}
 
 	/** update the profile status for yourself */
-	const updateProfileStatus = async (status: string) => {
+	const updateProfileStatus = async (status: string, emoji: string, duration: number) => {
 		await query({
 			tag: 'iq',
 			attrs: {
 				to: S_WHATSAPP_NET,
-				type: 'set',
-				xmlns: 'status'
+				type: 'get',
+				xmlns: 'w:mex'
 			},
 			content: [
 				{
-					tag: 'status',
-					attrs: {},
-					content: Buffer.from(status, 'utf-8')
+					tag: 'query',
+					attrs: { query_id: '9152604461510864' },
+					content: Buffer.from(
+						JSON.stringify({
+							variables: {
+								input: {
+									text: status.slice(0, 50),
+									emoji: { content: emoji },
+									ephemeral_duration_sec: duration
+								}
+							}
+						}),
+						'utf-8'
+					)
 				}
 			]
 		})
 	}
-
+	
 	const updateProfileName = async (name: string) => {
 		await chatModify({ pushNameSetting: name }, '')
 	}

--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -389,7 +389,7 @@ export const makeChatsSocket = (config: SocketConfig) => {
 						JSON.stringify({
 							variables: {
 								input: {
-									text: status.slice(0, 50),
+									text: Array.from(status).slice(0, 50).join(''),
 									emoji: { content: emoji },
 									ephemeral_duration_sec: duration
 								}


### PR DESCRIPTION
This commit fixes updateProfileStatus() function to accept emoji and duration parameters as per new whatsapp web changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated updateProfileStatus to accept emoji and duration and to use the new WhatsApp Web `w:mex` query. Trims status text to 50 Unicode characters to avoid broken emoji and failed updates.

- **Migration**
  - Update calls to `updateProfileStatus(status, emoji, duration)` where `duration` is in seconds.
  - Pass an emoji string (e.g., "😊") or an empty string if none.

<sup>Written for commit 9a469c758bcb19a05746d3617c10c883457d375e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile status updates now support custom emojis and expiration durations.
  * Status text is limited to 50 characters for improved consistency.
  * Status changes are applied through the updated profile-status experience for more reliable updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->