### PR TITLE
fix: parse statusV3Messages from INITIAL_STATUS_V3 history sync

### DIFF
--- a/src/Utils/history.ts
+++ b/src/Utils/history.ts
@@ -126,6 +126,12 @@ export const processHistoryMessage = (item: proto.IHistorySync, logger?: ILogger
 			}
 
 			break
+		case proto.HistorySync.HistorySyncType.INITIAL_STATUS_V3:
+			for (const msg of item.statusV3Messages || []) {
+				messages.push(msg as WAMessage)
+			}
+
+			break
 	}
 
 	return {

--- a/src/__tests__/Utils/history.test.ts
+++ b/src/__tests__/Utils/history.test.ts
@@ -429,4 +429,74 @@ describe('processHistoryMessage', () => {
 			expect(result.pastParticipants).toEqual(pastParticipants)
 		})
 	})
+
+	describe('INITIAL_STATUS_V3 processing', () => {
+		it('should extract statusV3Messages into messages', () => {
+			const historySync: proto.IHistorySync = {
+				syncType: proto.HistorySync.HistorySyncType.INITIAL_STATUS_V3,
+				statusV3Messages: [
+					{
+						key: { remoteJid: 'status@broadcast', fromMe: true, id: 'AAAAAAAAAAAAAAAA' },
+						message: { imageMessage: { caption: 'my status' } },
+						messageTimestamp: 1700000000
+					},
+					{
+						key: { remoteJid: 'status@broadcast', fromMe: false, id: 'BBBBBBBBBBBBBBBB' },
+						message: { extendedTextMessage: { text: 'someone else' } },
+						messageTimestamp: 1700000001
+					}
+				]
+			}
+
+			const result = processHistoryMessage(historySync)
+
+			expect(result.messages).toHaveLength(2)
+			expect(result.messages[0]!.key.id).toBe('AAAAAAAAAAAAAAAA')
+			expect(result.messages[1]!.key.id).toBe('BBBBBBBBBBBBBBBB')
+		})
+
+		it('should preserve userReceipt on status messages', () => {
+			const historySync: proto.IHistorySync = {
+				syncType: proto.HistorySync.HistorySyncType.INITIAL_STATUS_V3,
+				statusV3Messages: [
+					{
+						key: { remoteJid: 'status@broadcast', fromMe: true, id: 'CCCCCCCCCCCCCCCC' },
+						message: { imageMessage: {} },
+						userReceipt: [
+							{ userJid: '1234567890123@s.whatsapp.net', readTimestamp: 1700000005 },
+							{ userJid: '9876543210987@s.whatsapp.net', receiptTimestamp: 1700000006 }
+						]
+					}
+				]
+			}
+
+			const result = processHistoryMessage(historySync)
+
+			expect(result.messages[0]!.userReceipt).toHaveLength(2)
+			expect(result.messages[0]!.userReceipt![0]!.readTimestamp).toBe(1700000005)
+		})
+
+		it('should return empty messages when statusV3Messages is absent', () => {
+			const historySync: proto.IHistorySync = {
+				syncType: proto.HistorySync.HistorySyncType.INITIAL_STATUS_V3
+			}
+
+			const result = processHistoryMessage(historySync)
+
+			expect(result.messages).toEqual([])
+			expect(result.chats).toEqual([])
+			expect(result.contacts).toEqual([])
+		})
+
+		it('should return empty messages when statusV3Messages is empty', () => {
+			const historySync: proto.IHistorySync = {
+				syncType: proto.HistorySync.HistorySyncType.INITIAL_STATUS_V3,
+				statusV3Messages: []
+			}
+
+			const result = processHistoryMessage(historySync)
+
+			expect(result.messages).toEqual([])
+		})
+	})
 })


### PR DESCRIPTION
`INITIAL_STATUS_V3` blobs get downloaded but never parsed. `processHistoryMessage` has no case for it, so it falls through the switch and returns empty arrays. `statusV3Messages` isn't read anywhere in the codebase.

Everything else is already in place: `PROCESSABLE_HISTORY_TYPES` includes the type so the blob passes the whitelist, and `validate-connection.ts` sends `historySyncConfig` so the server offers the phase. So we download it on every connect and throw it away.

This adds the missing case.

Tested on an account with 4 statuses posted before linking. Before, the blob is accepted but no `messaging-history.set` fires for syncType 1. After:

```
[BLOB] syncType=1 fields: statusV3Messages[508], phoneNumberToLidMappings[130], syncType
[history-set] INITIAL_STATUS_V3(1) isLatest=true messages=1473
```

All 4 came through with `key.fromMe === true`, captions, media that downloads fine, and `userReceipt` populated. View counts matched the app exactly (71, 37, 37, 32).

One note for anyone using this: a view is a read receipt. `userReceipt.length` counts everyone it was delivered to, which is a much bigger number.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse `INITIAL_STATUS_V3` history sync so status messages posted before linking are imported instead of dropped. This ensures `messaging-history.set` fires for sync type 1 and statuses include media, captions, and receipts.

- **Bug Fixes**
  - Handle `INITIAL_STATUS_V3` in `processHistoryMessage` by pushing `statusV3Messages` into `messages`, with tests covering extraction, `userReceipt` preservation, and empty/missing arrays.

<sup>Written for commit ab87fe64b40c44e04df628ee11fcd97209485df7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

