### PR TITLE
fix(socket): do not announce presence on a partial creds.update

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -1051,11 +1051,14 @@ export const makeSocket = (config: SocketConfig) => {
 	ev.on('creds.update', update => {
 		const name = update.me?.name
 		// if name has just been received
-		if (creds.me?.name !== name) {
+		// a partial update carries no `me`, which would otherwise send a nameless <presence/>.
+		// an attribute-less presence node is read as "available" by the server, which marks the
+		// account online and suppresses push notifications to the user's phone.
+		if (typeof name === 'string' && name.length > 0 && creds.me?.name !== name) {
 			logger.debug({ name }, 'updated pushName')
 			sendNode({
 				tag: 'presence',
-				attrs: { name: name! }
+				attrs: { name }
 			}).catch(err => {
 				logger.warn({ trace: err.stack }, 'error in sending presence update on name change')
 			})

--- a/src/__tests__/binary/presence-on-creds-update.test.ts
+++ b/src/__tests__/binary/presence-on-creds-update.test.ts
@@ -24,8 +24,9 @@ jest.unstable_mockModule('../../Socket/Client/websocket', () => ({
 	}))
 }))
 
-const { DEFAULT_CONNECTION_CONFIG } = await import('../../Defaults')
+const { DEFAULT_CONNECTION_CONFIG, NOISE_WA_HEADER } = await import('../../Defaults')
 const makeWASocket = (await import('../../Socket')).default
+const { decodeBinaryNode } = await import('../../WABinary/decode')
 const { makeSession } = await import('../TestUtils/session')
 
 describe('presence announcement on creds.update', () => {
@@ -45,6 +46,16 @@ describe('presence announcement on creds.update', () => {
 	}
 
 	const settle = () => new Promise(resolve => setTimeout(resolve, 50))
+
+	/**
+	 * A frame is `[intro header?][3-byte big-endian length][node]`. No transport is negotiated
+	 * in these tests, so the payload is not encrypted and decodes directly.
+	 */
+	const decodeFrame = (frame: Buffer) => {
+		const intro = Buffer.from(NOISE_WA_HEADER)
+		const body = frame.subarray(0, intro.length).equals(intro) ? frame.subarray(intro.length) : frame
+		return decodeBinaryNode(body.subarray(3))
+	}
 
 	it('does not send presence for a partial update that carries no `me`', async () => {
 		const { sock, clear } = await makeSocket('Test User')
@@ -77,7 +88,12 @@ describe('presence announcement on creds.update', () => {
 		sock.ev.emit('creds.update', { me: { id: ME, name: 'New Name' } })
 		await settle()
 
-		expect(send).toHaveBeenCalled()
+		expect(send).toHaveBeenCalledTimes(1)
+		// assert on the node itself: a nameless or mistagged frame is the exact regression
+		// this PR guards against, and it would satisfy a bare "was called" check
+		const node = await decodeFrame(send.mock.calls[0]![0] as Buffer)
+		expect(node.tag).toBe('presence')
+		expect(node.attrs.name).toBe('New Name')
 
 		await sock.end(new Error('Test completed'))
 		await clear()

--- a/src/__tests__/binary/presence-on-creds-update.test.ts
+++ b/src/__tests__/binary/presence-on-creds-update.test.ts
@@ -1,0 +1,85 @@
+import { jest } from '@jest/globals'
+
+/**
+ * A partial `creds.update` (one carrying no `me`) used to fail the push-name comparison and
+ * send a `<presence>` node whose only attribute was `undefined`. Undefined attributes are
+ * stripped when encoding, so the node went out bare - and a presence node with no `type` is
+ * read as "available". Because `creds.update` fires on ordinary key churn, the account was
+ * announced online continuously even with `markOnlineOnConnect: false`, which makes WhatsApp
+ * stop delivering push notifications to the user's phone.
+ */
+
+const send = jest.fn((_data: unknown, cb?: (err?: Error) => void) => cb?.())
+
+jest.unstable_mockModule('../../Socket/Client/websocket', () => ({
+	WebSocketClient: jest.fn().mockImplementation(() => ({
+		connect: jest.fn(),
+		close: jest.fn(),
+		on: jest.fn(),
+		off: jest.fn(),
+		removeAllListeners: jest.fn(),
+		emit: jest.fn(),
+		send,
+		isOpen: true
+	}))
+}))
+
+const { DEFAULT_CONNECTION_CONFIG } = await import('../../Defaults')
+const makeWASocket = (await import('../../Socket')).default
+const { makeSession } = await import('../TestUtils/session')
+
+describe('presence announcement on creds.update', () => {
+	const ME = '1234567890:1@s.whatsapp.net'
+
+	const makeSocket = async (name: string | undefined) => {
+		const { state, clear } = await makeSession()
+		state.creds.me = { id: ME, name }
+		const sock = makeWASocket({
+			...DEFAULT_CONNECTION_CONFIG,
+			auth: state,
+			markOnlineOnConnect: false,
+			connectTimeoutMs: 200
+		})
+		send.mockClear()
+		return { sock, clear }
+	}
+
+	const settle = () => new Promise(resolve => setTimeout(resolve, 50))
+
+	it('does not send presence for a partial update that carries no `me`', async () => {
+		const { sock, clear } = await makeSocket('Test User')
+
+		// the shape emitted by ordinary key churn, e.g. from messages-recv
+		sock.ev.emit('creds.update', { lastAccountSyncTimestamp: Date.now() })
+		await settle()
+
+		expect(send).not.toHaveBeenCalled()
+
+		await sock.end(new Error('Test completed'))
+		await clear()
+	})
+
+	it('does not send presence when the push name is unchanged', async () => {
+		const { sock, clear } = await makeSocket('Test User')
+
+		sock.ev.emit('creds.update', { me: { id: ME, name: 'Test User' } })
+		await settle()
+
+		expect(send).not.toHaveBeenCalled()
+
+		await sock.end(new Error('Test completed'))
+		await clear()
+	})
+
+	it('still announces a genuinely new push name', async () => {
+		const { sock, clear } = await makeSocket('Old Name')
+
+		sock.ev.emit('creds.update', { me: { id: ME, name: 'New Name' } })
+		await settle()
+
+		expect(send).toHaveBeenCalled()
+
+		await sock.end(new Error('Test completed'))
+		await clear()
+	})
+})


### PR DESCRIPTION
## Problem

A `creds.update` that carries no `me` leaves `name` as `undefined`, so the push-name comparison in `Socket/socket.ts` is true for any session that has a stored push name:

```ts
const name = update.me?.name        // undefined on a partial update
if (creds.me?.name !== name) {      // 'Gal' !== undefined -> true
    sendNode({ tag: 'presence', attrs: { name: name! } })
}
```

Three things combine, and the third is what makes it continuous rather than a one-off:

1. **The comparison misfires on partial updates.** The `name!` assertion is exactly the assumption that does not hold.
2. **The node is typeless, which means _available_.** `WABinary/encode.ts:226` filters out undefined attributes, so `attrs: { name: undefined }` serialises to a bare `<presence/>`. Baileys' own inbound reader treats that as online (`Socket/chats.ts:885`: `attrs.type === 'unavailable' ? 'unavailable' : 'available'`). Nothing is logged, because the send succeeds.
3. **`creds.update` fires on ordinary key churn**, including from `Socket/messages-recv.ts`, so the announcement repeats continuously - which is why `markOnlineOnConnect: false` looks like it is being ignored.

**User-visible effect:** the account is marked online, so WhatsApp stops sending push notifications to the primary phone. On a personal number this presents as WhatsApp silently never notifying you again - messages only appear when you open the app. Calls are unaffected (separate VoIP path), which makes it look like a device or OS problem rather than a library one, and sends people through every iOS notification setting before they suspect their own linked client.

Reproduction, no send required: read-only client with `markOnlineOnConnect: false`, already paired. Leave the phone locked, message the number from another account, and it goes online for several minutes without the phone being touched.

## Fix

```ts
if (typeof name === 'string' && name.length > 0 && creds.me?.name !== name) {
```

Real push-name updates are still announced; partial credential patches no longer are. The now-redundant `name!` assertion is dropped.

## Tests

Adds `src/__tests__/binary/presence-on-creds-update.test.ts` with three cases:

- a partial update carrying no `me` sends nothing **(fails on `master`, passes with this change)**
- an update whose push name is unchanged sends nothing
- a genuinely new push name is still announced

Verified by stashing the source change and re-running: 1 failed, 2 passed. With the fix: 3 passed.

Full suite: **410 passed, 29 suites**. `tsc --noEmit` clean, `eslint` clean on the changed file (the 3 remaining `any` warnings are pre-existing and on other lines), `prettier` reports both files unchanged.

> Note: the test uses `jest.unstable_mockModule` rather than the existing `mockWebSocket()` helper in `TestUtils/session.ts`. That helper calls `jest.mock` inside a function body, where it is not hoisted, so it is currently a no-op under ESM. Happy to fix the helper separately if that is wanted - I left it alone to keep this PR to one behaviour change.

## Context

Fixes #2553. The same one-line guard was proposed in #2627, which was closed by the stale bot on 21 Jul with `state_reason: completed`; nothing was changed and `master` still carries the code today. This PR adds the regression test that was missing there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops sending presence announcements on partial `creds.update` events that lack a `me` field, which previously sent a bare `<presence/>` node that marked the account online and suppressed push notifications.

**Bug Fixes**
- Guards the push-name comparison so only non-empty string names trigger an announcement.
- Adds regression tests covering partial updates, unchanged names, and genuine name changes, decoding the sent frame to assert the node carries the new name.

<sup>Written for commit b8f2fa96770b3a561d066b823c56b0c370f89aa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented partial credential updates from incorrectly marking accounts as online.
  * Push notifications are no longer suppressed by unintended presence announcements.
  * Presence updates now occur only when the push name genuinely changes.

* **Tests**
  * Added coverage for partial updates, unchanged names, and valid push-name changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->