### PR TITLE
feat(socket): observation hooks for inbound frames and decrypted payloads

### DIFF
--- a/packages/baileys/src/Socket/messages-recv.ts
+++ b/packages/baileys/src/Socket/messages-recv.ts
@@ -1698,7 +1698,14 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				category,
 				author,
 				decrypt
-			} = decryptMessageNode(node, authState.creds.me!.id, authState.creds.me!.lid || '', signalRepository, logger)
+			} = decryptMessageNode(
+				node,
+				authState.creds.me!.id,
+				authState.creds.me!.lid || '',
+				signalRepository,
+				logger,
+				config.onDecryptedPayload
+			)
 
 			const alt = msg.key.participantAlt || msg.key.remoteJidAlt
 			// store new mappings we didn't have before

--- a/packages/baileys/src/Socket/socket.ts
+++ b/packages/baileys/src/Socket/socket.ts
@@ -741,7 +741,15 @@ export const makeSocket = (config: SocketConfig) => {
 
 	const onMessageReceived = async (data: Buffer) => {
 		await noise.decodeFrame(data, (frame, decoded) => {
-			config.onFrameDecoded?.(frame, decoded)
+			if (config.onFrameDecoded) {
+				try {
+					config.onFrameDecoded(frame, decoded)
+				} catch (err) {
+					// Observation must not stop dispatch. Throwing here would
+					// abandon this frame and any others already buffered.
+					logger.error({ err }, 'onFrameDecoded threw')
+				}
+			}
 
 			// reset ping timeout
 			lastDateRecv = new Date()

--- a/packages/baileys/src/Socket/socket.ts
+++ b/packages/baileys/src/Socket/socket.ts
@@ -740,7 +740,9 @@ export const makeSocket = (config: SocketConfig) => {
 	}
 
 	const onMessageReceived = async (data: Buffer) => {
-		await noise.decodeFrame(data, frame => {
+		await noise.decodeFrame(data, (frame, decoded) => {
+			config.onFrameDecoded?.(frame, decoded)
+
 			// reset ping timeout
 			lastDateRecv = new Date()
 

--- a/packages/baileys/src/Types/Socket.ts
+++ b/packages/baileys/src/Types/Socket.ts
@@ -132,7 +132,9 @@ export type SocketConfig = {
 	/**
 	 * Called for every inbound frame, with the bytes it was decoded from.
 	 *
-	 * Exceptions are logged and swallowed.
+	 * Those bytes are read-only: the node points into them, so writing to them
+	 * corrupts the stanza before the socket handles it. Exceptions are logged
+	 * and swallowed.
 	 */
 	onFrameDecoded?: OnFrame
 

--- a/packages/baileys/src/Types/Socket.ts
+++ b/packages/baileys/src/Types/Socket.ts
@@ -129,7 +129,11 @@ export type SocketConfig = {
 		| PatchedMessageWithRecipientJID[]
 		| PatchedMessageWithRecipientJID
 
-	/** Called for every inbound frame, with the bytes it was decoded from. */
+	/**
+	 * Called for every inbound frame, with the bytes it was decoded from.
+	 *
+	 * Exceptions are logged and swallowed.
+	 */
 	onFrameDecoded?: OnFrame
 
 	/**

--- a/packages/baileys/src/Types/Socket.ts
+++ b/packages/baileys/src/Types/Socket.ts
@@ -1,7 +1,9 @@
 import type { Agent } from 'https'
 import type { URL } from 'url'
 import { proto } from '../../WAProto/index.js'
+import type { OnDecryptedPayload } from '../Utils/decode-wa-message'
 import type { ILogger } from '../Utils/logger'
+import type { OnFrame } from '../Utils/noise-handler'
 import type { AuthenticationState, LIDMapping, SignalAuthState, TransactionCapabilityOptions } from './Auth'
 import type { GroupMetadata } from './GroupMetadata'
 import { type MediaConnInfo, type WAMessageKey } from './Message'
@@ -126,6 +128,17 @@ export type SocketConfig = {
 		| Promise<PatchedMessageWithRecipientJID[] | PatchedMessageWithRecipientJID>
 		| PatchedMessageWithRecipientJID[]
 		| PatchedMessageWithRecipientJID
+
+	/** Called for every inbound frame, with the bytes it was decoded from. */
+	onFrameDecoded?: OnFrame
+
+	/**
+	 * Called for every `<enc>` payload after Signal decrypts it.
+	 *
+	 * Fires later than {@link onFrameDecoded}: the frame is there at decode
+	 * time, the plaintext only after decryption.
+	 */
+	onDecryptedPayload?: OnDecryptedPayload
 
 	/** verify app state MACs */
 	appStateMacVerification: {

--- a/packages/baileys/src/Utils/decode-wa-message.ts
+++ b/packages/baileys/src/Utils/decode-wa-message.ts
@@ -265,8 +265,13 @@ export function decodeMessageNode(stanza: BinaryNode, meId: string, meLid: strin
  * Called for each `<enc>` payload right after Signal decrypts it, before the
  * protobuf is parsed.
  *
+ * Only for `<enc>` children. A `<plaintext>` child never went through Signal
+ * and its bytes are already in the frame.
+ *
  * Also fires when unpadding throws, with `unpadded` false. The ratchet has
  * already advanced by then, so the plaintext would otherwise be lost.
+ *
+ * Exceptions from the callback are logged and swallowed.
  *
  * `plaintext` is only valid during the call. Copy it if you keep it.
  */
@@ -359,17 +364,33 @@ export const decryptMessageNode = (
 								throw new Error(`Unknown e2e type: ${e2eType}`)
 						}
 
+						// Only <enc>: a <plaintext> child never went through Signal
+						// and its bytes are already in the frame. Errors are
+						// swallowed so a throwing callback cannot mark a message
+						// undecryptable, or mask the unpad error below.
+						const observe = (payload: Uint8Array, unpadded: boolean) => {
+							if (tag !== 'enc' || !onDecryptedPayload) {
+								return
+							}
+
+							try {
+								onDecryptedPayload({ stanza, childIndex, encType: e2eType, plaintext: payload, unpadded })
+							} catch (err) {
+								logger.error({ key: fullMessage.key, err }, 'onDecryptedPayload threw')
+							}
+						}
+
 						let plaintext: Uint8Array
 						try {
 							plaintext = e2eType !== 'plaintext' ? unpadRandomMax16(msgBuffer) : msgBuffer
 						} catch (err) {
 							// The ratchet already advanced, so hand the plaintext
 							// over before rethrowing or it is lost for good.
-							onDecryptedPayload?.({ stanza, childIndex, encType: e2eType, plaintext: msgBuffer, unpadded: false })
+							observe(msgBuffer, false)
 							throw err
 						}
 
-						onDecryptedPayload?.({ stanza, childIndex, encType: e2eType, plaintext, unpadded: true })
+						observe(plaintext, true)
 
 						let msg: proto.IMessage = proto.Message.decode(plaintext)
 						msg = msg.deviceSentMessage?.message || msg

--- a/packages/baileys/src/Utils/decode-wa-message.ts
+++ b/packages/baileys/src/Utils/decode-wa-message.ts
@@ -271,11 +271,15 @@ export function decodeMessageNode(stanza: BinaryNode, meId: string, meLid: strin
  * Also fires when unpadding throws, with `unpadded` false. The ratchet has
  * already advanced by then, so the plaintext would otherwise be lost.
  *
- * The callback cannot affect decryption: `plaintext` is a copy it owns, and
- * exceptions from it are logged and swallowed.
+ * `plaintext` is a copy the callback owns, and exceptions from it are logged
+ * and swallowed, so neither can affect decryption.
+ *
+ * `stanza` is the live node rather than a snapshot, so treat it as read-only.
+ * Removing or rewriting a child the loop has not reached yet changes what gets
+ * decrypted.
  */
 export type OnDecryptedPayload = (payload: {
-	/** The `<message>` stanza this `<enc>` belongs to. */
+	/** The `<message>` stanza this `<enc>` belongs to. Read-only, see above. */
 	stanza: BinaryNode
 	/** Index of the `<enc>` among all of the stanza's children, not just the `<enc>` ones. */
 	childIndex: number
@@ -366,10 +370,11 @@ export const decryptMessageNode = (
 						// Only <enc>: a <plaintext> child never went through Signal
 						// and its bytes are already in the frame.
 						//
-						// The callback gets a copy and errors from it are
-						// swallowed, so observing cannot change what a message
-						// decodes to, mark it undecryptable, or mask the unpad
-						// error below. These same bytes go to the parser next.
+						// The callback gets a copy of the plaintext, since these
+						// same bytes go to the parser next, and its errors are
+						// swallowed so it cannot mark a message undecryptable or
+						// mask the unpad error below. The stanza it also gets is
+						// live, and documented read-only for that reason.
 						const observe = (payload: Uint8Array, unpadded: boolean) => {
 							if (tag !== 'enc' || !onDecryptedPayload) {
 								return

--- a/packages/baileys/src/Utils/decode-wa-message.ts
+++ b/packages/baileys/src/Utils/decode-wa-message.ts
@@ -261,12 +261,35 @@ export function decodeMessageNode(stanza: BinaryNode, meId: string, meLid: strin
 	}
 }
 
+/**
+ * Called for each `<enc>` payload right after Signal decrypts it, before the
+ * protobuf is parsed.
+ *
+ * Also fires when unpadding throws, with `unpadded` false. The ratchet has
+ * already advanced by then, so the plaintext would otherwise be lost.
+ *
+ * `plaintext` is only valid during the call. Copy it if you keep it.
+ */
+export type OnDecryptedPayload = (payload: {
+	/** The `<message>` stanza this `<enc>` belongs to. */
+	stanza: BinaryNode
+	/** Index of the `<enc>` among all of the stanza's children, not just the `<enc>` ones. */
+	childIndex: number
+	/** The `<enc>` node's `type` attribute. */
+	encType: string
+	/** The decrypted bytes, not yet parsed. */
+	plaintext: Uint8Array
+	/** False if unpadding threw. */
+	unpadded: boolean
+}) => void
+
 export const decryptMessageNode = (
 	stanza: BinaryNode,
 	meId: string,
 	meLid: string,
 	repository: SignalRepositoryWithLIDStore,
-	logger: ILogger
+	logger: ILogger,
+	onDecryptedPayload?: OnDecryptedPayload
 ) => {
 	const { fullMessage, author, sender } = decodeMessageNode(stanza, meId, meLid)
 	return {
@@ -276,7 +299,7 @@ export const decryptMessageNode = (
 		async decrypt() {
 			let decryptables = 0
 			if (Array.isArray(stanza.content)) {
-				for (const { tag, attrs, content } of stanza.content) {
+				for (const [childIndex, { tag, attrs, content }] of stanza.content.entries()) {
 					if (tag === 'verified_name' && content instanceof Uint8Array) {
 						const cert = proto.VerifiedNameCertificate.decode(content)
 						const details = proto.VerifiedNameCertificate.Details.decode(cert.details!)
@@ -336,9 +359,19 @@ export const decryptMessageNode = (
 								throw new Error(`Unknown e2e type: ${e2eType}`)
 						}
 
-						let msg: proto.IMessage = proto.Message.decode(
-							e2eType !== 'plaintext' ? unpadRandomMax16(msgBuffer) : msgBuffer
-						)
+						let plaintext: Uint8Array
+						try {
+							plaintext = e2eType !== 'plaintext' ? unpadRandomMax16(msgBuffer) : msgBuffer
+						} catch (err) {
+							// The ratchet already advanced, so hand the plaintext
+							// over before rethrowing or it is lost for good.
+							onDecryptedPayload?.({ stanza, childIndex, encType: e2eType, plaintext: msgBuffer, unpadded: false })
+							throw err
+						}
+
+						onDecryptedPayload?.({ stanza, childIndex, encType: e2eType, plaintext, unpadded: true })
+
+						let msg: proto.IMessage = proto.Message.decode(plaintext)
 						msg = msg.deviceSentMessage?.message || msg
 						if (msg.senderKeyDistributionMessage) {
 							//eslint-disable-next-line max-depth

--- a/packages/baileys/src/Utils/decode-wa-message.ts
+++ b/packages/baileys/src/Utils/decode-wa-message.ts
@@ -271,9 +271,8 @@ export function decodeMessageNode(stanza: BinaryNode, meId: string, meLid: strin
  * Also fires when unpadding throws, with `unpadded` false. The ratchet has
  * already advanced by then, so the plaintext would otherwise be lost.
  *
- * Exceptions from the callback are logged and swallowed.
- *
- * `plaintext` is only valid during the call. Copy it if you keep it.
+ * The callback cannot affect decryption: `plaintext` is a copy it owns, and
+ * exceptions from it are logged and swallowed.
  */
 export type OnDecryptedPayload = (payload: {
 	/** The `<message>` stanza this `<enc>` belongs to. */
@@ -365,16 +364,25 @@ export const decryptMessageNode = (
 						}
 
 						// Only <enc>: a <plaintext> child never went through Signal
-						// and its bytes are already in the frame. Errors are
-						// swallowed so a throwing callback cannot mark a message
-						// undecryptable, or mask the unpad error below.
+						// and its bytes are already in the frame.
+						//
+						// The callback gets a copy and errors from it are
+						// swallowed, so observing cannot change what a message
+						// decodes to, mark it undecryptable, or mask the unpad
+						// error below. These same bytes go to the parser next.
 						const observe = (payload: Uint8Array, unpadded: boolean) => {
 							if (tag !== 'enc' || !onDecryptedPayload) {
 								return
 							}
 
 							try {
-								onDecryptedPayload({ stanza, childIndex, encType: e2eType, plaintext: payload, unpadded })
+								onDecryptedPayload({
+									stanza,
+									childIndex,
+									encType: e2eType,
+									plaintext: new Uint8Array(payload),
+									unpadded
+								})
 							} catch (err) {
 								logger.error({ key: fullMessage.key, err }, 'onDecryptedPayload threw')
 							}

--- a/packages/baileys/src/Utils/noise-handler.ts
+++ b/packages/baileys/src/Utils/noise-handler.ts
@@ -74,7 +74,9 @@ class TransportState {
  * format byte stripped. Not set during the handshake, where frames are not
  * nodes yet.
  *
- * It is a view into the decrypted frame, not a copy. Copy it if you keep it.
+ * It is a view into the decrypted frame, not a copy, and the node's own binary
+ * content points into the same bytes. Treat it as read-only and copy it if you
+ * keep it: writing to it corrupts the stanza before the socket handles it.
  */
 export type OnFrame = (frame: Uint8Array | BinaryNode, decoded?: Uint8Array) => void
 

--- a/packages/baileys/src/Utils/noise-handler.ts
+++ b/packages/baileys/src/Utils/noise-handler.ts
@@ -4,7 +4,7 @@ import { proto } from '../../WAProto/index.js'
 import { NOISE_MODE, WA_CERT_DETAILS } from '../Defaults'
 import type { KeyPair } from '../Types'
 import type { BinaryNode } from '../WABinary'
-import { decodeBinaryNode } from '../WABinary'
+import { decodeBinaryNodeWithBuffer } from '../WABinary'
 import { aesDecryptGCM, aesEncryptGCM, Curve, hkdf, sha256 } from './crypto'
 import type { ILogger } from './logger'
 
@@ -67,6 +67,17 @@ class TransportState {
 	}
 }
 
+/**
+ * Called for each decoded frame.
+ *
+ * `decoded` is the buffer the node was parsed from, inflated and with the
+ * format byte stripped. Not set during the handshake, where frames are not
+ * nodes yet.
+ *
+ * It is a view into the decrypted frame, not a copy. Copy it if you keep it.
+ */
+export type OnFrame = (frame: Uint8Array | BinaryNode, decoded?: Uint8Array) => void
+
 export const makeNoiseHandler = ({
 	keyPair: { private: privateKey, public: publicKey },
 	NOISE_HEADER,
@@ -102,7 +113,7 @@ export const makeNoiseHandler = ({
 
 	let transport: TransportState | null = null
 	let isWaitingForTransport = false
-	let pendingOnFrame: ((buff: Uint8Array | BinaryNode) => void) | null = null
+	let pendingOnFrame: OnFrame | null = null
 
 	let introHeader: Buffer
 	if (routingInfo) {
@@ -179,7 +190,7 @@ export const makeNoiseHandler = ({
 		}
 	}
 
-	const processData = async (onFrame: (buff: Uint8Array | BinaryNode) => void) => {
+	const processData = async (onFrame: OnFrame) => {
 		let size: number | undefined
 
 		while (true) {
@@ -192,16 +203,19 @@ export const makeNoiseHandler = ({
 			let frame: Uint8Array | BinaryNode = inBytes.subarray(3, size + 3)
 			inBytes = inBytes.subarray(size + 3)
 
+			let decoded: Uint8Array | undefined
+
 			if (transport) {
-				const result = transport.decrypt(frame)
-				frame = await decodeBinaryNode(result)
+				const result = await decodeBinaryNodeWithBuffer(transport.decrypt(frame))
+				decoded = result.decompressed
+				frame = result.node
 			}
 
 			if (logger.level === 'trace') {
 				logger.trace({ msg: (frame as BinaryNode)?.attrs?.id }, 'recv frame')
 			}
 
-			onFrame(frame)
+			onFrame(frame, decoded)
 		}
 	}
 
@@ -284,7 +298,7 @@ export const makeNoiseHandler = ({
 
 			return frame
 		},
-		decodeFrame: (newData: Buffer | Uint8Array, onFrame: (buff: Uint8Array | BinaryNode) => void) => {
+		decodeFrame: (newData: Buffer | Uint8Array, onFrame: OnFrame) => {
 			// M10: serialize the inBytes mutation + processData drain.
 			return decodeFrameMutex.runExclusive(async () => {
 				if (isWaitingForTransport) {

--- a/packages/baileys/src/WABinary/decode.ts
+++ b/packages/baileys/src/WABinary/decode.ts
@@ -306,3 +306,15 @@ export const decodeBinaryNode = async (buff: Buffer): Promise<BinaryNode> => {
 	const decompBuff = await decompressingIfRequired(buff)
 	return decodeDecompressedBinaryNode(decompBuff, constants)
 }
+
+/**
+ * Same as {@link decodeBinaryNode}, but also returns the decompressed buffer.
+ *
+ * Useful if you need the stanza's original bytes. Re-encoding the node can
+ * produce different bytes than what was received, since a value often has more
+ * than one valid encoding.
+ */
+export const decodeBinaryNodeWithBuffer = async (buff: Buffer): Promise<{ node: BinaryNode; decompressed: Buffer }> => {
+	const decompressed = await decompressingIfRequired(buff)
+	return { node: decodeDecompressedBinaryNode(decompressed, constants), decompressed }
+}

--- a/packages/baileys/src/__tests__/Utils/frame-observation.test.ts
+++ b/packages/baileys/src/__tests__/Utils/frame-observation.test.ts
@@ -114,6 +114,55 @@ describe('a decrypted payload is reported per <enc>', () => {
 		expect(seen[0]!.unpadded).toBe(false)
 		expect(Buffer.from(seen[0]!.bytes)).toEqual(Buffer.from(badlyPadded))
 	})
+
+	it('ignores a <plaintext> child, which never went through Signal', async () => {
+		const { decryptMessageNode } = await import('../../Utils/decode-wa-message')
+
+		const stanza: BinaryNode = {
+			tag: 'message',
+			attrs: { id: 'M3', from: '5511999998888@s.whatsapp.net', t: '1' },
+			content: [{ tag: 'plaintext', attrs: {}, content: decryptedMessage() }]
+		}
+
+		const seen: unknown[] = []
+		const { decrypt } = decryptMessageNode(
+			stanza,
+			'5511111111111:1@s.whatsapp.net',
+			'',
+			echoingRepository() as never,
+			createSilentLogger() as never,
+			payload => seen.push(payload)
+		)
+		await decrypt()
+
+		expect(seen).toHaveLength(0)
+	})
+
+	it('keeps decrypting when the callback throws', async () => {
+		const { decryptMessageNode } = await import('../../Utils/decode-wa-message')
+
+		const stanza: BinaryNode = {
+			tag: 'message',
+			attrs: { id: 'M4', from: '5511999998888@s.whatsapp.net', t: '1' },
+			content: [{ tag: 'enc', attrs: { type: 'msg', v: '2' }, content: padRandomMax16(decryptedMessage()) }]
+		}
+
+		const { fullMessage, decrypt } = decryptMessageNode(
+			stanza,
+			'5511111111111:1@s.whatsapp.net',
+			'',
+			echoingRepository() as never,
+			createSilentLogger() as never,
+			() => {
+				throw new Error('observer blew up')
+			}
+		)
+		await decrypt()
+
+		// Not a CIPHERTEXT stub: the message decrypted, the observer did not.
+		expect(fullMessage.messageStubType).toBeUndefined()
+		expect(fullMessage.message?.conversation).toBe('hello')
+	})
 })
 
 /** Hands the ciphertext straight back, so the test covers the hook and not libsignal. */

--- a/packages/baileys/src/__tests__/Utils/frame-observation.test.ts
+++ b/packages/baileys/src/__tests__/Utils/frame-observation.test.ts
@@ -1,0 +1,140 @@
+import { jest } from '@jest/globals'
+import { proto } from '../../../WAProto/index.js'
+import { decodeBinaryNodeWithBuffer, encodeBinaryNode } from '../../WABinary'
+import type { BinaryNode } from '../../WABinary/types'
+
+describe('frame bytes travel alongside the node', () => {
+	it('hands back the buffer the node was decoded from', async () => {
+		const node: BinaryNode = {
+			tag: 'message',
+			attrs: { id: 'ABCD1234', from: '5511999998888@s.whatsapp.net' },
+			content: [{ tag: 'enc', attrs: { type: 'msg' }, content: new Uint8Array([1, 2, 3]) }]
+		}
+
+		const encoded = encodeBinaryNode(node)
+		const { node: decoded, decompressed } = await decodeBinaryNodeWithBuffer(encoded)
+
+		expect(decoded.tag).toBe('message')
+		expect(decoded.attrs.id).toBe('ABCD1234')
+
+		// The format byte is stripped, since that is what the decoder consumed.
+		expect(Buffer.from(decompressed)).toEqual(encoded.subarray(1))
+	})
+
+	it('gives bytes that decode to the same node a second time', async () => {
+		const node: BinaryNode = {
+			tag: 'receipt',
+			attrs: { id: 'R1', from: '5511999998888@s.whatsapp.net', type: 'read' }
+		}
+
+		const { decompressed } = await decodeBinaryNodeWithBuffer(encodeBinaryNode(node))
+		// Format byte prefixed back, since that is what the entry point takes.
+		const again = await decodeBinaryNodeWithBuffer(Buffer.concat([Buffer.of(0), decompressed]))
+
+		expect(again.node).toEqual((await decodeBinaryNodeWithBuffer(encodeBinaryNode(node))).node)
+	})
+})
+
+describe('a decrypted payload is reported per <enc>', () => {
+	const decryptedMessage = () => proto.Message.encode({ conversation: 'hello' }).finish()
+
+	/** Pad to a 16-byte boundary the way WhatsApp does. */
+	const padRandomMax16 = (bytes: Uint8Array) => {
+		const pad = 16 - (bytes.length % 16)
+		const out = new Uint8Array(bytes.length + pad)
+		out.set(bytes)
+		out.fill(pad, bytes.length)
+		return out
+	}
+
+	it('addresses a payload by the child index it came from, not by counting <enc>', async () => {
+		const { decryptMessageNode } = await import('../../Utils/decode-wa-message')
+		const plaintext = decryptedMessage()
+
+		// `<enc>` at child index 1, which catches anyone counting `<enc>`
+		// nodes instead of children.
+		const stanza: BinaryNode = {
+			tag: 'message',
+			attrs: { id: 'M1', from: '5511999998888@s.whatsapp.net', t: '1' },
+			content: [
+				{ tag: 'participants', attrs: {} },
+				{ tag: 'enc', attrs: { type: 'msg', v: '2' }, content: padRandomMax16(plaintext) }
+			]
+		}
+
+		const seen: { childIndex: number; encType: string; unpadded: boolean; bytes: Uint8Array }[] = []
+		const { decrypt } = decryptMessageNode(
+			stanza,
+			'5511111111111:1@s.whatsapp.net',
+			'',
+			echoingRepository() as never,
+			createSilentLogger() as never,
+			payload =>
+				seen.push({
+					childIndex: payload.childIndex,
+					encType: payload.encType,
+					unpadded: payload.unpadded,
+					bytes: payload.plaintext
+				})
+		)
+		await decrypt()
+
+		expect(seen).toHaveLength(1)
+		expect(seen[0]!.childIndex).toBe(1)
+		expect(seen[0]!.encType).toBe('msg')
+		expect(seen[0]!.unpadded).toBe(true)
+		expect(Buffer.from(seen[0]!.bytes)).toEqual(Buffer.from(plaintext))
+	})
+
+	it('hands over a plaintext whose padding will not strip', async () => {
+		const { decryptMessageNode } = await import('../../Utils/decode-wa-message')
+
+		// A padding byte claiming more than the buffer holds. The ratchet has
+		// already advanced, so this plaintext exists exactly once.
+		const badlyPadded = new Uint8Array([1, 2, 3, 99])
+
+		const stanza: BinaryNode = {
+			tag: 'message',
+			attrs: { id: 'M2', from: '5511999998888@s.whatsapp.net', t: '1' },
+			content: [{ tag: 'enc', attrs: { type: 'msg', v: '2' }, content: badlyPadded }]
+		}
+
+		const seen: { unpadded: boolean; bytes: Uint8Array }[] = []
+		const { decrypt } = decryptMessageNode(
+			stanza,
+			'5511111111111:1@s.whatsapp.net',
+			'',
+			echoingRepository() as never,
+			createSilentLogger() as never,
+			payload => seen.push({ unpadded: payload.unpadded, bytes: payload.plaintext })
+		)
+		await decrypt()
+
+		expect(seen).toHaveLength(1)
+		expect(seen[0]!.unpadded).toBe(false)
+		expect(Buffer.from(seen[0]!.bytes)).toEqual(Buffer.from(badlyPadded))
+	})
+})
+
+/** Hands the ciphertext straight back, so the test covers the hook and not libsignal. */
+const echoingRepository = () => ({
+	decryptMessage: jest.fn(async ({ ciphertext }: { ciphertext: Uint8Array }) => ciphertext),
+	decryptGroupMessage: jest.fn(),
+	processSenderKeyDistributionMessage: jest.fn(),
+	lidMapping: {
+		getLIDForPN: jest.fn(async () => undefined),
+		getPNForLID: jest.fn(async () => undefined),
+		storeLIDPNMappings: jest.fn(async () => {})
+	}
+})
+
+const createSilentLogger = () => ({
+	child: jest.fn().mockReturnThis(),
+	trace: jest.fn(),
+	debug: jest.fn(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	fatal: jest.fn(),
+	level: 'silent'
+})

--- a/packages/baileys/src/__tests__/Utils/frame-observation.test.ts
+++ b/packages/baileys/src/__tests__/Utils/frame-observation.test.ts
@@ -138,6 +138,30 @@ describe('a decrypted payload is reported per <enc>', () => {
 		expect(seen).toHaveLength(0)
 	})
 
+	it('is handed a copy, so it cannot change what the message decodes to', async () => {
+		const { decryptMessageNode } = await import('../../Utils/decode-wa-message')
+
+		const stanza: BinaryNode = {
+			tag: 'message',
+			attrs: { id: 'M5', from: '5511999998888@s.whatsapp.net', t: '1' },
+			content: [{ tag: 'enc', attrs: { type: 'msg', v: '2' }, content: padRandomMax16(decryptedMessage()) }]
+		}
+
+		const { fullMessage, decrypt } = decryptMessageNode(
+			stanza,
+			'5511111111111:1@s.whatsapp.net',
+			'',
+			echoingRepository() as never,
+			createSilentLogger() as never,
+			// These bytes go to the protobuf parser right after this returns.
+			payload => payload.plaintext.fill(0xff)
+		)
+		await decrypt()
+
+		expect(fullMessage.messageStubType).toBeUndefined()
+		expect(fullMessage.message?.conversation).toBe('hello')
+	})
+
 	it('keeps decrypting when the callback throws', async () => {
 		const { decryptMessageNode } = await import('../../Utils/decode-wa-message')
 

--- a/packages/baileys/src/__tests__/Utils/frame-observation.test.ts
+++ b/packages/baileys/src/__tests__/Utils/frame-observation.test.ts
@@ -51,14 +51,15 @@ describe('a decrypted payload is reported per <enc>', () => {
 		const { decryptMessageNode } = await import('../../Utils/decode-wa-message')
 		const plaintext = decryptedMessage()
 
-		// `<enc>` at child index 1, which catches anyone counting `<enc>`
-		// nodes instead of children.
+		// Two `<enc>` at child indices 1 and 2. Counting `<enc>` nodes instead
+		// would report 0 and 1, so the positions have to be the child ones.
 		const stanza: BinaryNode = {
 			tag: 'message',
 			attrs: { id: 'M1', from: '5511999998888@s.whatsapp.net', t: '1' },
 			content: [
 				{ tag: 'participants', attrs: {} },
-				{ tag: 'enc', attrs: { type: 'msg', v: '2' }, content: padRandomMax16(plaintext) }
+				{ tag: 'enc', attrs: { type: 'msg', v: '2' }, content: padRandomMax16(plaintext) },
+				{ tag: 'enc', attrs: { type: 'pkmsg', v: '2' }, content: padRandomMax16(plaintext) }
 			]
 		}
 
@@ -79,10 +80,9 @@ describe('a decrypted payload is reported per <enc>', () => {
 		)
 		await decrypt()
 
-		expect(seen).toHaveLength(1)
-		expect(seen[0]!.childIndex).toBe(1)
-		expect(seen[0]!.encType).toBe('msg')
-		expect(seen[0]!.unpadded).toBe(true)
+		expect(seen.map(entry => entry.childIndex)).toEqual([1, 2])
+		expect(seen.map(entry => entry.encType)).toEqual(['msg', 'pkmsg'])
+		expect(seen.every(entry => entry.unpadded)).toBe(true)
 		expect(Buffer.from(seen[0]!.bytes)).toEqual(Buffer.from(plaintext))
 	})
 
@@ -147,6 +147,7 @@ describe('a decrypted payload is reported per <enc>', () => {
 			content: [{ tag: 'enc', attrs: { type: 'msg', v: '2' }, content: padRandomMax16(decryptedMessage()) }]
 		}
 
+		let calls = 0
 		const { fullMessage, decrypt } = decryptMessageNode(
 			stanza,
 			'5511111111111:1@s.whatsapp.net',
@@ -154,10 +155,15 @@ describe('a decrypted payload is reported per <enc>', () => {
 			echoingRepository() as never,
 			createSilentLogger() as never,
 			() => {
+				calls += 1
 				throw new Error('observer blew up')
 			}
 		)
 		await decrypt()
+
+		// Without this the test would also pass if the callback never ran, which
+		// is the other way to not see an exception.
+		expect(calls).toBe(1)
 
 		// Not a CIPHERTEXT stub: the message decrypted, the observer did not.
 		expect(fullMessage.messageStubType).toBeUndefined()


### PR DESCRIPTION
Two optional callbacks for code that needs to observe the receive path without changing it. Both are off by default.

### `onFrameDecoded(frame, decoded)`

`frame` is the parsed node, as before. `decoded` is the buffer it was parsed from, inflated and with the format byte stripped.

Re-encoding a decoded node does not reliably give back the bytes that came in, since a value can have more than one valid encoding. If you forward stanzas to another process, or compare two clients byte for byte, you need the originals.

`processData` already had that buffer in scope and let it fall out right after decoding. This adds `decodeBinaryNodeWithBuffer`, which does exactly what `decodeBinaryNode` does and also returns the decompressed buffer, and passes it to `onFrame`. It is a view into the decrypted frame, not a copy.

### `onDecryptedPayload({ stanza, childIndex, encType, plaintext, unpadded })`

Fires right after Signal decrypts an `<enc>`, before the protobuf is parsed.

It also fires when `unpadRandomMax16` throws, with `unpadded: false`. That case is the reason I think this one earns its place on its own: the ratchet has already advanced by then, so the plaintext exists exactly once, and right now it goes away with the exception. Nothing downstream can distinguish a message that never arrived from one that arrived and failed to unpad.

Only `<enc>` children. A `<plaintext>` child is a sibling tag that never goes through Signal, and its bytes are already in the frame. `<enc type="plaintext">` still reports, since that is an `<enc>`.

Payloads are addressed by child index rather than by counting `<enc>` nodes, since a `<message>` carries other children too and a fan-out message numbers the copies for your own device after the direct ones.

### Cost when nobody is observing

Not quite zero, so to be exact about it: `decodeBinaryNodeWithBuffer` allocates one short-lived `{ node, decompressed }` object per inbound frame whether or not a callback is set. Everything else is a nullish check.

I benchmarked it against `decodeBinaryNode` at 30k frames per round over 5 alternating rounds, warming every case before measuring any, and the difference is -0.7%, inside the run-to-run spread. I opted not to branch on whether an observer is configured: the noise handler does not know that (the socket always passes an `onFrame`), so it would mean threading a flag through `decodeFrame` and keeping two decode paths that can drift apart. Happy to do it if you would rather have the branch.

### Observing cannot change what arrives

`onDecryptedPayload` gets its own copy of the plaintext. It used to receive the same array the protobuf parser reads on the next line, so an observer that wrote to it changed what the message decoded to, turning a good message into a `CIPHERTEXT` stub. The copy also means the buffer is the callback's to keep, with no lifetime caveat.

The `stanza` in that payload is still the live node, and the loop reads its children array as it goes, so a callback that splices it or rewrites a later child's content does change what the remaining `<enc>` nodes decrypt to. It is documented read-only rather than copied: a per-`<enc>` copy would be quadratic in ciphertext, and it would be odd here alone when `onFrameDecoded` and `ws.emit('frame')` both hand over the live node. If you would rather the payload carried only the stanza's id, or a frozen shallow copy, that is an easy change.

`onFrameDecoded`'s buffer is deliberately **not** copied, since handing the bytes over without copying them is the whole point, and a consumer that keeps them can copy. Worth flagging explicitly though: the node's binary content points into those same bytes, so an observer that writes to them corrupts the stanza before the socket handles it. The docs now say so. If you would rather that hook were also copy-on-handover, say the word, but it costs a full frame copy on every inbound frame (I measured +15% and +2KB per frame) and it would defeat the reason to add it.

### Errors from callbacks are contained

A throwing `onFrameDecoded` escaped into `processData`'s loop, which dropped the current frame and left anything already buffered undispatched until more data arrived. A throwing `onDecryptedPayload` was caught by the decrypt error handler, so a bug in an observer marked good messages as `CIPHERTEXT`, and on the unpad path it replaced the real error with its own. Both are logged through the existing logger and swallowed.

### Notes

- `decodeBinaryNode` is untouched, so existing callers see nothing.
- `pnpm lint` is 0 errors and adds no new warnings (262 before and after). `pnpm test` is 509 passing. I did not run e2e locally.
- Tests in `src/__tests__/Utils/frame-observation.test.ts` cover the returned buffer, a round trip through it, child indices with two `<enc>` present, the failed unpad path, a `<plaintext>` child being skipped, and decryption surviving a callback that throws or writes to the plaintext.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional callbacks for observing decoded incoming frames and decrypted message payloads.
  * Preserved decompressed frame data for inspection alongside decoded messages.
  * Decryption observations include payload details, child indexes, encryption type, and padding status.
  * Observation errors are safely logged without interrupting message or frame processing.

* **Tests**
  * Added coverage for frame observation, payload reporting, re-decoding, and invalid padding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->