### PR TITLE
fix: use default media host for directPath downloads

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -33,7 +33,7 @@ const getTmpFilesDirectory = () => tmpdir()
 
 const getImageProcessingLibrary = async () => {
 	//@ts-ignore
-	const [jimp, sharp] = await Promise.all([import('jimp').catch(() => { }), import('sharp').catch(() => { })])
+const [jimp, sharp] = await Promise.all([import('jimp').catch(() => {}), import('sharp').catch(() => {})])
 
 	if (sharp) {
 		return { sharp }

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -33,7 +33,7 @@ const getTmpFilesDirectory = () => tmpdir()
 
 const getImageProcessingLibrary = async () => {
 	//@ts-ignore
-const [jimp, sharp] = await Promise.all([import('jimp').catch(() => {}), import('sharp').catch(() => {})])
+	const [jimp, sharp] = await Promise.all([import('jimp').catch(() => {}), import('sharp').catch(() => {})])
 
 	if (sharp) {
 		return { sharp }

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -33,7 +33,7 @@ const getTmpFilesDirectory = () => tmpdir()
 
 const getImageProcessingLibrary = async () => {
 	//@ts-ignore
-	const [jimp, sharp] = await Promise.all([import('jimp').catch(() => {}), import('sharp').catch(() => {})])
+	const [jimp, sharp] = await Promise.all([import('jimp').catch(() => { }), import('sharp').catch(() => { })])
 
 	if (sharp) {
 		return { sharp }
@@ -239,7 +239,7 @@ export async function getAudioDuration(buffer: Buffer | string | Readable) {
 }
 
 /**
-  referenced from and modifying https://github.com/wppconnect-team/wa-js/blob/main/src/chat/functions/prepareAudioWaveform.ts
+	referenced from and modifying https://github.com/wppconnect-team/wa-js/blob/main/src/chat/functions/prepareAudioWaveform.ts
  */
 export async function getAudioWaveform(buffer: Buffer | string | Readable, logger?: ILogger) {
 	try {
@@ -285,7 +285,7 @@ export async function getAudioWaveform(buffer: Buffer | string | Readable, logge
 }
 
 export const toReadable = (buffer: Buffer) => {
-	const readable = new Readable({ read: () => {} })
+	const readable = new Readable({ read: () => { } })
 	readable.push(buffer)
 	readable.push(null)
 	return readable
@@ -535,7 +535,8 @@ export const downloadContentFromMessage = async (
 ) => {
 	// Fallback host: explicit opt > host parsed from `url` > DEF_MEDIA_HOST.
 	// Lets us honor a non-default host carried by the proto without forcing callers to thread it through.
-	const fallbackHost = opts.host ?? extractHost(url)
+	const urlHost = extractHost(url)
+	const fallbackHost = opts.host ?? (urlHost !== 'a.whatsapp.net' ? urlHost : DEF_MEDIA_HOST)
 	const downloadUrl = directPath ? getUrlFromDirectPath(directPath, fallbackHost) : url
 	if (!downloadUrl) {
 		throw new Boom('No valid media URL or directPath present in message', { statusCode: 400 })

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -812,8 +812,7 @@ export const normalizeMessageContent = (content: WAMessageContent | null | undef
 			message?.editedMessage ||
 			message?.associatedChildMessage ||
 			message?.groupStatusMessage ||
-			message?.groupStatusMessageV2 ||
-			message?.lottieStickerMessage
+			message?.groupStatusMessageV2
 		)
 	}
 }

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -812,7 +812,8 @@ export const normalizeMessageContent = (content: WAMessageContent | null | undef
 			message?.editedMessage ||
 			message?.associatedChildMessage ||
 			message?.groupStatusMessage ||
-			message?.groupStatusMessageV2
+			message?.groupStatusMessageV2 ||
+			message?.lottieStickerMessage
 		)
 	}
 }


### PR DESCRIPTION
This fixes media downloads when a message contains an obsolete WhatsApp media URL host.

#### Problem

Some messages include a `url` hosted on `a.whatsapp.net` together with a valid `directPath`. Baileys currently extracts the host from `url` and reuses it when rebuilding the download URL from `directPath`.

As a result, the library may try to download media from `a.whatsapp.net` instead of the working media host, which causes failures such as:

```text
Cause:
Error: getaddrinfo ENOTFOUND a.whatsapp.net
code: ENOTFOUND
syscall: getaddrinfo
hostname: a.whatsapp.net
```

#### Cause

In `downloadContentFromMessage()`, the host used for `directPath` downloads is derived from the message `url`. If that `url` contains the obsolete `a.whatsapp.net` host, the generated download URL also uses that obsolete host.

#### Fix

This change makes `directPath` downloads fall back to the default media host instead of reusing the obsolete host from `url`. This preserves the existing explicit host override behavior while avoiding failures caused by stale message URLs.

#### Result

Messages that contain a stale `a.whatsapp.net` URL but a valid `directPath` are downloaded successfully from the working default media host instead of failing with DNS resolution errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes directPath media downloads by treating `a.whatsapp.net` in message URLs as obsolete and falling back to the default media host. Previously we reused the URL host and often failed DNS lookup; now we default unless an explicit host override is provided.

- Affects only directPath downloads; plain URL downloads are unchanged. `opts.host` still takes precedence.
- Change is localized to `downloadContentFromMessage` in `src/Utils/messages-media.ts`; no API changes.
- Non-functional changes are formatting-only.

<sup>Written for commit 3d541a3fae21e44d44289cf79934da4d2fc1926a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media download fallback behavior by avoiding unsuitable hosts derived from message URLs.
  * Media downloads now use the default host unless an explicit host is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->