### PR TITLE
fix: retry decrypt with stanza-provided LID/PN pairing on session mismatch

### DIFF
--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -224,11 +224,17 @@ export const decryptMessageNode = (
 										{ key: fullMessage.key, primary: user, retryWith: altUser },
 										'primary identity failed to decrypt, retrying with stanza-provided PN/LID pairing'
 									)
-									msgBuffer = await repository.decryptMessage({
-										jid: altUser,
-										type: e2eType,
-										ciphertext: content
-									})
+									try {
+										msgBuffer = await repository.decryptMessage({
+											jid: altUser,
+											type: e2eType,
+											ciphertext: content
+										})
+									} catch {
+										// preserve the original, more informative error
+										// (e.g. "Bad MAC") over the retry's (e.g. "no session")
+										throw err
+									}
 								}
 
 								break

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -190,14 +190,49 @@ export const decryptMessageNode = (
 								})
 								break
 							case 'pkmsg':
-							case 'msg':
+							case 'msg': {
 								const user = isJidUser(sender) ? sender : author
-								msgBuffer = await repository.decryptMessage({
-									jid: user,
-									type: e2eType,
-									ciphertext: content
-								})
+								try {
+									msgBuffer = await repository.decryptMessage({
+										jid: user,
+										type: e2eType,
+										ciphertext: content
+									})
+								} catch (err) {
+									// WhatsApp tags this exact stanza with both identity
+									// forms (sender_pn/sender_lid, or participant_pn/
+									// participant_lid for group messages) whenever it
+									// knows the pairing. If the primary address's
+									// session doesn't verify, retry once with the OTHER
+									// form WhatsApp itself paired to this message before
+									// giving up — fixes persistent "Bad MAC" when our
+									// stored session and the sender's current session
+									// were established under different identity forms
+									// of the same device (own-account multi-device sync
+									// is the case observed in production; the same gap
+									// applies to any contact mid-migration to LID). See
+									// https://github.com/WhiskeySockets/Baileys/issues/2234
+									// and https://github.com/WhiskeySockets/Baileys/issues/2321.
+									const altUser = isLidUser(user)
+										? stanza.attrs.participant_pn || stanza.attrs.sender_pn
+										: stanza.attrs.participant_lid || stanza.attrs.sender_lid
+									if (!altUser || altUser === user) {
+										throw err
+									}
+
+									logger.debug(
+										{ key: fullMessage.key, primary: user, retryWith: altUser },
+										'primary identity failed to decrypt, retrying with stanza-provided PN/LID pairing'
+									)
+									msgBuffer = await repository.decryptMessage({
+										jid: altUser,
+										type: e2eType,
+										ciphertext: content
+									})
+								}
+
 								break
+							}
 							case 'plaintext':
 								msgBuffer = content
 								break


### PR DESCRIPTION
## Summary

- Retry decryption with the identity form (LID or phone-number JID) that WhatsApp itself paired to a stanza, when the primary address fails to decrypt.
- Applies to both `pkmsg` and `msg` message types, for 1:1 chats (`sender_pn`/`sender_lid`) and group messages (`participant_pn`/`participant_lid`).

## Root cause

`decryptMessageNode` picks a single JID form (`sender`/`author`, derived from the stanza's `from`/`participant`) and passes it straight to `repository.decryptMessage`. When a device's session was established under one identity form (phone-number JID or LID) but a later stanza addresses the same device using the other form, session lookup fails and `libsignal` throws `Bad MAC` — even though a working session for that exact device already exists under the other address.

This isn't session corruption: `session_cipher.js` decrypts by walking every stored session state for the address it's given, and a stanza addressed under the "wrong" form for us never reaches the session that would actually verify. WhatsApp already tells us the pairing on the stanza itself — `sender_pn`/`sender_lid` (1:1) and `participant_pn`/`participant_lid` (groups) — but `decryptMessageNode` never reads them before deciding which address to decrypt against.

Most reproducible with an account's own multi-device sync traffic (a linked companion device sends self-sync stanzas addressed via LID while the receiving companion's session for that device was established via the phone-number JID, or vice versa), but the same gap applies to any contact mid-migration to LID.

## Fix

On a decrypt failure for `pkmsg`/`msg`, check whether the stanza carries the *other* identity form for the same sender (`participant_pn`/`sender_pn` when the primary attempt used a LID, `participant_lid`/`sender_lid` when it used a phone-number JID). If so, retry once against that address before giving up. No retry is attempted when the stanza doesn't carry the alternate form, or when it's identical to the one already tried — third-party sessions that never touch this code path are unaffected.

## Testing

Deployed to a production long-running bot (Baileys 6.7.24) that was previously hitting continuous `Bad MAC` on its own account's multi-device sync traffic — restarting every 1-2 minutes for 11+ hours before this change (self-sync stanzas were the only source of the failures; no group or 1:1 message content was ever affected). After deploying this fix: zero `Bad MAC`/`Failed to decrypt` occurrences over a clean run, versus a steady background rate beforehand. Confirmed via `docker logs`, comparing exact-match counts (`Session error:Error: Bad MAC`) before and after.

Related: #635, #1437, #1725, #1734, #1754, #2079, #2234, #2321

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries decryption with the stanza’s paired identity (LID or phone-number JID) when the primary address fails, fixing persistent “Bad MAC” from session identity mismatches. Preserves the original decrypt error if the retry also fails.

- Applies to `pkmsg` and `msg` for 1:1 (`sender_pn`/`sender_lid`) and groups (`participant_pn`/`participant_lid`).
- On decrypt failure, retries once with the other identity from the stanza; skips retry when the alternate is missing or identical.
- If both attempts fail, rethrows the original error (e.g., “Bad MAC”) instead of the retry’s error.
- Adds a debug log when a retry is attempted.

<sup>Written for commit c82d22d22ee01db739b781e1df064f019bff94e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

