### PR TITLE
fix(socket): rotate the adv secret on companion_reg_refresh and re-render the QR

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -38,8 +38,10 @@ import {
 	getCompanionPlatformId,
 	getErrorCodeFromStreamError,
 	getNextPreKeysNode,
+	handleCompanionRegRefresh,
 	makeEventBuffer,
 	makeNoiseHandler,
+	makePairingQRRenderer,
 	promiseTimeout,
 	signedKeyPair,
 	xmppSignedPreKey
@@ -868,6 +870,9 @@ export const makeSocket = (config: SocketConfig) => {
 		'CB:xmlstreamend',
 		() => void end(new Boom('Connection Terminated by Server', { statusCode: DisconnectReason.connectionClosed }))
 	)
+	// Re-render the QR currently on screen. Set while a pairing QR flow is
+	// live on this connection, undefined otherwise.
+	let refreshPairingQR: (() => void) | undefined
 	// QR gen
 	ws.on('CB:iq,type:set,pair-device', async (stanza: BinaryNode) => {
 		const iq: BinaryNode = {
@@ -884,7 +889,17 @@ export const makeSocket = (config: SocketConfig) => {
 		const refNodes = getBinaryNodeChildren(pairDeviceNode, 'ref')
 		const noiseKeyB64 = Buffer.from(creds.noiseKey.public).toString('base64')
 		const identityKeyB64 = Buffer.from(creds.signedIdentityKey.public).toString('base64')
-		const advB64 = creds.advSecretKey
+
+		const renderer = makePairingQRRenderer(
+			refNodes.map(refNode => (refNode.content as Buffer).toString('utf-8')),
+			// creds.advSecretKey is read per render rather than captured once:
+			// a companion_reg_refresh rotates it mid-flow.
+			ref =>
+				ev.emit('connection.update', {
+					qr: buildPairingQRData(ref, noiseKeyB64, identityKeyB64, creds.advSecretKey, browser)
+				})
+		)
+		refreshPairingQR = () => void renderer.refresh()
 
 		let qrMs = qrTimeout || 60_000 // time to let a QR live
 		const genPairQR = () => {
@@ -892,22 +907,29 @@ export const makeSocket = (config: SocketConfig) => {
 				return
 			}
 
-			const refNode = refNodes.shift()
-			if (!refNode) {
+			if (!renderer.next()) {
 				void end(new Boom('QR refs attempts ended', { statusCode: DisconnectReason.timedOut }))
 				return
 			}
-
-			const ref = (refNode.content as Buffer).toString('utf-8')
-			const qr = buildPairingQRData(ref, noiseKeyB64, identityKeyB64, advB64, browser)
-
-			ev.emit('connection.update', { qr })
 
 			qrTimer = setTimeout(genPairQR, qrMs)
 			qrMs = qrTimeout || 20_000 // shorter subsequent qrs
 		}
 
 		genPairQR()
+	})
+	// the server retiring an unpaired companion's registration material
+	ws.on('CB:notification,type:companion_reg_refresh', (node: BinaryNode) => {
+		handleCompanionRegRefresh(node, {
+			creds,
+			emitCredsUpdate: update => ev.emit('creds.update', update),
+			// Deliberately re-renders the ref already on screen and leaves
+			// qrTimer alone: that ref has not expired, only the secret it
+			// advertises changed. Spending a ref here would drain the pool the
+			// server allotted and end the flow with 'QR refs attempts ended'.
+			refreshQR: () => refreshPairingQR?.(),
+			logger
+		})
 	})
 	// device paired for the first time
 	// if device pairs successfully, the server asks to restart the connection

--- a/src/Utils/companion-reg-client-utils.ts
+++ b/src/Utils/companion-reg-client-utils.ts
@@ -1,4 +1,7 @@
-import type { WABrowserDescription } from '../Types'
+import { randomBytes } from 'crypto'
+import type { AuthenticationCreds, WABrowserDescription } from '../Types'
+import { type BinaryNode, getBinaryNodeChild } from '../WABinary'
+import type { ILogger } from './logger'
 
 export enum CompanionWebClientType {
 	UNKNOWN = 0,
@@ -45,4 +48,100 @@ export const buildPairingQRData = (
 		'https://wa.me/settings/linked_devices#' +
 		[ref, noiseKeyB64, identityKeyB64, advB64, getCompanionPlatformId(browser)].join(',')
 	)
+}
+
+export type PairingQRRenderer = {
+	/** Render the next ref's QR. False once the server's allotment is spent. */
+	next(): boolean
+	/** Re-render the QR on screen. Consumes no ref; false if none is shown yet. */
+	refresh(): boolean
+}
+
+/**
+ * Holds the ref currently on screen so it can be re-rendered.
+ *
+ * `render` is called with the ref rather than a finished payload so the caller
+ * can read the adv secret at render time: a `companion_reg_refresh` rotates it
+ * mid-flow, and every QR emitted afterwards has to advertise the new value.
+ */
+export const makePairingQRRenderer = (refs: string[], render: (ref: string) => void): PairingQRRenderer => {
+	let index = 0
+	let current: string | undefined
+
+	return {
+		next() {
+			const ref = refs[index]
+			if (ref === undefined) {
+				return false
+			}
+
+			index += 1
+			current = ref
+			render(ref)
+			return true
+		},
+		refresh() {
+			if (current === undefined) {
+				return false
+			}
+
+			render(current)
+			return true
+		}
+	}
+}
+
+export type CompanionRegRefreshContext = {
+	creds: AuthenticationCreds
+	emitCredsUpdate: (update: Partial<AuthenticationCreds>) => void
+	refreshQR: () => void
+	logger: ILogger
+}
+
+export type CompanionRegRefreshOutcome = 'rotated' | 'ignored_malformed' | 'ignored_registered'
+
+/** The two children WA Web's parser accepts on this notification. */
+const COMPANION_REG_REFRESH_CHILDREN = ['companion_reg_refresh', 'pair-device-rotate-qr'] as const
+
+/**
+ * `<notification type="companion_reg_refresh">` - the server retiring an
+ * unpaired companion's registration material.
+ *
+ * WA Web accepts the stanza with either a `companion_reg_refresh` or a
+ * `pair-device-rotate-qr` child, rejects it when neither is present, and
+ * answers by regenerating the adv secret key. That key is a quarter of what
+ * the pairing QR advertises, so a client that only acks keeps offering a QR
+ * built on a secret the server has already retired: the phone scans it,
+ * reports a failed link, and no pair-success ever arrives.
+ *
+ * The ack itself is unchanged - the generic notification path already sends
+ * it - so this only adds the rotation and the re-render.
+ */
+export const handleCompanionRegRefresh = (
+	node: BinaryNode,
+	{ creds, emitCredsUpdate, refreshQR, logger }: CompanionRegRefreshContext
+): CompanionRegRefreshOutcome => {
+	if (!COMPANION_REG_REFRESH_CHILDREN.some(tag => getBinaryNodeChild(node, tag))) {
+		logger.warn({ node }, 'companion_reg_refresh carries neither expected child; ignoring')
+		return 'ignored_malformed'
+	}
+
+	// WA Web rotates unconditionally; a registered session is the one case
+	// where that is wrong here. `creds.me` is set by pair-success and by
+	// requestPairingCode, and in both cases the adv secret is what a completed
+	// or pending pairing is verified against - re-minting it would break the
+	// session rather than refresh a pending registration.
+	if (creds.me) {
+		logger.debug('companion_reg_refresh on a registered session; keeping the adv secret')
+		return 'ignored_registered'
+	}
+
+	// Same construction as initAuthCreds and as WA Web's generateADVSecretKey:
+	// 32 CSPRNG bytes, base64.
+	creds.advSecretKey = randomBytes(32).toString('base64')
+	emitCredsUpdate({ advSecretKey: creds.advSecretKey })
+
+	logger.info('rotated the adv secret the server asked to retire; re-rendering the pairing QR')
+	refreshQR()
+	return 'rotated'
 }

--- a/src/Utils/companion-reg-client-utils.ts
+++ b/src/Utils/companion-reg-client-utils.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from 'crypto'
 import type { AuthenticationCreds, WABrowserDescription } from '../Types'
-import { type BinaryNode, getBinaryNodeChild } from '../WABinary'
+import type { BinaryNode } from '../WABinary'
+import { getBinaryNodeChild } from '../WABinary'
 import type { ILogger } from './logger'
 
 export enum CompanionWebClientType {
@@ -132,7 +133,7 @@ export const handleCompanionRegRefresh = (
 	// or pending pairing is verified against - re-minting it would break the
 	// session rather than refresh a pending registration.
 	if (creds.me) {
-		logger.debug('companion_reg_refresh on a registered session; keeping the adv secret')
+		logger.debug({ id: node.attrs.id }, 'companion_reg_refresh on a registered session; keeping the adv secret')
 		return 'ignored_registered'
 	}
 
@@ -141,7 +142,7 @@ export const handleCompanionRegRefresh = (
 	creds.advSecretKey = randomBytes(32).toString('base64')
 	emitCredsUpdate({ advSecretKey: creds.advSecretKey })
 
-	logger.info('rotated the adv secret the server asked to retire; re-rendering the pairing QR')
+	logger.info({ id: node.attrs.id }, 'rotated the adv secret the server asked to retire; re-rendering the pairing QR')
 	refreshQR()
 	return 'rotated'
 }

--- a/src/__tests__/Socket/companion-reg-refresh.test.ts
+++ b/src/__tests__/Socket/companion-reg-refresh.test.ts
@@ -93,8 +93,11 @@ const bootUnpairedSocket = async () => {
 	// registered up front so a failing expectation still shuts the socket down:
 	// its QR timer would otherwise outlive the test
 	cleanups.push(async () => {
-		await sock.end(new Error('test finished'))
-		await clear()
+		try {
+			await sock.end(new Error('test finished'))
+		} finally {
+			await clear()
+		}
 	})
 
 	const qrs: string[] = []
@@ -118,31 +121,34 @@ describe('CB:notification,type:companion_reg_refresh', () => {
 		}
 	})
 
-	it('rotates the adv secret and re-renders the QR on screen', async () => {
-		const { sock, creds, qrs, credsUpdates } = await bootUnpairedSocket()
+	it.each(['companion_reg_refresh', 'pair-device-rotate-qr'])(
+		'rotates the adv secret and re-renders the QR on screen for a <%s> child',
+		async childTag => {
+			const { sock, creds, qrs, credsUpdates } = await bootUnpairedSocket()
 
-		deliver(sock.ws, pairDeviceIq())
-		await settle()
-		expect(qrs).toHaveLength(1)
+			deliver(sock.ws, pairDeviceIq())
+			await settle()
+			expect(qrs).toHaveLength(1)
 
-		const retiredSecret = creds.advSecretKey
-		deliver(sock.ws, refreshNotification('companion_reg_refresh'))
-		await settle()
+			const retiredSecret = creds.advSecretKey
+			deliver(sock.ws, refreshNotification(childTag))
+			await settle()
 
-		// rotated, and handed to the auth store
-		expect(creds.advSecretKey).not.toBe(retiredSecret)
-		expect(Buffer.from(creds.advSecretKey, 'base64')).toHaveLength(32)
-		expect(credsUpdates).toContainEqual({ advSecretKey: creds.advSecretKey })
+			// rotated, and handed to the auth store
+			expect(creds.advSecretKey).not.toBe(retiredSecret)
+			expect(Buffer.from(creds.advSecretKey, 'base64')).toHaveLength(32)
+			expect(credsUpdates).toContainEqual({ advSecretKey: creds.advSecretKey })
 
-		// re-rendered: same ref, new secret. A fresh ref would spend one of the
-		// pool the server allotted, for a ref that has not expired.
-		expect(qrs).toHaveLength(2)
-		const [before, after] = qrs.map(qrFields)
-		expect(after![0]).toBe(before![0])
-		expect(after![0]).toBe(REFS[0])
-		expect(after![3]).toBe(creds.advSecretKey)
-		expect(after![3]).not.toBe(before![3])
-	})
+			// re-rendered: same ref, new secret. A fresh ref would spend one of the
+			// pool the server allotted, for a ref that has not expired.
+			expect(qrs).toHaveLength(2)
+			const [before, after] = qrs.map(qrFields)
+			expect(after![0]).toBe(before![0])
+			expect(after![0]).toBe(REFS[0])
+			expect(after![3]).toBe(creds.advSecretKey)
+			expect(after![3]).not.toBe(before![3])
+		}
+	)
 
 	it('ignores a notification carrying neither expected child', async () => {
 		const { sock, creds, qrs, credsUpdates } = await bootUnpairedSocket()

--- a/src/__tests__/Socket/companion-reg-refresh.test.ts
+++ b/src/__tests__/Socket/companion-reg-refresh.test.ts
@@ -1,0 +1,161 @@
+import { jest } from '@jest/globals'
+import { EventEmitter } from 'events'
+import P from 'pino'
+import type { AuthenticationCreds } from '../../Types'
+import type { BinaryNode } from '../../WABinary'
+
+/**
+ * The socket only reaches the network through the `ws` package, so faking that
+ * one module is enough to hold a connection open. Everything the stanza is
+ * routed through - the real WebSocketClient and the `CB:*` fan-out its
+ * listeners are keyed on - stays in play.
+ */
+class FakeWebSocket extends EventEmitter {
+	static readonly CONNECTING = 0
+	static readonly OPEN = 1
+	static readonly CLOSING = 2
+	static readonly CLOSED = 3
+
+	readyState: number = FakeWebSocket.OPEN
+
+	send(data: Uint8Array | string, cb?: (err?: Error) => void) {
+		cb?.()
+	}
+
+	close() {
+		this.readyState = FakeWebSocket.CLOSED
+		this.emit('close')
+	}
+}
+
+jest.unstable_mockModule('ws', () => ({ __esModule: true, default: FakeWebSocket }))
+
+// Imported after the mock is registered: mock factories are not hoisted in ESM.
+const { DEF_CALLBACK_PREFIX, DEFAULT_CONNECTION_CONFIG } = await import('../../Defaults')
+const { default: makeWASocket } = await import('../../Socket')
+const { makeSession } = await import('../TestUtils/session')
+
+const logger = P({ level: 'silent' })
+
+const REFS = ['ref-1', 'ref-2']
+
+const pairDeviceIq = (): BinaryNode => ({
+	tag: 'iq',
+	attrs: { from: 's.whatsapp.net', type: 'set', id: 'pair-device-1' },
+	content: [
+		{
+			tag: 'pair-device',
+			attrs: {},
+			content: REFS.map(ref => ({ tag: 'ref', attrs: {}, content: Buffer.from(ref, 'utf-8') }))
+		}
+	]
+})
+
+const refreshNotification = (childTag?: string): BinaryNode => ({
+	tag: 'notification',
+	attrs: { from: 's.whatsapp.net', id: 'notification-1', type: 'companion_reg_refresh' },
+	content: childTag ? [{ tag: childTag, attrs: {} }] : []
+})
+
+/**
+ * Mirrors the `CB:*` fan-out `onMessageReceived` performs, so a stanza reaches
+ * the handlers it would reach on a live connection - including the generic
+ * `CB:notification` one that acks it. Raw frames cannot be fed in instead: the
+ * noise transport only decodes them into binary nodes once a handshake has run.
+ */
+const deliver = (ws: EventEmitter, node: BinaryNode) => {
+	const childTag = Array.isArray(node.content) ? node.content[0]?.tag : ''
+
+	for (const [attr, value] of Object.entries(node.attrs)) {
+		ws.emit(`${DEF_CALLBACK_PREFIX}${node.tag},${attr}:${value},${childTag}`, node)
+		ws.emit(`${DEF_CALLBACK_PREFIX}${node.tag},${attr}:${value}`, node)
+		ws.emit(`${DEF_CALLBACK_PREFIX}${node.tag},${attr}`, node)
+	}
+
+	ws.emit(`${DEF_CALLBACK_PREFIX}${node.tag},,${childTag}`, node)
+	ws.emit(`${DEF_CALLBACK_PREFIX}${node.tag}`, node)
+}
+
+/** ref, noise key, identity key, adv secret, platform id - what the QR advertises */
+const qrFields = (qr: string) => qr.split('#')[1]!.split(',')
+
+/** the handlers ack and emit asynchronously; let those settle */
+const settle = () => new Promise(resolve => setTimeout(resolve, 50))
+
+const cleanups: Array<() => Promise<void>> = []
+
+const bootUnpairedSocket = async () => {
+	const { state, clear } = await makeSession()
+	// no creds.me: an unpaired companion, the only state the server sends this
+	// notification in
+	const sock = makeWASocket({ ...DEFAULT_CONNECTION_CONFIG, auth: state, logger })
+
+	// registered up front so a failing expectation still shuts the socket down:
+	// its QR timer would otherwise outlive the test
+	cleanups.push(async () => {
+		await sock.end(new Error('test finished'))
+		await clear()
+	})
+
+	const qrs: string[] = []
+	const credsUpdates: Partial<AuthenticationCreds>[] = []
+	sock.ev.on('connection.update', ({ qr }) => {
+		if (qr) {
+			qrs.push(qr)
+		}
+	})
+	sock.ev.on('creds.update', update => {
+		credsUpdates.push(update)
+	})
+
+	return { sock, creds: state.creds, qrs, credsUpdates }
+}
+
+describe('CB:notification,type:companion_reg_refresh', () => {
+	afterEach(async () => {
+		for (const cleanup of cleanups.splice(0)) {
+			await cleanup()
+		}
+	})
+
+	it('rotates the adv secret and re-renders the QR on screen', async () => {
+		const { sock, creds, qrs, credsUpdates } = await bootUnpairedSocket()
+
+		deliver(sock.ws, pairDeviceIq())
+		await settle()
+		expect(qrs).toHaveLength(1)
+
+		const retiredSecret = creds.advSecretKey
+		deliver(sock.ws, refreshNotification('companion_reg_refresh'))
+		await settle()
+
+		// rotated, and handed to the auth store
+		expect(creds.advSecretKey).not.toBe(retiredSecret)
+		expect(Buffer.from(creds.advSecretKey, 'base64')).toHaveLength(32)
+		expect(credsUpdates).toContainEqual({ advSecretKey: creds.advSecretKey })
+
+		// re-rendered: same ref, new secret. A fresh ref would spend one of the
+		// pool the server allotted, for a ref that has not expired.
+		expect(qrs).toHaveLength(2)
+		const [before, after] = qrs.map(qrFields)
+		expect(after![0]).toBe(before![0])
+		expect(after![0]).toBe(REFS[0])
+		expect(after![3]).toBe(creds.advSecretKey)
+		expect(after![3]).not.toBe(before![3])
+	})
+
+	it('ignores a notification carrying neither expected child', async () => {
+		const { sock, creds, qrs, credsUpdates } = await bootUnpairedSocket()
+
+		deliver(sock.ws, pairDeviceIq())
+		await settle()
+
+		const secretOnScreen = creds.advSecretKey
+		deliver(sock.ws, refreshNotification())
+		await settle()
+
+		expect(creds.advSecretKey).toBe(secretOnScreen)
+		expect(credsUpdates.some(update => 'advSecretKey' in update)).toBe(false)
+		expect(qrs).toHaveLength(1)
+	})
+})

--- a/src/__tests__/Socket/companion-reg-refresh.test.ts
+++ b/src/__tests__/Socket/companion-reg-refresh.test.ts
@@ -79,9 +79,6 @@ const deliver = (ws: EventEmitter, node: BinaryNode) => {
 /** ref, noise key, identity key, adv secret, platform id - what the QR advertises */
 const qrFields = (qr: string) => qr.split('#')[1]!.split(',')
 
-/** the handlers ack and emit asynchronously; let those settle */
-const settle = () => new Promise(resolve => setTimeout(resolve, 50))
-
 const cleanups: Array<() => Promise<void>> = []
 
 const bootUnpairedSocket = async () => {
@@ -111,7 +108,28 @@ const bootUnpairedSocket = async () => {
 		credsUpdates.push(update)
 	})
 
-	return { sock, creds: state.creds, qrs, credsUpdates }
+	const waitForQR = () =>
+		new Promise<string>(resolve => {
+			const listener = ({ qr }: { qr?: string }) => {
+				if (qr) {
+					sock.ev.off('connection.update', listener)
+					resolve(qr)
+				}
+			}
+
+			sock.ev.on('connection.update', listener)
+		})
+	const waitForCredsUpdate = () =>
+		new Promise<Partial<AuthenticationCreds>>(resolve => {
+			const listener = (update: Partial<AuthenticationCreds>) => {
+				sock.ev.off('creds.update', listener)
+				resolve(update)
+			}
+
+			sock.ev.on('creds.update', listener)
+		})
+
+	return { sock, creds: state.creds, qrs, credsUpdates, waitForQR, waitForCredsUpdate }
 }
 
 describe('CB:notification,type:companion_reg_refresh', () => {
@@ -124,15 +142,18 @@ describe('CB:notification,type:companion_reg_refresh', () => {
 	it.each(['companion_reg_refresh', 'pair-device-rotate-qr'])(
 		'rotates the adv secret and re-renders the QR on screen for a <%s> child',
 		async childTag => {
-			const { sock, creds, qrs, credsUpdates } = await bootUnpairedSocket()
+			const { sock, creds, qrs, credsUpdates, waitForQR, waitForCredsUpdate } = await bootUnpairedSocket()
 
+			const firstQR = waitForQR()
 			deliver(sock.ws, pairDeviceIq())
-			await settle()
+			await firstQR
 			expect(qrs).toHaveLength(1)
 
 			const retiredSecret = creds.advSecretKey
+			const refreshedQR = waitForQR()
+			const credsUpdate = waitForCredsUpdate()
 			deliver(sock.ws, refreshNotification(childTag))
-			await settle()
+			await Promise.all([refreshedQR, credsUpdate])
 
 			// rotated, and handed to the auth store
 			expect(creds.advSecretKey).not.toBe(retiredSecret)
@@ -151,14 +172,14 @@ describe('CB:notification,type:companion_reg_refresh', () => {
 	)
 
 	it('ignores a notification carrying neither expected child', async () => {
-		const { sock, creds, qrs, credsUpdates } = await bootUnpairedSocket()
+		const { sock, creds, qrs, credsUpdates, waitForQR } = await bootUnpairedSocket()
 
+		const firstQR = waitForQR()
 		deliver(sock.ws, pairDeviceIq())
-		await settle()
+		await firstQR
 
 		const secretOnScreen = creds.advSecretKey
 		deliver(sock.ws, refreshNotification())
-		await settle()
 
 		expect(creds.advSecretKey).toBe(secretOnScreen)
 		expect(credsUpdates.some(update => 'advSecretKey' in update)).toBe(false)

--- a/src/__tests__/Utils/companion-reg-refresh.test.ts
+++ b/src/__tests__/Utils/companion-reg-refresh.test.ts
@@ -1,0 +1,155 @@
+import { jest } from '@jest/globals'
+import P from 'pino'
+import type { AuthenticationCreds } from '../../Types'
+import { initAuthCreds } from '../../Utils/auth-utils'
+import {
+	buildPairingQRData,
+	handleCompanionRegRefresh,
+	makePairingQRRenderer
+} from '../../Utils/companion-reg-client-utils'
+import type { BinaryNode } from '../../WABinary'
+
+const logger = P({ level: 'silent' })
+
+const notification = (childTag?: string): BinaryNode => ({
+	tag: 'notification',
+	attrs: { from: 's.whatsapp.net', id: '1', type: 'companion_reg_refresh' },
+	content: childTag ? [{ tag: childTag, attrs: {} }] : []
+})
+
+const context = (creds: AuthenticationCreds) => {
+	const emitCredsUpdate = jest.fn<(update: Partial<AuthenticationCreds>) => void>()
+	const refreshQR = jest.fn<() => void>()
+	return { ctx: { creds, emitCredsUpdate, refreshQR, logger }, emitCredsUpdate, refreshQR }
+}
+
+describe('handleCompanionRegRefresh', () => {
+	// WA Web's parser (WAWebHandleCompanionReqRefreshNotification) rejects the
+	// stanza outright unless one of these two children is present.
+	it.each(['companion_reg_refresh', 'pair-device-rotate-qr'])('rotates the adv secret for a <%s> child', childTag => {
+		const creds = initAuthCreds()
+		const before = creds.advSecretKey
+		const { ctx, emitCredsUpdate, refreshQR } = context(creds)
+
+		expect(handleCompanionRegRefresh(notification(childTag), ctx)).toBe('rotated')
+
+		expect(creds.advSecretKey).not.toBe(before)
+		expect(Buffer.from(creds.advSecretKey, 'base64')).toHaveLength(32)
+		expect(emitCredsUpdate).toHaveBeenCalledWith({ advSecretKey: creds.advSecretKey })
+		expect(refreshQR).toHaveBeenCalledTimes(1)
+	})
+
+	it('ignores a notification carrying neither expected child', () => {
+		const creds = initAuthCreds()
+		const before = creds.advSecretKey
+		const { ctx, emitCredsUpdate, refreshQR } = context(creds)
+
+		expect(handleCompanionRegRefresh(notification(), ctx)).toBe('ignored_malformed')
+		expect(handleCompanionRegRefresh(notification('something-else'), ctx)).toBe('ignored_malformed')
+
+		expect(creds.advSecretKey).toBe(before)
+		expect(emitCredsUpdate).not.toHaveBeenCalled()
+		expect(refreshQR).not.toHaveBeenCalled()
+	})
+
+	// creds.me is set by pair-success and by requestPairingCode. In both cases
+	// the adv secret is the one a pending or completed pairing was verified
+	// against, so re-minting it would break the session rather than refresh a
+	// pending registration.
+	it('leaves a registered session alone', () => {
+		const creds: AuthenticationCreds = {
+			...initAuthCreds(),
+			me: { id: '15551234567@s.whatsapp.net', name: '~' }
+		}
+		const before = creds.advSecretKey
+		const { ctx, emitCredsUpdate, refreshQR } = context(creds)
+
+		expect(handleCompanionRegRefresh(notification('companion_reg_refresh'), ctx)).toBe('ignored_registered')
+
+		expect(creds.advSecretKey).toBe(before)
+		expect(emitCredsUpdate).not.toHaveBeenCalled()
+		expect(refreshQR).not.toHaveBeenCalled()
+	})
+
+	it('mints a fresh secret every time, never a fixed one', () => {
+		const creds = initAuthCreds()
+		const { ctx } = context(creds)
+
+		handleCompanionRegRefresh(notification('companion_reg_refresh'), ctx)
+		const first = creds.advSecretKey
+		handleCompanionRegRefresh(notification('companion_reg_refresh'), ctx)
+
+		expect(creds.advSecretKey).not.toBe(first)
+	})
+})
+
+describe('makePairingQRRenderer', () => {
+	it('walks the server-allotted refs in order and reports exhaustion', () => {
+		const rendered: string[] = []
+		const renderer = makePairingQRRenderer(['ref-1', 'ref-2'], ref => rendered.push(ref))
+
+		expect(renderer.next()).toBe(true)
+		expect(renderer.next()).toBe(true)
+		expect(renderer.next()).toBe(false)
+		expect(rendered).toEqual(['ref-1', 'ref-2'])
+	})
+
+	it('re-renders the ref on screen without consuming one', () => {
+		const rendered: string[] = []
+		const renderer = makePairingQRRenderer(['ref-1', 'ref-2'], ref => rendered.push(ref))
+
+		renderer.next()
+		expect(renderer.refresh()).toBe(true)
+		expect(renderer.refresh()).toBe(true)
+
+		// The refreshes re-showed ref-1; ref-2 is still unspent.
+		expect(rendered).toEqual(['ref-1', 'ref-1', 'ref-1'])
+		expect(renderer.next()).toBe(true)
+		expect(rendered).toEqual(['ref-1', 'ref-1', 'ref-1', 'ref-2'])
+	})
+
+	it('refuses to refresh before a QR has been shown', () => {
+		const rendered: string[] = []
+		const renderer = makePairingQRRenderer(['ref-1'], ref => rendered.push(ref))
+
+		expect(renderer.refresh()).toBe(false)
+		expect(rendered).toEqual([])
+	})
+
+	it('does not exhaust the ref pool no matter how often the server asks', () => {
+		const renderer = makePairingQRRenderer(['ref-1'], () => {})
+
+		renderer.next()
+		for (let i = 0; i < 50; i++) {
+			expect(renderer.refresh()).toBe(true)
+		}
+
+		// One ref was allotted and one was spent: the pool is where it was.
+		expect(renderer.next()).toBe(false)
+	})
+})
+
+describe('a rotation while a QR is on screen', () => {
+	// This is the whole bug: the QR advertises the adv secret, so a QR built
+	// before the rotation is scannable but unpairable afterwards.
+	it('re-renders the same ref with the new secret', () => {
+		const creds = initAuthCreds()
+		const emitted: string[] = []
+		const renderer = makePairingQRRenderer(['ref-1', 'ref-2'], ref =>
+			emitted.push(buildPairingQRData(ref, 'noise', 'identity', creds.advSecretKey, ['Baileys', 'Chrome', '1']))
+		)
+		const { ctx } = context(creds)
+
+		renderer.next()
+		handleCompanionRegRefresh(notification('companion_reg_refresh'), {
+			...ctx,
+			refreshQR: () => void renderer.refresh()
+		})
+
+		expect(emitted).toHaveLength(2)
+		const [before, after] = emitted.map(qr => qr.split('#')[1]!.split(','))
+		expect(after![0]).toBe(before![0]) // same ref
+		expect(after![3]).not.toBe(before![3]) // rotated adv secret
+		expect(after![3]).toBe(creds.advSecretKey)
+	})
+})


### PR DESCRIPTION
Fixes #2737.

## Problem

The server sends `<notification type="companion_reg_refresh">` to an unpaired companion to retire the registration material it is currently advertising. Baileys has no handler for it: `handleNotification` acks it and `processNotification` drops it.

The adv secret is one of the four fields `buildPairingQRData` encodes, so from that notification onward the QR on screen advertises a secret the server has already retired. The phone scans it, reports a failed link, and no `pair-success` ever arrives. The flow stalls silently until the refs run out.

## Protocol basis

WA Web's `WAWebHandleCompanionReqRefreshNotification`:

- parses the stanza with `assertTag('notification')`, `assertAttr('type', 'companion_reg_refresh')`, and a parse error unless it has a `companion_reg_refresh` **or** `pair-device-rotate-qr` child;
- calls `WAWebAdvSignatureApi.generateADVSecretKey()`, which is `new Uint8Array(32)` + `crypto.getRandomValues` + base64;
- triggers `advSecretEventEmitter` `'change'`, which `WAWebLinkDeviceQrcode_react` listens to and re-renders the QR from — separately from the `Conn` `'change:ref'` listener that handles ref rotation. The refresh therefore re-renders the **current** ref rather than advancing to the next one;
- acks the notification.

Two independent clients handle it the same way: [`whatsapp-rust`](https://github.com/oxidezap/whatsapp-rust/blob/main/src/handlers/notification/companion_reg.rs) and [`zapo`](https://github.com/vinikjkkj/zapo/blob/main/src/auth/pairing/WaPairingFlow.ts) both accept only those two children, rotate the secret and re-render the current QR.

## Approach

- `handleCompanionRegRefresh` in `Utils/companion-reg-client-utils.ts` — the decision: accept only the two children, mint 32 CSPRNG bytes, emit `creds.update`, ask for a re-render.
- `makePairingQRRenderer` in the same file — holds the ref currently on screen so it can be re-rendered. `next()` walks the server's allotment; `refresh()` re-renders the current ref and consumes nothing. This is what keeps a burst of refresh notifications from draining the pool and ending the flow with `QR refs attempts ended`.
- `socket.ts` reads `creds.advSecretKey` **per render** rather than capturing it once, and leaves `qrTimer` untouched on a refresh: the ref has not expired, only the secret it carries changed.

One deliberate divergence from WA Web, which rotates unconditionally: a session with `creds.me` set is left alone. `creds.me` is set both by `pair-success` and by `requestPairingCode`, and in both cases the adv secret is what a completed or pending pairing is verified against (`configureSuccessfulPairing`, and the `link_code_companion_reg` HKDF in `messages-recv`), so re-minting it would break the session rather than refresh a pending registration.

## Tests

`src/__tests__/Utils/companion-reg-refresh.test.ts` covers the handler and renderer against mocked binary nodes: both accepted children rotate; a notification with neither is ignored with no side effects; a registered session is left alone; each rotation mints a fresh 32-byte key and emits it; the renderer walks refs in order and reports exhaustion; `refresh()` re-renders the same ref, returns false before any QR is shown, and 50 refreshes leave the pool exactly where it was; and a rotation while a QR is on screen re-emits a payload with the **same ref** and a **different adv secret**.

`src/__tests__/Socket/companion-reg-refresh.test.ts` routes mocked pairing and refresh nodes through the real socket `CB:` listener fan-out. It covers both accepted refresh child forms, verifies `creds.update` and a re-rendered QR with the same ref and new secret, and confirms malformed notifications are ignored. The test waits on the exact socket events instead of fixed sleeps and always clears temporary auth state in `finally`.

Each of the three guards was verified by sabotage — dropping the child check, dropping the registered-session check, and making `refresh()` consume a ref each fail the suite.

`yarn lint` 0 errors (no new warnings), `yarn test --runInBand` 420 passed / 30 suites, `yarn build` clean. e2e was not run locally — no bartender instance here.

## Risks and non-goals

- The QR emission path is restructured but its observable behaviour is unchanged when no refresh arrives: same refs, same order, same timings, same payload.
- No new stanza is put on the wire. The ack is untouched — `handleNotification` already sends one for every notification.
- Not addressed here: the pre-login ack crash. On master `sendMessageAck` reads `authState.creds.me!.id`, which throws for a notification that arrives before login. That is #2749's fix and is orthogonal — the two handlers are separate `CB:` listeners, so the rotation and re-render happen either way.

## Prior art

- #2741 (merged, `0af2386`) fixed the WIN32 → WIN_HYBRID sub-platform, which is what lets a desktop-identity client reach the QR at all. Not touched here.
- #2749 (open) fixes acking nodes before login, including this exact notification. Deliberately not duplicated; that PR owns `sendMessageAck`.
- #2608 (open) concerns an empty `link_code_companion_reg` in the pairing-code flow, a different stanza and a different path.

Drafted with Claude Code, reviewed and tested by me.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rotate the adv secret and re-render the current pairing QR when the server sends `companion_reg_refresh`, preventing stalled pairing flows. Fixes #2737.

- **Bug Fixes**
  - Handle `<notification type="companion_reg_refresh">` only when it has `companion_reg_refresh` or `pair-device-rotate-qr`.
  - Rotate `advSecretKey` (32 CSPRNG bytes), emit `creds.update`, and re-render the same QR ref; keep the QR timer unchanged.
  - Read `creds.advSecretKey` at render time so refreshed QRs use the new secret.
  - Skip rotation when `creds.me` is set to avoid breaking an active or pending pairing.
  - Added socket and utils tests; socket tests wait for QR and creds events to avoid race conditions and cover valid children, rotation, and QR re-render.

- **Refactors**
  - Added `makePairingQRRenderer` with `next()` and `refresh()` to re-render the current ref without consuming it.
  - Updated `socket.ts` to use the renderer and wire `handleCompanionRegRefresh` for QR refresh.

<sup>Written for commit 4f263f0e365c2e74dd1b824031d1c5910f518c26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic pairing QR refresh when companion registration details change.
  * QR codes now update with refreshed security credentials while preserving the current pairing reference.
  * Added handling for valid, malformed, and already-registered companion refresh notifications.

* **Bug Fixes**
  * Prevented unnecessary QR timer resets and reference consumption during refreshes.

* **Tests**
  * Added coverage for QR rendering, refresh behavior, credential rotation, and notification handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
