### PR TITLE
feat(socket): allow overriding companion_platform_display for code pairing

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -785,7 +785,7 @@ export const makeSocket = (config: SocketConfig) => {
 		// The server answers `<iq type='result'><link_code_companion_reg
 		// stage='companion_hello'><link_code_pairing_ref>…` on success, so waiting
 		// for it is safe.
-		await query({
+		const registration = await query({
 			tag: 'iq',
 			attrs: {
 				to: S_WHATSAPP_NET,
@@ -803,6 +803,24 @@ export const makeSocket = (config: SocketConfig) => {
 				})
 			]
 		})
+
+		// ⚠️ A TIMEOUT LOOKS LIKE A SUCCESS HERE, SO IT HAS TO BE CHECKED.
+		//
+		// `waitForMessage` deliberately swallows its `timedOut` Boom and returns
+		// `undefined`, and `query` arms no outer timer when called without an
+		// explicit `timeoutMs` -- as here. So an unanswered registration IQ makes
+		// `query` RESOLVE with `undefined` rather than throw, and `assertNodeErrorFree`
+		// is skipped by its own `if (result && 'tag' in result)` guard.
+		//
+		// Without this check the flow below would persist `creds.me` for a device
+		// the server never acknowledged -- the exact poisoning this change is meant
+		// to prevent, just reached through the network-failure path instead of the
+		// rejection path.
+		if (!registration) {
+			throw new Boom('Companion registration timed out', {
+				statusCode: DisconnectReason.timedOut
+			})
+		}
 
 		// ⚠️ Only now. `creds.me` is what tells the next connection to LOG IN
 		// rather than REGISTER (see the `if (!creds.me)` branch above), so writing

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -769,12 +769,9 @@ export const makeSocket = (config: SocketConfig) => {
 			throw new Error('Custom pairing code must be exactly 8 chars')
 		}
 
-		// Needed before `generatePairingKey()`, which derives from it.
-		authState.creds.pairingCode = pairingCode
-
 		const me = { id: jidEncode(phoneNumber, 's.whatsapp.net'), name: '~' }
 
-		// ⚠️ `query`, not `sendNode`. `sendNode` only writes the IQ and returns, so
+		// `query`, not `sendNode`. `sendNode` only writes the IQ and returns, so
 		// a rejected registration -- WhatsApp answers `400 bad-request` when it
 		// does not recognise `companion_platform_display`, or `429 rate-overlimit`
 		// when asked too often -- used to go unnoticed: the caller still got a
@@ -796,7 +793,7 @@ export const makeSocket = (config: SocketConfig) => {
 			content: [
 				buildCompanionRegNode({
 					jid: me.id,
-					wrappedEphemeralPub: await generatePairingKey(),
+					wrappedEphemeralPub: await generatePairingKey(pairingCode),
 					serverAuthKeyPub: authState.creds.noiseKey.public,
 					browser,
 					platformDisplay: config.companionPlatformDisplay
@@ -804,7 +801,7 @@ export const makeSocket = (config: SocketConfig) => {
 			]
 		})
 
-		// ⚠️ A TIMEOUT LOOKS LIKE A SUCCESS HERE, SO IT HAS TO BE CHECKED.
+		// A TIMEOUT LOOKS LIKE A SUCCESS HERE, SO IT HAS TO BE CHECKED.
 		//
 		// `waitForMessage` deliberately swallows its `timedOut` Boom and returns
 		// `undefined`, and `query` arms no outer timer when called without an
@@ -822,22 +819,27 @@ export const makeSocket = (config: SocketConfig) => {
 			})
 		}
 
-		// ⚠️ Only now. `creds.me` is what tells the next connection to LOG IN
+		// Only now. `creds.me` is what tells the next connection to LOG IN
 		// rather than REGISTER (see the `if (!creds.me)` branch above), so writing
 		// it before the server accepted the registration left the session claiming
 		// a device that does not exist: every later socket -- code expiry, restart,
 		// reconnect -- got `401 loggedOut`, and one failed attempt poisoned all the
 		// following ones.
+		authState.creds.pairingCode = pairingCode
 		authState.creds.me = me
 		ev.emit('creds.update', authState.creds)
 
-		return authState.creds.pairingCode
+		return pairingCode
 	}
 
-	async function generatePairingKey() {
+	// Takes the code as an argument rather than reading `authState.creds`: two
+	// overlapping `requestPairingCode` calls would otherwise interleave on that
+	// shared field, and one could derive its payload from the other's code while
+	// returning its own.
+	async function generatePairingKey(pairingCode: string) {
 		const salt = randomBytes(32)
 		const randomIv = randomBytes(16)
-		const key = await derivePairingCodeKey(authState.creds.pairingCode!, salt)
+		const key = await derivePairingCodeKey(pairingCode, salt)
 		const ciphered = aesEncryptCTR(authState.creds.pairingEphemeralKeyPair.public, key, randomIv)
 		return Buffer.concat([salt, randomIv, ciphered])
 	}

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -26,6 +26,7 @@ import {
 	addTransactionCapability,
 	aesEncryptCTR,
 	bindWaitForConnectionUpdate,
+	buildCompanionRegNode,
 	buildPairingQRData,
 	bytesToCrockford,
 	configureSuccessfulPairing,
@@ -784,45 +785,13 @@ export const makeSocket = (config: SocketConfig) => {
 				xmlns: 'md'
 			},
 			content: [
-				{
-					tag: 'link_code_companion_reg',
-					attrs: {
-						jid: authState.creds.me.id,
-						stage: 'companion_hello',
-
-						should_show_push_notification: 'true'
-					},
-					content: [
-						{
-							tag: 'link_code_pairing_wrapped_companion_ephemeral_pub',
-							attrs: {},
-							content: await generatePairingKey()
-						},
-						{
-							tag: 'companion_server_auth_key_pub',
-							attrs: {},
-							content: authState.creds.noiseKey.public
-						},
-						{
-							tag: 'companion_platform_id',
-							attrs: {},
-							content: getCompanionPlatformId(browser)
-						},
-						{
-							tag: 'companion_platform_display',
-							attrs: {},
-							// See `companionPlatformDisplay` in SocketConfig: WhatsApp
-							// validates this string, so integrators branding `browser[0]`
-							// need a way to send something it recognises.
-							content: config.companionPlatformDisplay ?? `${browser[1]} (${browser[0]})`
-						},
-						{
-							tag: 'link_code_pairing_nonce',
-							attrs: {},
-							content: '0'
-						}
-					]
-				}
+				buildCompanionRegNode({
+					jid: authState.creds.me.id,
+					wrappedEphemeralPub: await generatePairingKey(),
+					serverAuthKeyPub: authState.creds.noiseKey.public,
+					browser,
+					platformDisplay: config.companionPlatformDisplay
+				})
 			]
 		})
 		return authState.creds.pairingCode

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -769,14 +769,23 @@ export const makeSocket = (config: SocketConfig) => {
 			throw new Error('Custom pairing code must be exactly 8 chars')
 		}
 
+		// Needed before `generatePairingKey()`, which derives from it.
 		authState.creds.pairingCode = pairingCode
 
-		authState.creds.me = {
-			id: jidEncode(phoneNumber, 's.whatsapp.net'),
-			name: '~'
-		}
-		ev.emit('creds.update', authState.creds)
-		await sendNode({
+		const me = { id: jidEncode(phoneNumber, 's.whatsapp.net'), name: '~' }
+
+		// ⚠️ `query`, not `sendNode`. `sendNode` only writes the IQ and returns, so
+		// a rejected registration -- WhatsApp answers `400 bad-request` when it
+		// does not recognise `companion_platform_display`, or `429 rate-overlimit`
+		// when asked too often -- used to go unnoticed: the caller still got a
+		// pairing code, generated locally and never acknowledged by the server. The
+		// user would type a code that could not work, with nothing anywhere to say
+		// why. `query` surfaces the error stanza instead (`assertNodeErrorFree`).
+		//
+		// The server answers `<iq type='result'><link_code_companion_reg
+		// stage='companion_hello'><link_code_pairing_ref>…` on success, so waiting
+		// for it is safe.
+		await query({
 			tag: 'iq',
 			attrs: {
 				to: S_WHATSAPP_NET,
@@ -786,7 +795,7 @@ export const makeSocket = (config: SocketConfig) => {
 			},
 			content: [
 				buildCompanionRegNode({
-					jid: authState.creds.me.id,
+					jid: me.id,
 					wrappedEphemeralPub: await generatePairingKey(),
 					serverAuthKeyPub: authState.creds.noiseKey.public,
 					browser,
@@ -794,6 +803,16 @@ export const makeSocket = (config: SocketConfig) => {
 				})
 			]
 		})
+
+		// ⚠️ Only now. `creds.me` is what tells the next connection to LOG IN
+		// rather than REGISTER (see the `if (!creds.me)` branch above), so writing
+		// it before the server accepted the registration left the session claiming
+		// a device that does not exist: every later socket -- code expiry, restart,
+		// reconnect -- got `401 loggedOut`, and one failed attempt poisoned all the
+		// following ones.
+		authState.creds.me = me
+		ev.emit('creds.update', authState.creds)
+
 		return authState.creds.pairingCode
 	}
 

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -811,7 +811,10 @@ export const makeSocket = (config: SocketConfig) => {
 						{
 							tag: 'companion_platform_display',
 							attrs: {},
-							content: `${browser[1]} (${browser[0]})`
+							// See `companionPlatformDisplay` in SocketConfig: WhatsApp
+							// validates this string, so integrators branding `browser[0]`
+							// need a way to send something it recognises.
+							content: config.companionPlatformDisplay ?? `${browser[1]} (${browser[0]})`
 						},
 						{
 							tag: 'link_code_pairing_nonce',

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -51,6 +51,22 @@ export type SocketConfig = {
 	version: WAVersion
 	/** override browser config */
 	browser: WABrowserDescription
+	/**
+	 * Overrides the human-readable client description sent as
+	 * `companion_platform_display` when pairing by code.
+	 *
+	 * WhatsApp validates this field: an unrecognised value makes the server
+	 * answer `400 bad-request` to `companion_hello`. By default it is derived
+	 * from `browser` as `${browser[1]} (${browser[0]})`, which breaks pairing by
+	 * code for any integrator that puts a product name in `browser[0]` -- even
+	 * though that same value is accepted for QR pairing and is precisely what
+	 * the user then sees under "Linked devices".
+	 *
+	 * The failure is silent: `requestPairingCode()` returns a locally generated
+	 * code the server never accepted, so the code simply does not work when
+	 * typed, with nothing in the logs to say why.
+	 */
+	companionPlatformDisplay?: string
 	/** Initial pushName carried in the registration ClientPayload (used by mock servers for deterministic phone assignment). */
 	pushName?: string
 	/** agent used for fetch requests -- uploading/downloading media */

--- a/src/Utils/companion-reg-client-utils.ts
+++ b/src/Utils/companion-reg-client-utils.ts
@@ -1,3 +1,4 @@
+import type { BinaryNode } from '../WABinary'
 import type { WABrowserDescription } from '../Types'
 
 export enum CompanionWebClientType {
@@ -46,3 +47,61 @@ export const buildPairingQRData = (
 		[ref, noiseKeyB64, identityKeyB64, advB64, getCompanionPlatformId(browser)].join(',')
 	)
 }
+
+/**
+ * Builds the `link_code_companion_reg` stanza sent when pairing by code.
+ *
+ * Extracted from `requestPairingCode` so the payload can be asserted directly:
+ * the only impure parts of that flow are the ephemeral key derivation and the
+ * message tag, both of which are passed in.
+ *
+ * `platformDisplay` overrides `companion_platform_display`. WhatsApp validates
+ * that field -- see `companionPlatformDisplay` in SocketConfig.
+ */
+export const buildCompanionRegNode = ({
+	jid,
+	wrappedEphemeralPub,
+	serverAuthKeyPub,
+	browser,
+	platformDisplay
+}: {
+	jid: string
+	wrappedEphemeralPub: Uint8Array
+	serverAuthKeyPub: Uint8Array
+	browser: WABrowserDescription
+	platformDisplay?: string
+}): BinaryNode => ({
+	tag: 'link_code_companion_reg',
+	attrs: {
+		jid,
+		stage: 'companion_hello',
+		should_show_push_notification: 'true'
+	},
+	content: [
+		{
+			tag: 'link_code_pairing_wrapped_companion_ephemeral_pub',
+			attrs: {},
+			content: wrappedEphemeralPub
+		},
+		{
+			tag: 'companion_server_auth_key_pub',
+			attrs: {},
+			content: serverAuthKeyPub
+		},
+		{
+			tag: 'companion_platform_id',
+			attrs: {},
+			content: getCompanionPlatformId(browser)
+		},
+		{
+			tag: 'companion_platform_display',
+			attrs: {},
+			content: platformDisplay ?? `${browser[1]} (${browser[0]})`
+		},
+		{
+			tag: 'link_code_pairing_nonce',
+			attrs: {},
+			content: '0'
+		}
+	]
+})

--- a/src/__tests__/Utils/companion-reg-client-utils.test.ts
+++ b/src/__tests__/Utils/companion-reg-client-utils.test.ts
@@ -3,10 +3,8 @@ import {
 	CompanionWebClientType,
 	getCompanionWebClientType
 } from '../../Utils/companion-reg-client-utils'
-// Imported from the module rather than the `WABinary` barrel: the barrel pulls
-// in WAProto, which the other suites in this folder already trip over.
-import { getBinaryNodeChild } from '../../WABinary/generic-utils'
-import type { BinaryNode } from '../../WABinary/types'
+import { getBinaryNodeChild } from '../../WABinary'
+import type { BinaryNode } from '../../WABinary'
 import type { WABrowserDescription } from '../../Types'
 
 const EPHEMERAL_PUB = new Uint8Array([1, 2, 3])

--- a/src/__tests__/Utils/companion-reg-client-utils.test.ts
+++ b/src/__tests__/Utils/companion-reg-client-utils.test.ts
@@ -3,7 +3,10 @@ import {
 	CompanionWebClientType,
 	getCompanionWebClientType
 } from '../../Utils/companion-reg-client-utils'
-import type { BinaryNode } from '../../WABinary'
+// Imported from the module rather than the `WABinary` barrel: the barrel pulls
+// in WAProto, which the other suites in this folder already trip over.
+import { getBinaryNodeChild } from '../../WABinary/generic-utils'
+import type { BinaryNode } from '../../WABinary/types'
 import type { WABrowserDescription } from '../../Types'
 
 const EPHEMERAL_PUB = new Uint8Array([1, 2, 3])
@@ -18,7 +21,7 @@ const build = (browser: WABrowserDescription, platformDisplay?: string) =>
 		platformDisplay
 	})
 
-const childContent = (node: BinaryNode, tag: string) => (node.content as BinaryNode[]).find(c => c.tag === tag)?.content
+const childContent = (node: BinaryNode, tag: string) => getBinaryNodeChild(node, tag)?.content
 
 describe('buildCompanionRegNode', () => {
 	it('derives companion_platform_display from the browser when no override is given', () => {

--- a/src/__tests__/Utils/companion-reg-client-utils.test.ts
+++ b/src/__tests__/Utils/companion-reg-client-utils.test.ts
@@ -1,0 +1,75 @@
+import {
+	buildCompanionRegNode,
+	CompanionWebClientType,
+	getCompanionWebClientType
+} from '../../Utils/companion-reg-client-utils'
+import type { BinaryNode } from '../../WABinary'
+import type { WABrowserDescription } from '../../Types'
+
+const EPHEMERAL_PUB = new Uint8Array([1, 2, 3])
+const AUTH_KEY_PUB = new Uint8Array([4, 5, 6])
+
+const build = (browser: WABrowserDescription, platformDisplay?: string) =>
+	buildCompanionRegNode({
+		jid: '15551234567@s.whatsapp.net',
+		wrappedEphemeralPub: EPHEMERAL_PUB,
+		serverAuthKeyPub: AUTH_KEY_PUB,
+		browser,
+		platformDisplay
+	})
+
+const childContent = (node: BinaryNode, tag: string) => (node.content as BinaryNode[]).find(c => c.tag === tag)?.content
+
+describe('buildCompanionRegNode', () => {
+	it('derives companion_platform_display from the browser when no override is given', () => {
+		const node = build(['Ubuntu', 'Chrome', '22.04.4'])
+
+		expect(childContent(node, 'companion_platform_display')).toBe('Chrome (Ubuntu)')
+	})
+
+	it('sends the override as companion_platform_display when one is given', () => {
+		const node = build(['My Product', 'Chrome', '22.04.4'], 'Chrome (Windows)')
+
+		expect(childContent(node, 'companion_platform_display')).toBe('Chrome (Windows)')
+	})
+
+	it('leaves companion_platform_id derived from the browser, override or not', () => {
+		const withOverride = build(['My Product', 'Chrome', '22.04.4'], 'Chrome (Windows)')
+		const without = build(['My Product', 'Chrome', '22.04.4'])
+
+		expect(childContent(withOverride, 'companion_platform_id')).toBe(CompanionWebClientType.CHROME.toString())
+		expect(childContent(without, 'companion_platform_id')).toBe(CompanionWebClientType.CHROME.toString())
+	})
+
+	it('keeps the rest of the stanza identical whether the override is set or not', () => {
+		const browser: WABrowserDescription = ['My Product', 'Chrome', '22.04.4']
+		const withOverride = build(browser, 'Chrome (Windows)')
+		const without = build(browser)
+
+		expect(withOverride.attrs).toEqual(without.attrs)
+		expect(withOverride.attrs.stage).toBe('companion_hello')
+
+		for (const tag of [
+			'link_code_pairing_wrapped_companion_ephemeral_pub',
+			'companion_server_auth_key_pub',
+			'link_code_pairing_nonce'
+		]) {
+			expect(childContent(withOverride, tag)).toEqual(childContent(without, tag))
+		}
+	})
+})
+
+describe('getCompanionWebClientType', () => {
+	it('maps a known browser name to its client type', () => {
+		expect(getCompanionWebClientType(['Ubuntu', 'Chrome', '22.04.4'])).toBe(CompanionWebClientType.CHROME)
+	})
+
+	it('falls back to OTHER_WEB_CLIENT for an unknown browser name', () => {
+		expect(getCompanionWebClientType(['Ubuntu', 'Arc', '22.04.4'])).toBe(CompanionWebClientType.OTHER_WEB_CLIENT)
+	})
+
+	it('distinguishes Desktop builds by operating system', () => {
+		expect(getCompanionWebClientType(['Windows', 'Desktop', '10.0'])).toBe(CompanionWebClientType.UWP)
+		expect(getCompanionWebClientType(['Mac OS', 'Desktop', '14.4.1'])).toBe(CompanionWebClientType.ELECTRON)
+	})
+})


### PR DESCRIPTION
## The problem

WhatsApp **validates** the `companion_platform_display` field sent with `link_code_companion_reg`. Baileys derives it from the browser description:

```ts
content: `${browser[1]} (${browser[0]})`
```

But `browser[0]` is also what the user sees under **Linked devices** — which is why integrators put a product name there. QR pairing accepts any value happily. Pairing by code does not:

```xml
<iq from='@s.whatsapp.net' type='error' id='…'>
  <error code='400' text='bad-request'/>
</iq>
```

Measured against production WhatsApp on 2026-08-12 (rc14), reproduced on two accounts:

| `companion_platform_display` | Server reply |
|---|---|
| `Chrome (Acme)` | **400 bad-request** |
| `Chrome (Windows)` | **accepted** |

So today an integrator has to choose between naming their product and being able to link users by code.

## Why this is worth a fix rather than a note

**The failure is completely silent.** `requestPairingCode()` still returns a code — generated locally with `bytesToCrockford(randomBytes(5))`, before the stanza is even sent, and never acknowledged by the server. The promise resolves normally. The user types the code, nothing happens, and there is no error anywhere: not in the return value, not in the logs at default level, not on the phone beyond a generic "couldn't connect".

Only a `trace`-level dump of the stanza exchange reveals the 400. It took a full day to find.

There are several open issues that read like this same symptom — code returned, linking never completes, no diagnosis: #2764, #2759, #2590, #2008. I can't claim they are all this cause, but the shape matches, and none has a diagnosis attached.

## The change

An optional `companionPlatformDisplay` on `SocketConfig`. When unset, the payload is **byte-identical** to before — no behaviour change for existing users.

```ts
const sock = makeWASocket({
  browser: ['My Product', 'Chrome', '10.0'],   // shown under Linked devices
  companionPlatformDisplay: 'Chrome (Windows)' // what WhatsApp validates
})
```

Verified: with the brand kept in `browser[0]` and this override set, the `companion_hello` is accepted and the returned code works.

## Tests

`buildCompanionRegNode` is extracted from `requestPairingCode` into `Utils/companion-reg-client-utils.ts`, next to `getCompanionPlatformId` and `buildPairingQRData`, which already handle this payload. That extraction is what makes the stanza assertable — it was built inline inside `makeSocket`, which is why the repo has no `requestPairingCode` test today.

`src/__tests__/Utils/companion-reg-client-utils.test.ts` covers:

- no override → `${browser[1]} (${browser[0]})`;
- `companionPlatformDisplay` set → that value verbatim;
- `companion_platform_id` stays derived from `browser` either way;
- the rest of the stanza is identical with and without the override — so the backward-compatibility claim above is *asserted*, not just stated;
- the `getCompanionWebClientType` table, including its Desktop → UWP/Electron branch.

**Correction to an earlier version of this description:** I first wrote that most
of the `src/__tests__/Utils/` suites failed on `master`. That was wrong — I was
invoking Jest without `--experimental-vm-modules`, which the repo's own `test`
script sets. Run properly, the full suite is green: **29 suites, 414 tests**,
before and after this change. Apologies for the noise.

## Review follow-ups

Both addressed, and the first one improved the PR materially:

- **`sendNode` → `query`.** `sendNode` only writes the IQ and returns, so a
  rejected registration went unnoticed — the caller still got a locally
  generated code. That is exactly the silent failure described above; using
  `query` removes it rather than documenting it. Safe to wait for: the server
  answers `<iq type='result'><link_code_companion_reg stage='companion_hello'>
  <link_code_pairing_ref>…` on success, captured on a real connection.
- **`creds.me` / `creds.pairingCode` are emitted only after the server
  accepts.** `creds.me` is what makes the next connection log in rather than
  register, so writing it up front left the session claiming a device that does
  not exist — every later socket got `401 loggedOut`, and one failed attempt
  poisoned all the following ones.
- **Typed binary node accessor** in the test helper.

## Notes

- Only `Windows` was confirmed accepted. I did not map which values WhatsApp considers valid, because the server rate-limits pairing requests per number aggressively (`429 rate-overlimit`, lasting well over fifteen minutes, and each attempt appears to push it further out). That's also why this PR adds an escape hatch rather than an allow-list: I'd rather not encode a list I couldn't measure.
- `tsc` and `prettier` both clean; `yarn.lock` untouched.

---

Drafted with Claude Code, then measured against production WhatsApp and reviewed by me — per the AI policy in `CODE_OF_CONDUCT.md`. The 400/accepted results in the table above are real server responses from my own accounts, not inferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to customize the companion platform description shown during pairing by code.
  * Added support for platform-specific companion metadata during registration.
  * Improved pairing registration to preserve credentials and pairing details only after successful registration.

* **Bug Fixes**
  * Pairing server errors now surface correctly, and timed-out pairing requests are explicitly rejected.

* **Tests**
  * Added coverage for platform labels, browser mappings, desktop classification, and registration metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->