### PR TITLE
fix(deps): mark sharp as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,9 @@
     },
     "link-preview-js": {
       "optional": true
+    },
+    "sharp": {
+      "optional": true
     }
   },
   "packageManager": "yarn@4.9.2",


### PR DESCRIPTION
`sharp` is declared in `peerDependencies` but omitted from
`peerDependenciesMeta`, so package managers treat it as **required**.

It is optional at runtime. `src/Utils/messages-media.ts` loads it through a
caught dynamic import — on the same line as `jimp` — and falls back when it is
absent:

```ts
const [jimp, sharp] = await Promise.all([
  import('jimp').catch(() => {}),
  import('sharp').catch(() => {}),
])
```

`jimp` is marked optional. `sharp` is not.

### Effect on consumers

`npm install baileys@7.0.0-rc14` into an empty project (npm 11, linux arm64):

| peer | marked optional | installed? |
|---|---|---|
| `jimp` | yes | no — correctly skipped |
| `sharp` | **no** | **yes — `sharp` + `@img/*`, ~19 MB of native binaries** |

So a project that never touches image processing still downloads ~19 MB of
platform-specific binaries. On platforms where `sharp` publishes no prebuild
this becomes a source build, or an install failure.

Downstream projects work around it today; for example OpenClaw carries a
`packageExtensions` entry in `pnpm-workspace.yaml` that adds exactly the
three lines in this PR.

### The change

Adds the missing `peerDependenciesMeta` entry, so all four declared peers now
have one and the manifest matches how the code already treats `sharp`. No code
changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks `sharp` as an optional peer dependency to match runtime behavior and prevent unnecessary native binary downloads. This reduces install size (~19 MB) and avoids source builds/failures on platforms without prebuilds.

- Adds `peerDependenciesMeta.sharp.optional: true` in `package.json`; no code changes.
- Old behavior: package managers auto-installed `sharp` and `@img/*` even if unused. New behavior: `sharp` is not auto-installed; the code continues to dynamically import `sharp`/`jimp` and fall back when absent.
- Migration: If you use `sharp` features, add `sharp` to your app’s dependencies.

<sup>Written for commit 102227194f9c5f395bdaaa6445bc0c3c65fa7710. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation compatibility by making the optional image-processing dependency explicitly optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->