### PR TITLE
fix(messages-recv): don't NACK undecryptable status messages — one pending status stalls the entire offline queue

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -1727,7 +1727,17 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 							}
 
 							acked = true
-							await sendMessageAck(node, NACK_REASONS.UnhandledError)
+							// Undecryptable statuses: ack without a NACK reason. A NACK makes the
+							// server keep the stanza and re-deliver it on every (re)connect, and
+							// while it is pending the rest of the offline queue is withheld —
+							// one undecryptable fresh status stalls delivery of every queued
+							// message. Statuses are best-effort content; dropping one is far
+							// better than freezing the account's message delivery.
+							if (isJidStatusBroadcast(msg.key.remoteJid!)) {
+								await sendMessageAck(node)
+							} else {
+								await sendMessageAck(node, NACK_REASONS.UnhandledError)
+							}
 						})
 					}
 				} else {


### PR DESCRIPTION
## The problem

When a `status@broadcast` message fails to decrypt (e.g. `No session found to decrypt message` for a contact's status posted while the companion was offline), the current code sends a retry request and then acks the node with `NACK_REASONS.UnhandledError`.

The server treats that NACK as a failed delivery: it **keeps the stanza pending and re-delivers it as the first item of the offline stream on every (re)connect** — and while it is pending, **the rest of the offline queue is withheld**. One undecryptable fresh status silently freezes delivery of every queued message for the account.

## Observed behavior (real account, Baileys 7.0.0-rc.9)

- `offline_preview` reported a steadily growing queue (reached 80+ queued `message` items over a day).
- On every connect, the server streamed exactly one stanza — the same undecryptable status (same message id each time) — then nothing else. Decryption failed, a retry request was sent, the node was NACKed, and the connection stayed idle.
- Regular messages (including the account owner's own device-sync messages) were never delivered, with no errors anywhere — from the app's perspective, inbound had silently died.
- Changing the final ack for status messages to a plain `sendMessageAck(node)` immediately unblocked the queue: all pending messages (4 stacked undecryptable statuses among them) streamed in and normal delivery resumed. Verified across multiple reconnects afterwards; the queue now drains to zero.

## The fix

Keep the retry request exactly as it is (the recovery path is untouched), but ack undecryptable **status** messages without a NACK reason, so the server considers them handled and advances the queue.

This complements the existing `STATUS_EXPIRY_SECONDS` skip (which already plain-acks undecryptable statuses older than 24h): fresh undecryptable statuses currently still take the NACK path, and they are precisely the ones that sit at the head of a live queue.

Statuses are best-effort, ephemeral content — dropping one that cannot be decrypted is far better than freezing the account's message delivery.

## Scope / risk

- Only the ack *reason* changes, and only for `status@broadcast` stanzas that failed to decrypt.
- The retry request is still sent first, so if the sender's device answers the retry, the status can still be recovered through the normal retry flow.
- Non-status messages keep the existing NACK behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Plain-ack undecryptable `status@broadcast` messages to prevent offline queue stalls. Previously we sent a retry and then NACKed; the server kept the stanza pending and re-delivered it first on every reconnect, withholding the rest of the queue.

- After sending the retry request, undecryptable statuses are acked without a NACK reason; non-status messages still NACK.
- This unblocks offline delivery and aligns with the existing 24h expiry path that already plain-acks old statuses.
- Scope is minimal: only the ack reason changes for undecryptable statuses; no config or migration changes.

<sup>Written for commit ccf21eb10d1742e416299d4bbf3592ce1f1d6db6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status-broadcast messages that cannot be decrypted are now acknowledged without generating an error response.
  * Other undecryptable messages continue to receive the appropriate error notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->