### PR TITLE
feat(socket): allow overriding companion_platform_display for code pairing

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -811,7 +811,10 @@ export const makeSocket = (config: SocketConfig) => {
 						{
 							tag: 'companion_platform_display',
 							attrs: {},
-							content: `${browser[1]} (${browser[0]})`
+							// See `companionPlatformDisplay` in SocketConfig: WhatsApp
+							// validates this string, so integrators branding `browser[0]`
+							// need a way to send something it recognises.
+							content: config.companionPlatformDisplay ?? `${browser[1]} (${browser[0]})`
 						},
 						{
 							tag: 'link_code_pairing_nonce',

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -51,6 +51,22 @@ export type SocketConfig = {
 	version: WAVersion
 	/** override browser config */
 	browser: WABrowserDescription
+	/**
+	 * Overrides the human-readable client description sent as
+	 * `companion_platform_display` when pairing by code.
+	 *
+	 * WhatsApp validates this field: an unrecognised value makes the server
+	 * answer `400 bad-request` to `companion_hello`. By default it is derived
+	 * from `browser` as `${browser[1]} (${browser[0]})`, which breaks pairing by
+	 * code for any integrator that puts a product name in `browser[0]` -- even
+	 * though that same value is accepted for QR pairing and is precisely what
+	 * the user then sees under "Linked devices".
+	 *
+	 * The failure is silent: `requestPairingCode()` returns a locally generated
+	 * code the server never accepted, so the code simply does not work when
+	 * typed, with nothing in the logs to say why.
+	 */
+	companionPlatformDisplay?: string
 	/** Initial pushName carried in the registration ClientPayload (used by mock servers for deterministic phone assignment). */
 	pushName?: string
 	/** agent used for fetch requests -- uploading/downloading media */


### PR DESCRIPTION
## The problem

WhatsApp **validates** the `companion_platform_display` field sent with `link_code_companion_reg`. Baileys derives it from the browser description:

```ts
content: `${browser[1]} (${browser[0]})`
```

But `browser[0]` is also what the user sees under **Linked devices** — which is why integrators put a product name there. QR pairing accepts any value happily. Pairing by code does not:

```xml
<iq from='@s.whatsapp.net' type='error' id='…'>
  <error code='400' text='bad-request'/>
</iq>
```

Measured against production WhatsApp on 2026-08-12 (rc14), reproduced on two accounts:

| `companion_platform_display` | Server reply |
|---|---|
| `Chrome (Acme)` | **400 bad-request** |
| `Chrome (Windows)` | **accepted** |

So today an integrator has to choose between naming their product and being able to link users by code.

## Why this is worth a fix rather than a note

**The failure is completely silent.** `requestPairingCode()` still returns a code — generated locally with `bytesToCrockford(randomBytes(5))`, before the stanza is even sent, and never acknowledged by the server. The promise resolves normally. The user types the code, nothing happens, and there is no error anywhere: not in the return value, not in the logs at default level, not on the phone beyond a generic "couldn't connect".

Only a `trace`-level dump of the stanza exchange reveals the 400. It took a full day to find.

There are several open issues that read like this same symptom — code returned, linking never completes, no diagnosis: #2764, #2759, #2590, #2008. I can't claim they are all this cause, but the shape matches, and none has a diagnosis attached.

## The change

An optional `companionPlatformDisplay` on `SocketConfig`. When unset, the payload is **byte-identical** to before — no behaviour change for existing users.

```ts
const sock = makeWASocket({
  browser: ['My Product', 'Chrome', '10.0'],   // shown under Linked devices
  companionPlatformDisplay: 'Chrome (Windows)' // what WhatsApp validates
})
```

Verified: with the brand kept in `browser[0]` and this override set, the `companion_hello` is accepted and the returned code works.

## Notes

- Only `Windows` was confirmed accepted. I did not map which values WhatsApp considers valid, because the server rate-limits pairing requests per number aggressively (`429 rate-overlimit`, lasting well over fifteen minutes, and each attempt appears to push it further out). That's also why this PR adds an escape hatch rather than an allow-list: I'd rather not encode a list I couldn't measure.
- `tsc` and `prettier` both clean; `yarn.lock` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
