### PR TITLE
fix: unwrap lottieStickerMessage in normalizeMessageContent

### DIFF
--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -812,7 +812,8 @@ export const normalizeMessageContent = (content: WAMessageContent | null | undef
 			message?.editedMessage ||
 			message?.associatedChildMessage ||
 			message?.groupStatusMessage ||
-			message?.groupStatusMessageV2
+			message?.groupStatusMessageV2 ||
+			message?.lottieStickerMessage
 		)
 	}
 }


### PR DESCRIPTION

 `lottieStickerMessage` is a wrapper message containing an inner `stickerMessage`.

 `normalizeMessageContent()` currently unwraps other wrapper types such as `ephemeralMessage`, `viewOnceMessage`, and `editedMessage`, but does not unwrap `lottieStickerMessage`.

 Because of this, code consuming the normalized message sees `lottieStickerMessage` as the content type instead of the inner `stickerMessage`. In particular, `downloadMediaMessage()` calls `extractMessageContent()` and then determines the media type from the extracted content, so Lottie stickers are not recognized as normal sticker media.

 This change adds `lottieStickerMessage` to the existing wrapper-unwrapping logic in `normalizeMessageContent()`. No special handling is needed elsewhere because after normalization the existing sticker media path works normally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unwraps `lottieStickerMessage` in `normalizeMessageContent` so Lottie stickers are normalized to the inner `stickerMessage`. Previously the wrapper leaked through, causing `downloadMediaMessage()` (via `extractMessageContent()`) to miss sticker media.

- Behavior change: old returned `lottieStickerMessage`; new returns the inner `stickerMessage`. Lottie stickers now follow the existing sticker media path and download correctly.
- No API changes or migrations; this only adds `lottieStickerMessage` to the existing wrapper-unwrapping list.

<sup>Written for commit 6294403c64c41f3b2dec15ab80d4cbb646dd11c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message handling by correctly normalizing content from animated sticker messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->