### PR TITLE
fix(generics): fallback to fetchLatestWaWebVersion on Defaults fetch failure

### DIFF
--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -242,15 +242,16 @@ export const fetchLatestBaileysVersion = async (options: RequestInit = {}) => {
 		const response = await fetch(URL, {
 			dispatcher: options.dispatcher,
 			method: 'GET',
-			headers: options.headers
+			headers: options.headers,
+			signal: options.signal
 		})
 		if (!response.ok) {
 			throw new Boom(`Failed to fetch latest Baileys version: ${response.statusText}`, { statusCode: response.status })
 		}
 
 		const text = await response.text()
-		// Extract version from Defaults/index.ts (const version = [...])
-		const versionMatch = text.match(/const version = \[(\d+),\s*(\d+),\s*(\d+)\]/)
+		// Extract version from Defaults/index.ts (const version = [...]) allowing flexible whitespace
+		const versionMatch = text.match(/const\s+version(?:\s*:[^=]+)?\s*=\s*\[\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\]/)
 		if (!versionMatch) {
 			throw new Error('Could not parse version from Defaults/index.ts')
 		}
@@ -262,13 +263,12 @@ export const fetchLatestBaileysVersion = async (options: RequestInit = {}) => {
 			isLatest: true
 		}
 	} catch (error) {
-		try {
-			const waWebVersion = await fetchLatestWaWebVersion(options)
-			if (waWebVersion.isLatest) {
-				return waWebVersion
-			}
-		} catch {
-			// Fallback to hardcoded default if WA Web endpoint is also unavailable
+		const waWebVersion = await fetchLatestWaWebVersion({
+			dispatcher: options.dispatcher,
+			signal: options.signal
+		})
+		if (waWebVersion.isLatest) {
+			return waWebVersion
 		}
 
 		return {

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -249,22 +249,28 @@ export const fetchLatestBaileysVersion = async (options: RequestInit = {}) => {
 		}
 
 		const text = await response.text()
-		// Extract version from line 7 (const version = [...])
-		const lines = text.split('\n')
-		const versionLine = lines[6] // Line 7 (0-indexed)
-		const versionMatch = versionLine!.match(/const version = \[(\d+),\s*(\d+),\s*(\d+)\]/)
-
-		if (versionMatch) {
-			const version = [parseInt(versionMatch[1]!), parseInt(versionMatch[2]!), parseInt(versionMatch[3]!)] as WAVersion
-
-			return {
-				version,
-				isLatest: true
-			}
-		} else {
+		// Extract version from Defaults/index.ts (const version = [...])
+		const versionMatch = text.match(/const version = \[(\d+),\s*(\d+),\s*(\d+)\]/)
+		if (!versionMatch) {
 			throw new Error('Could not parse version from Defaults/index.ts')
 		}
+
+		const version = [parseInt(versionMatch[1]!), parseInt(versionMatch[2]!), parseInt(versionMatch[3]!)] as WAVersion
+
+		return {
+			version,
+			isLatest: true
+		}
 	} catch (error) {
+		try {
+			const waWebVersion = await fetchLatestWaWebVersion(options)
+			if (waWebVersion.isLatest) {
+				return waWebVersion
+			}
+		} catch {
+			// Fallback to hardcoded default if WA Web endpoint is also unavailable
+		}
+
 		return {
 			version: baileysVersion as WAVersion,
 			isLatest: false,

--- a/src/__tests__/Utils/generics.test.ts
+++ b/src/__tests__/Utils/generics.test.ts
@@ -1,4 +1,5 @@
-import { BufferJSON } from '../../Utils/generics'
+import { jest } from '@jest/globals'
+import { BufferJSON, fetchLatestBaileysVersion } from '../../Utils/generics'
 
 describe('BufferJSON', () => {
 	const originalObject = {
@@ -66,5 +67,81 @@ describe('BufferJSON', () => {
 	it('should correctly handle an empty object', () => {
 		const revived = JSON.parse('{}', BufferJSON.reviver)
 		expect(revived).toEqual({})
+	})
+})
+
+describe('fetchLatestBaileysVersion', () => {
+	const originalFetch = globalThis.fetch
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch
+	})
+
+	it('should parse version with standard and flexible whitespace', async () => {
+		const mockDefaultsContent = `
+			import { WAVersion } from '../Types'
+			export const version: WAVersion = [ 2 , 3000 , 1043857760 ]
+		`
+
+		globalThis.fetch = (jest.fn() as any).mockImplementation(async (url: string) => {
+			if (typeof url === 'string' && url.includes('raw.githubusercontent.com')) {
+				return {
+					ok: true,
+					text: async () => mockDefaultsContent,
+				} as any
+			}
+			throw new Error('Unexpected URL')
+		})
+
+		const result = await fetchLatestBaileysVersion()
+		expect(result.isLatest).toBe(true)
+		expect(result.version).toEqual([2, 3000, 1043857760])
+	})
+
+	it('should fallback to fetchLatestWaWebVersion when GitHub fetch fails', async () => {
+		globalThis.fetch = (jest.fn() as any).mockImplementation(async (url: string) => {
+			if (typeof url === 'string' && url.includes('raw.githubusercontent.com')) {
+				return {
+					ok: false,
+					status: 503,
+					statusText: 'Service Unavailable',
+				} as any
+			}
+			if (typeof url === 'string' && url.includes('web.whatsapp.com/sw.js')) {
+				return {
+					ok: true,
+					text: async () => 'self.__BUILD_MANIFEST = { "client_revision": 1045345293 }',
+				} as any
+			}
+			throw new Error('Unexpected URL')
+		})
+
+		const result = await fetchLatestBaileysVersion({
+			headers: { 'Authorization': 'token secret-gh-token' }
+		})
+
+		expect(result.isLatest).toBe(true)
+		expect(result.version).toEqual([2, 3000, 1045345293])
+
+		// Verify GitHub-only headers are NOT passed to web.whatsapp.com
+		const swCall = ((globalThis.fetch as any).mock.calls as any[]).find(c => c[0]?.includes('web.whatsapp.com/sw.js'))
+		expect(swCall).toBeDefined()
+		expect(swCall[1]?.headers).not.toHaveProperty('Authorization')
+	})
+
+	it('should fallback to static baileysVersion when both remote calls fail', async () => {
+		globalThis.fetch = (jest.fn() as any).mockImplementation(async () => {
+			return {
+				ok: false,
+				status: 500,
+				statusText: 'Internal Server Error',
+			} as any
+		})
+
+		const result = await fetchLatestBaileysVersion()
+		expect(result.isLatest).toBe(false)
+		expect(Array.isArray(result.version)).toBe(true)
+		expect(result.version).toHaveLength(3)
+		expect(result.error).toBeDefined()
 	})
 })


### PR DESCRIPTION
### Summary

When GitHub raw endpoints (`raw.githubusercontent.com`) experience outages, rate limits, or network failures, `fetchLatestBaileysVersion()` previously fell back directly to the hardcoded `baileysVersion` constant (`[2, 3000, 1035194821]`). Because this static constant is outdated, WhatsApp Web servers permanently reject connection attempts with `405 Method Not Allowed / Connection Failure`.

### Changes

1. **Direct WA Web Fallback**: When fetching `Defaults/index.ts` from GitHub fails, `fetchLatestBaileysVersion()` now attempts `fetchLatestWaWebVersion(options)` (querying WhatsApp Web's `https://web.whatsapp.com/sw.js`) before falling back to the static `baileysVersion` constant.
2. **Resilient Version Parsing**: Replaced line-index dependent extraction (`lines[6]`) with a full-content regular expression match (`/const version = \[(\d+),\s*(\d+),\s*(\d+)\]/`) so changes to comments, imports, or file structure in `Defaults/index.ts` do not break version extraction.

### Verification

- Unit tests: Ran full test suite (`28 passed, 407 passed`).
- Live verification: Verified `fetchLatestBaileysVersion()` and `fetchLatestWaWebVersion()` resolve modern WhatsApp Web versions (`2.3000.1043857760` / `2.3000.1045345293`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a WA Web fallback for version resolution and hardens parsing and request options when GitHub fetch of `Defaults/index.ts` fails, avoiding 405 rejections from the outdated static version.

- Uses a layout-tolerant regex to extract the version from `Defaults/index.ts` (replaces line-index parsing).
- On GitHub failure, calls `fetchLatestWaWebVersion` with only `dispatcher` and `signal` to prevent cross-origin header leaks; then falls back to the static `baileysVersion` if needed.
- Forwards the abort `signal` to the GitHub fetch; normal behavior is unchanged when GitHub succeeds.
- Adds tests for flexible whitespace parsing, WA Web fallback, and header isolation.
- No API changes; no migration required.

<sup>Written for commit 15f383ce22da6c20c74ae5df708510d15e2e7dcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the latest supported web version across varying source formats.
  * Added fallback lookups when the primary version check fails.
  * Ensured a stable default version is used if all remote retrieval attempts are unsuccessful.
  * Improved compatibility when making version checks with request headers or cancellation signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->