### PR TITLE
fix(business): resolve own LID for order MEX lookup

### DIFF
--- a/src/Socket/business-mex.ts
+++ b/src/Socket/business-mex.ts
@@ -55,7 +55,7 @@ export const fetchMexOrderDetails = async ({
 	const jid = resolveOrderMexJid(requestedJid, ownJids)
 	if (!jid) throw new Boom('Order details require a valid seller JID', { statusCode: 400 })
 
-	logger.debug({ queryId: BUSINESS_ORDER_MEX_QUERY.queryId }, 'querying order details through MEX')
+	logger.debug({ queryId: BUSINESS_ORDER_MEX_QUERY.queryId, orderId, jid }, 'querying order details through MEX')
 	const result = await executeQuery(
 		orderMexVariables(jid, orderId, token),
 		BUSINESS_ORDER_MEX_QUERY.queryId,

--- a/src/Socket/business-mex.ts
+++ b/src/Socket/business-mex.ts
@@ -1,7 +1,6 @@
 import { Boom } from '@hapi/boom'
 import { parseMexOrderDetails } from '../Utils/business-mex'
-import type { ILogger } from '../Utils/logger'
-import { jidNormalizedUser } from '../WABinary'
+import { isLidUser, isPnUser, jidNormalizedUser } from '../WABinary'
 
 export const BUSINESS_ORDER_MEX_QUERY = {
 	queryId: '26593811266898374',
@@ -28,27 +27,17 @@ type FetchMexOrderDetailsOptions = {
 	requestedJid: string
 	ownJids: readonly (string | undefined)[]
 	executeQuery: ExecuteMexQuery
-	logger: Pick<ILogger, 'debug'>
 }
 
-export const getOrderMexJidCandidates = (requestedJid: string, ownJids: readonly (string | undefined)[]) => {
+export const resolveOrderMexJid = (requestedJid: string, ownJids: readonly (string | undefined)[]) => {
 	const requested = jidNormalizedUser(requestedJid)
-	if (!requested) return []
+	if (!requested) return undefined
 
 	const ownAliases = ownJids.map(jidNormalizedUser).filter((jid): jid is string => !!jid)
-	return [...new Set([requested, ...(ownAliases.includes(requested) ? ownAliases : [])])]
-}
+	const ownPn = ownAliases.find(isPnUser)
+	const requestedIsOwnLid = isLidUser(requested) && ownAliases.includes(requested)
 
-export const isMexOrderAliasFallbackError = (error: unknown) => {
-	if (!(error instanceof Boom) || error.output.statusCode !== 400) return false
-	if (!error.message.startsWith('GraphQL server error:')) return false
-
-	const data = error.data
-	if (typeof data !== 'object' || data === null || Array.isArray(data)) return false
-	const extensions = 'extensions' in data ? data.extensions : undefined
-	if (typeof extensions !== 'object' || extensions === null || Array.isArray(extensions)) return false
-
-	return 'error_code' in extensions && extensions.error_code === 400
+	return requestedIsOwnLid && ownPn ? ownPn : requested
 }
 
 export const fetchMexOrderDetails = async ({
@@ -56,27 +45,16 @@ export const fetchMexOrderDetails = async ({
 	token,
 	requestedJid,
 	ownJids,
-	executeQuery,
-	logger
+	executeQuery
 }: FetchMexOrderDetailsOptions) => {
-	// Order messages can identify the local catalog by either alias, independently of the alias accepted by MEX.
-	const candidates = getOrderMexJidCandidates(requestedJid, ownJids)
-	if (!candidates.length) throw new Boom('Order details require a valid seller JID', { statusCode: 400 })
+	// WhatsApp Web derives this value from the current user. Incoming orders may carry the same account's LID instead.
+	const jid = resolveOrderMexJid(requestedJid, ownJids)
+	if (!jid) throw new Boom('Order details require a valid seller JID', { statusCode: 400 })
 
-	for (const [index, candidate] of candidates.entries()) {
-		try {
-			const result = await executeQuery(
-				orderMexVariables(candidate, orderId, token),
-				BUSINESS_ORDER_MEX_QUERY.queryId,
-				BUSINESS_ORDER_MEX_QUERY.dataPath
-			)
-			return parseMexOrderDetails(result)
-		} catch (error) {
-			const hasAnotherAlias = index < candidates.length - 1
-			if (!hasAnotherAlias || !isMexOrderAliasFallbackError(error)) throw error
-			logger.debug({ orderId, attempt: index + 1 }, 'order lookup rejected own-account alias; trying the next alias')
-		}
-	}
-
-	throw new Boom('Order lookup did not attempt a seller JID', { statusCode: 500 })
+	const result = await executeQuery(
+		orderMexVariables(jid, orderId, token),
+		BUSINESS_ORDER_MEX_QUERY.queryId,
+		BUSINESS_ORDER_MEX_QUERY.dataPath
+	)
+	return parseMexOrderDetails(result)
 }

--- a/src/Socket/business-mex.ts
+++ b/src/Socket/business-mex.ts
@@ -55,7 +55,16 @@ export const fetchMexOrderDetails = async ({
 	const jid = resolveOrderMexJid(requestedJid, ownJids)
 	if (!jid) throw new Boom('Order details require a valid seller JID', { statusCode: 400 })
 
-	logger.debug({ queryId: BUSINESS_ORDER_MEX_QUERY.queryId, orderId, jid }, 'querying order details through MEX')
+	const requested = jidNormalizedUser(requestedJid)
+	logger.debug(
+		{
+			queryId: BUSINESS_ORDER_MEX_QUERY.queryId,
+			requestedJidType: isLidUser(requested) ? 'lid' : isPnUser(requested) ? 'pn' : 'other',
+			resolvedJidType: isLidUser(jid) ? 'lid' : isPnUser(jid) ? 'pn' : 'other',
+			usedOwnPnAlias: isLidUser(requested) && isPnUser(jid)
+		},
+		'querying order details through MEX'
+	)
 	const result = await executeQuery(
 		orderMexVariables(jid, orderId, token),
 		BUSINESS_ORDER_MEX_QUERY.queryId,

--- a/src/Socket/business-mex.ts
+++ b/src/Socket/business-mex.ts
@@ -1,6 +1,7 @@
 import { Boom } from '@hapi/boom'
+import type { ILogger } from '../Utils/logger'
 import { parseMexOrderDetails } from '../Utils/business-mex'
-import { isLidUser, isPnUser, jidNormalizedUser } from '../WABinary'
+import { areJidsSameUser, isLidUser, isPnUser, jidNormalizedUser } from '../WABinary'
 
 export const BUSINESS_ORDER_MEX_QUERY = {
 	queryId: '26593811266898374',
@@ -27,6 +28,7 @@ type FetchMexOrderDetailsOptions = {
 	requestedJid: string
 	ownJids: readonly (string | undefined)[]
 	executeQuery: ExecuteMexQuery
+	logger: ILogger
 }
 
 export const resolveOrderMexJid = (requestedJid: string, ownJids: readonly (string | undefined)[]) => {
@@ -35,7 +37,8 @@ export const resolveOrderMexJid = (requestedJid: string, ownJids: readonly (stri
 
 	const ownAliases = ownJids.map(jidNormalizedUser).filter((jid): jid is string => !!jid)
 	const ownPn = ownAliases.find(isPnUser)
-	const requestedIsOwnLid = isLidUser(requested) && ownAliases.includes(requested)
+	const requestedIsOwnLid =
+		isLidUser(requested) && ownAliases.some(ownJid => isLidUser(ownJid) && areJidsSameUser(ownJid, requested))
 
 	return requestedIsOwnLid && ownPn ? ownPn : requested
 }
@@ -45,12 +48,14 @@ export const fetchMexOrderDetails = async ({
 	token,
 	requestedJid,
 	ownJids,
-	executeQuery
+	executeQuery,
+	logger
 }: FetchMexOrderDetailsOptions) => {
-	// WhatsApp Web derives this value from the current user. Incoming orders may carry the same account's LID instead.
+	// Resolve known local aliases before the single request; MEX failures must never select another JID.
 	const jid = resolveOrderMexJid(requestedJid, ownJids)
 	if (!jid) throw new Boom('Order details require a valid seller JID', { statusCode: 400 })
 
+	logger.debug({ queryId: BUSINESS_ORDER_MEX_QUERY.queryId }, 'querying order details through MEX')
 	const result = await executeQuery(
 		orderMexVariables(jid, orderId, token),
 		BUSINESS_ORDER_MEX_QUERY.queryId,

--- a/src/Socket/business-mex.ts
+++ b/src/Socket/business-mex.ts
@@ -1,0 +1,82 @@
+import { Boom } from '@hapi/boom'
+import { parseMexOrderDetails } from '../Utils/business-mex'
+import type { ILogger } from '../Utils/logger'
+import { jidNormalizedUser } from '../WABinary'
+
+export const BUSINESS_ORDER_MEX_QUERY = {
+	queryId: '26593811266898374',
+	dataPath: 'xwa_checkout_get_order_info'
+} as const
+
+export const orderMexVariables = (jid: string, orderId: string, token: string) => ({
+	request: {
+		order: {
+			id: orderId,
+			jid,
+			token: { sensitive_string_value: token },
+			image_dimensions: { width: 100, height: 100 },
+			direct_connection_encrypted_info: null
+		}
+	}
+})
+
+type ExecuteMexQuery = (variables: Record<string, unknown>, queryId: string, dataPath: string) => Promise<unknown>
+
+type FetchMexOrderDetailsOptions = {
+	orderId: string
+	token: string
+	requestedJid: string
+	ownJids: readonly (string | undefined)[]
+	executeQuery: ExecuteMexQuery
+	logger: Pick<ILogger, 'debug'>
+}
+
+export const getOrderMexJidCandidates = (requestedJid: string, ownJids: readonly (string | undefined)[]) => {
+	const requested = jidNormalizedUser(requestedJid)
+	if (!requested) return []
+
+	const ownAliases = ownJids.map(jidNormalizedUser).filter((jid): jid is string => !!jid)
+	return [...new Set([requested, ...(ownAliases.includes(requested) ? ownAliases : [])])]
+}
+
+export const isMexOrderAliasFallbackError = (error: unknown) => {
+	if (!(error instanceof Boom) || error.output.statusCode !== 400) return false
+	if (!error.message.startsWith('GraphQL server error:')) return false
+
+	const data = error.data
+	if (typeof data !== 'object' || data === null || Array.isArray(data)) return false
+	const extensions = 'extensions' in data ? data.extensions : undefined
+	if (typeof extensions !== 'object' || extensions === null || Array.isArray(extensions)) return false
+
+	return 'error_code' in extensions && extensions.error_code === 400
+}
+
+export const fetchMexOrderDetails = async ({
+	orderId,
+	token,
+	requestedJid,
+	ownJids,
+	executeQuery,
+	logger
+}: FetchMexOrderDetailsOptions) => {
+	// Order messages can identify the local catalog by either alias, independently of the alias accepted by MEX.
+	const candidates = getOrderMexJidCandidates(requestedJid, ownJids)
+	if (!candidates.length) throw new Boom('Order details require a valid seller JID', { statusCode: 400 })
+
+	for (const [index, candidate] of candidates.entries()) {
+		try {
+			const result = await executeQuery(
+				orderMexVariables(candidate, orderId, token),
+				BUSINESS_ORDER_MEX_QUERY.queryId,
+				BUSINESS_ORDER_MEX_QUERY.dataPath
+			)
+			return parseMexOrderDetails(result)
+		} catch (error) {
+			const hasAnotherAlias = index < candidates.length - 1
+			if (!hasAnotherAlias || !isMexOrderAliasFallbackError(error)) throw error
+			logger.debug({ orderId, attempt: index + 1 }, 'order lookup rejected own-account alias; trying the next alias')
+		}
+	}
+
+	throw new Boom('Order lookup did not attempt a seller JID', { statusCode: 500 })
+}

--- a/src/Socket/business.ts
+++ b/src/Socket/business.ts
@@ -260,8 +260,7 @@ export const makeBusinessSocket = (config: SocketConfig) => {
 			token: tokenBase64,
 			requestedJid: jid || authState.creds.me?.id || authState.creds.me?.lid || '',
 			ownJids: [authState.creds.me?.id, authState.creds.me?.lid],
-			executeQuery: executeWMexQuery,
-			logger: config.logger
+			executeQuery: executeWMexQuery
 		})
 	}
 

--- a/src/Socket/business.ts
+++ b/src/Socket/business.ts
@@ -4,18 +4,21 @@ import { getRawMediaUploadData } from '../Utils'
 import {
 	parseCatalogNode,
 	parseCollectionsNode,
-	parseOrderDetailsNode,
 	parseProductNode,
 	toProductNode,
 	uploadingNecessaryImagesOfProduct
 } from '../Utils/business'
 import { type BinaryNode, jidNormalizedUser, S_WHATSAPP_NET } from '../WABinary'
 import { getBinaryNodeChild } from '../WABinary/generic-utils'
+import { fetchMexOrderDetails } from './business-mex'
 import { makeMessagesRecvSocket } from './messages-recv'
+import { executeWMexQuery as genericExecuteWMexQuery } from './mex'
 
 export const makeBusinessSocket = (config: SocketConfig) => {
 	const sock = makeMessagesRecvSocket(config)
-	const { authState, query, waUploadToServer } = sock
+	const { authState, generateMessageTag, query, waUploadToServer } = sock
+	const executeWMexQuery = (variables: Record<string, unknown>, queryId: string, dataPath: string): Promise<unknown> =>
+		genericExecuteWMexQuery(variables, queryId, dataPath, query, generateMessageTag)
 
 	const updateBussinesProfile = async (args: UpdateBussinesProfileProps) => {
 		const node: BinaryNode[] = []
@@ -251,50 +254,15 @@ export const makeBusinessSocket = (config: SocketConfig) => {
 		return parseCollectionsNode(result)
 	}
 
-	const getOrderDetails = async (orderId: string, tokenBase64: string) => {
-		const result = await query({
-			tag: 'iq',
-			attrs: {
-				to: S_WHATSAPP_NET,
-				type: 'get',
-				xmlns: 'fb:thrift_iq',
-				smax_id: '5'
-			},
-			content: [
-				{
-					tag: 'order',
-					attrs: {
-						op: 'get',
-						id: orderId
-					},
-					content: [
-						{
-							tag: 'image_dimensions',
-							attrs: {},
-							content: [
-								{
-									tag: 'width',
-									attrs: {},
-									content: Buffer.from('100')
-								},
-								{
-									tag: 'height',
-									attrs: {},
-									content: Buffer.from('100')
-								}
-							]
-						},
-						{
-							tag: 'token',
-							attrs: {},
-							content: Buffer.from(tokenBase64)
-						}
-					]
-				}
-			]
+	const getOrderDetails = async (orderId: string, tokenBase64: string, jid?: string) => {
+		return fetchMexOrderDetails({
+			orderId,
+			token: tokenBase64,
+			requestedJid: jid || authState.creds.me?.id || authState.creds.me?.lid || '',
+			ownJids: [authState.creds.me?.id, authState.creds.me?.lid],
+			executeQuery: executeWMexQuery,
+			logger: config.logger
 		})
-
-		return parseOrderDetailsNode(result)
 	}
 
 	const productUpdate = async (productId: string, update: ProductUpdate) => {

--- a/src/Socket/business.ts
+++ b/src/Socket/business.ts
@@ -260,7 +260,8 @@ export const makeBusinessSocket = (config: SocketConfig) => {
 			token: tokenBase64,
 			requestedJid: jid || authState.creds.me?.id || authState.creds.me?.lid || '',
 			ownJids: [authState.creds.me?.id, authState.creds.me?.lid],
-			executeQuery: executeWMexQuery
+			executeQuery: executeWMexQuery,
+			logger: config.logger
 		})
 	}
 

--- a/src/Utils/business-mex.ts
+++ b/src/Utils/business-mex.ts
@@ -31,6 +31,7 @@ const stringAt = (value: unknown, path: string): string => {
 
 const numberAt = (value: unknown, path: string): number => {
 	if (typeof value !== 'number' && typeof value !== 'string') return malformedOrder(`${path} is not numeric`)
+	if (typeof value === 'string' && !value.trim()) return malformedOrder(`${path} is not numeric`)
 
 	const parsed = Number(value)
 	if (!Number.isFinite(parsed)) return malformedOrder(`${path} is not numeric`)
@@ -39,8 +40,8 @@ const numberAt = (value: unknown, path: string): number => {
 }
 
 export const parseMexOrderDetails = (value: unknown): OrderDetails => {
-	const response = objectAt(value, 'response')!
-	const order = objectAt(response.order, 'order')!
+	const payload = objectAt(value, 'payload')!
+	const order = objectAt(payload.order, 'order')!
 	const priceDetails = objectAt(order.price_details, 'order.price_details')!
 	const products = objectArrayAt(order.products, 'order.products').map<OrderProduct>((product, index) => {
 		const path = `order.products[${index}]`

--- a/src/Utils/business-mex.ts
+++ b/src/Utils/business-mex.ts
@@ -1,0 +1,68 @@
+import { Boom } from '@hapi/boom'
+import type { OrderDetails, OrderProduct } from '../Types'
+
+type JsonObject = Record<string, unknown>
+
+const malformedOrder = (detail: string): never => {
+	throw new Boom(`Malformed order MEX response: ${detail}`, { statusCode: 502 })
+}
+
+const objectAt = (value: unknown, path: string, optional = false): JsonObject | undefined => {
+	if ((value === undefined || value === null) && optional) return undefined
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+		return malformedOrder(`${path} is not an object`)
+	}
+
+	return value as JsonObject
+}
+
+const objectArrayAt = (value: unknown, path: string, optional = false): JsonObject[] => {
+	if ((value === undefined || value === null) && optional) return []
+	if (!Array.isArray(value)) return malformedOrder(`${path} is not an array`)
+
+	return value.map((entry, index) => objectAt(entry, `${path}[${index}]`)!)
+}
+
+const stringAt = (value: unknown, path: string): string => {
+	if (typeof value !== 'string') return malformedOrder(`${path} is not a string`)
+
+	return value
+}
+
+const numberAt = (value: unknown, path: string): number => {
+	if (typeof value !== 'number' && typeof value !== 'string') return malformedOrder(`${path} is not numeric`)
+
+	const parsed = Number(value)
+	if (!Number.isFinite(parsed)) return malformedOrder(`${path} is not numeric`)
+
+	return parsed
+}
+
+export const parseMexOrderDetails = (value: unknown): OrderDetails => {
+	const response = objectAt(value, 'response')!
+	const order = objectAt(response.order, 'order')!
+	const priceDetails = objectAt(order.price_details, 'order.price_details')!
+	const products = objectArrayAt(order.products, 'order.products').map<OrderProduct>((product, index) => {
+		const path = `order.products[${index}]`
+		const media = objectAt(product.media, `${path}.media`, true)
+		const images = objectArrayAt(media?.images, `${path}.media.images`, true)
+		const imageUrl = images[0]?.request_image_url
+
+		return {
+			id: stringAt(product.id, `${path}.id`),
+			name: stringAt(product.name, `${path}.name`),
+			imageUrl: typeof imageUrl === 'string' ? imageUrl : '',
+			price: numberAt(product.price, `${path}.price`),
+			currency: stringAt(product.currency, `${path}.currency`),
+			quantity: numberAt(product.quantity, `${path}.quantity`)
+		}
+	})
+
+	return {
+		price: {
+			total: numberAt(priceDetails.total_amount, 'order.price_details.total_amount'),
+			currency: stringAt(priceDetails.currency, 'order.price_details.currency')
+		},
+		products
+	}
+}

--- a/src/Utils/business-mex.ts
+++ b/src/Utils/business-mex.ts
@@ -40,8 +40,7 @@ const numberAt = (value: unknown, path: string): number => {
 }
 
 export const parseMexOrderDetails = (value: unknown): OrderDetails => {
-	const payload = objectAt(value, 'payload')!
-	const order = objectAt(payload.order, 'order')!
+	const order = objectAt(objectAt(value, 'MEX data-path result')!.order, 'order')!
 	const priceDetails = objectAt(order.price_details, 'order.price_details')!
 	const products = objectArrayAt(order.products, 'order.products').map<OrderProduct>((product, index) => {
 		const path = `order.products[${index}]`

--- a/src/__tests__/Socket/business-mex.test.ts
+++ b/src/__tests__/Socket/business-mex.test.ts
@@ -7,6 +7,17 @@ import {
 	resolveOrderMexJid
 } from '../../Socket/business-mex'
 import { parseMexOrderDetails } from '../../Utils/business-mex'
+import type { ILogger } from '../../Utils/logger'
+
+const logger: ILogger = {
+	level: 'silent',
+	child: () => logger,
+	trace: jest.fn(),
+	debug: jest.fn(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn()
+}
 
 const orderResponse = {
 	order: {
@@ -80,7 +91,8 @@ describe('business MEX order lookup', () => {
 			token: 'token-1',
 			requestedJid: '11111111111111@lid',
 			ownJids: ['15550000001@s.whatsapp.net', '11111111111111@lid'],
-			executeQuery
+			executeQuery,
+			logger
 		})
 
 		expect(executeQuery).toHaveBeenCalledTimes(1)
@@ -97,7 +109,8 @@ describe('business MEX order lookup', () => {
 				token: 'token-1',
 				requestedJid: '11111111111111@lid',
 				ownJids: ['15550000001@s.whatsapp.net', '11111111111111@lid'],
-				executeQuery
+				executeQuery,
+				logger
 			})
 		).rejects.toBe(failure)
 		expect(executeQuery).toHaveBeenCalledTimes(1)
@@ -113,7 +126,8 @@ describe('business MEX order lookup', () => {
 				token: 'token-1',
 				requestedJid: '11111111111111@lid',
 				ownJids: ['15550000001@s.whatsapp.net', '11111111111111@lid'],
-				executeQuery
+				executeQuery,
+				logger
 			})
 		).rejects.toBe(failure)
 		expect(executeQuery).toHaveBeenCalledTimes(1)

--- a/src/__tests__/Socket/business-mex.test.ts
+++ b/src/__tests__/Socket/business-mex.test.ts
@@ -3,9 +3,8 @@ import { jest } from '@jest/globals'
 import {
 	BUSINESS_ORDER_MEX_QUERY,
 	fetchMexOrderDetails,
-	getOrderMexJidCandidates,
-	isMexOrderAliasFallbackError,
-	orderMexVariables
+	orderMexVariables,
+	resolveOrderMexJid
 } from '../../Socket/business-mex'
 import { parseMexOrderDetails } from '../../Utils/business-mex'
 
@@ -57,69 +56,40 @@ describe('business MEX order lookup', () => {
 		})
 	})
 
-	it('normalizes own-account aliases and preserves the requested JID as the first candidate', () => {
-		expect(
-			getOrderMexJidCandidates('11111111111111:7@lid', ['15550000001:4@s.whatsapp.net', '11111111111111:7@lid'])
-		).toEqual(['11111111111111@lid', '15550000001@s.whatsapp.net'])
+	it('resolves the current account LID to its PN for the order query', () => {
+		expect(resolveOrderMexJid('11111111111111:7@lid', ['15550000001:4@s.whatsapp.net', '11111111111111:7@lid'])).toBe(
+			'15550000001@s.whatsapp.net'
+		)
 	})
 
-	it('does not try own-account aliases for another business', () => {
-		expect(
-			getOrderMexJidCandidates('22222222222222@lid', ['15550000001@s.whatsapp.net', '11111111111111@lid'])
-		).toEqual(['22222222222222@lid'])
+	it('preserves PN and external business JIDs', () => {
+		const ownJids = ['15550000001@s.whatsapp.net', '11111111111111@lid']
+
+		expect(resolveOrderMexJid('15550000001:4@s.whatsapp.net', ownJids)).toBe('15550000001@s.whatsapp.net')
+		expect(resolveOrderMexJid('22222222222222@lid', ownJids)).toBe('22222222222222@lid')
 	})
 
-	it('retries a rejected own LID with its PN alias and returns the parsed order', async () => {
+	it('queries once with the resolved PN and returns the parsed order', async () => {
 		const executeQuery = jest.fn(async (variables: Record<string, unknown>) => {
-			if (orderJidFromVariables(variables) === '11111111111111@lid') throw mexBadRequest()
+			expect(orderJidFromVariables(variables)).toBe('15550000001@s.whatsapp.net')
 			return orderResponse
 		})
-		const debug = jest.fn()
 
 		const result = await fetchMexOrderDetails({
 			orderId: 'order-1',
 			token: 'token-1',
 			requestedJid: '11111111111111@lid',
 			ownJids: ['15550000001@s.whatsapp.net', '11111111111111@lid'],
-			executeQuery,
-			logger: { debug }
+			executeQuery
 		})
 
-		expect(executeQuery).toHaveBeenCalledTimes(2)
-		expect(orderJidFromVariables(executeQuery.mock.calls[0]![0])).toBe('11111111111111@lid')
-		expect(orderJidFromVariables(executeQuery.mock.calls[1]![0])).toBe('15550000001@s.whatsapp.net')
-		expect(debug).toHaveBeenCalledWith(
-			{ orderId: 'order-1', attempt: 1 },
-			'order lookup rejected own-account alias; trying the next alias'
-		)
+		expect(executeQuery).toHaveBeenCalledTimes(1)
 		expect(result).toEqual(parseMexOrderDetails(orderResponse))
 	})
 
-	it('also retries a rejected own PN with its LID alias', async () => {
-		const executeQuery = jest.fn(async (variables: Record<string, unknown>) => {
-			if (orderJidFromVariables(variables) === '15550000001@s.whatsapp.net') throw mexBadRequest()
-			return orderResponse
-		})
-
-		await fetchMexOrderDetails({
-			orderId: 'order-1',
-			token: 'token-1',
-			requestedJid: '15550000001@s.whatsapp.net',
-			ownJids: ['15550000001@s.whatsapp.net', '11111111111111@lid'],
-			executeQuery,
-			logger: { debug: jest.fn() }
-		})
-
-		expect(orderJidFromVariables(executeQuery.mock.calls[0]![0])).toBe('15550000001@s.whatsapp.net')
-		expect(orderJidFromVariables(executeQuery.mock.calls[1]![0])).toBe('11111111111111@lid')
-	})
-
-	it('propagates the final structured error when neither own-account alias resolves the order', async () => {
-		const finalFailure = mexBadRequest()
-		const executeQuery = jest
-			.fn<(variables: Record<string, unknown>) => Promise<unknown>>()
-			.mockRejectedValueOnce(mexBadRequest())
-			.mockRejectedValueOnce(finalFailure)
+	it('propagates GraphQL errors without retrying another alias', async () => {
+		const failure = mexBadRequest()
+		const executeQuery = jest.fn(async () => Promise.reject(failure))
 
 		await expect(
 			fetchMexOrderDetails({
@@ -127,11 +97,10 @@ describe('business MEX order lookup', () => {
 				token: 'token-1',
 				requestedJid: '11111111111111@lid',
 				ownJids: ['15550000001@s.whatsapp.net', '11111111111111@lid'],
-				executeQuery,
-				logger: { debug: jest.fn() }
+				executeQuery
 			})
-		).rejects.toBe(finalFailure)
-		expect(executeQuery).toHaveBeenCalledTimes(2)
+		).rejects.toBe(failure)
+		expect(executeQuery).toHaveBeenCalledTimes(1)
 	})
 
 	it('does not retry transport, authentication, or malformed-response failures', async () => {
@@ -144,17 +113,10 @@ describe('business MEX order lookup', () => {
 				token: 'token-1',
 				requestedJid: '11111111111111@lid',
 				ownJids: ['15550000001@s.whatsapp.net', '11111111111111@lid'],
-				executeQuery,
-				logger: { debug: jest.fn() }
+				executeQuery
 			})
 		).rejects.toBe(failure)
 		expect(executeQuery).toHaveBeenCalledTimes(1)
-	})
-
-	it('recognizes only structured MEX bad-request errors as alias mismatches', () => {
-		expect(isMexOrderAliasFallbackError(mexBadRequest())).toBe(true)
-		expect(isMexOrderAliasFallbackError(new Boom('Bad Request', { statusCode: 400 }))).toBe(false)
-		expect(isMexOrderAliasFallbackError(new Error('GraphQL server error: Bad Request'))).toBe(false)
 	})
 
 	it('rejects malformed order responses with a 502 Boom', () => {
@@ -164,5 +126,43 @@ describe('business MEX order lookup', () => {
 		} catch (error) {
 			expect((error as Boom).output.statusCode).toBe(502)
 		}
+	})
+
+	it('parses the unwrapped MEX data-path payload', () => {
+		expect(parseMexOrderDetails(orderResponse)).toEqual({
+			price: { currency: 'MXN', total: 300000 },
+			products: [
+				{
+					id: 'product-1',
+					name: 'Notebook',
+					currency: 'MXN',
+					price: 150000,
+					quantity: 2,
+					imageUrl: 'https://example.invalid/thumb.jpg'
+				}
+			]
+		})
+	})
+
+	it.each(['', '   '])('rejects a blank product price %j with a 502 Boom', value => {
+		const malformed = structuredClone(orderResponse)
+		malformed.order.products[0]!.price = value
+
+		expect(() => parseMexOrderDetails(malformed)).toThrow(Boom)
+		try {
+			parseMexOrderDetails(malformed)
+		} catch (error) {
+			expect((error as Boom).output.statusCode).toBe(502)
+		}
+	})
+
+	it('rejects blank quantity and total values', () => {
+		const blankQuantity = structuredClone(orderResponse)
+		blankQuantity.order.products[0]!.quantity = ''
+		const blankTotal = structuredClone(orderResponse)
+		blankTotal.order.price_details.total_amount = ' '
+
+		expect(() => parseMexOrderDetails(blankQuantity)).toThrow(Boom)
+		expect(() => parseMexOrderDetails(blankTotal)).toThrow(Boom)
 	})
 })

--- a/src/__tests__/Socket/business-mex.test.ts
+++ b/src/__tests__/Socket/business-mex.test.ts
@@ -1,0 +1,168 @@
+import { Boom } from '@hapi/boom'
+import { jest } from '@jest/globals'
+import {
+	BUSINESS_ORDER_MEX_QUERY,
+	fetchMexOrderDetails,
+	getOrderMexJidCandidates,
+	isMexOrderAliasFallbackError,
+	orderMexVariables
+} from '../../Socket/business-mex'
+import { parseMexOrderDetails } from '../../Utils/business-mex'
+
+const orderResponse = {
+	order: {
+		price_details: { currency: 'MXN', total_amount: '300000' },
+		products: [
+			{
+				id: 'product-1',
+				name: 'Notebook',
+				currency: 'MXN',
+				price: '150000',
+				quantity: '2',
+				media: { images: [{ request_image_url: 'https://example.invalid/thumb.jpg' }] }
+			}
+		]
+	}
+}
+
+const orderJidFromVariables = (variables: Record<string, unknown>) =>
+	(variables.request as { order: { jid: string } }).order.jid
+
+const mexBadRequest = () =>
+	new Boom('GraphQL server error: Bad Request', {
+		statusCode: 400,
+		data: {
+			message: 'Bad Request',
+			extensions: { error_code: 400, is_retryable: false, severity: 'CRITICAL' },
+			path: []
+		}
+	})
+
+describe('business MEX order lookup', () => {
+	it('uses the current persisted query and variable shape from WhatsApp Web', () => {
+		expect(BUSINESS_ORDER_MEX_QUERY).toEqual({
+			queryId: '26593811266898374',
+			dataPath: 'xwa_checkout_get_order_info'
+		})
+		expect(orderMexVariables('15550000001@s.whatsapp.net', 'order-1', 'token-1')).toEqual({
+			request: {
+				order: {
+					id: 'order-1',
+					jid: '15550000001@s.whatsapp.net',
+					token: { sensitive_string_value: 'token-1' },
+					image_dimensions: { width: 100, height: 100 },
+					direct_connection_encrypted_info: null
+				}
+			}
+		})
+	})
+
+	it('normalizes own-account aliases and preserves the requested JID as the first candidate', () => {
+		expect(
+			getOrderMexJidCandidates('11111111111111:7@lid', ['15550000001:4@s.whatsapp.net', '11111111111111:7@lid'])
+		).toEqual(['11111111111111@lid', '15550000001@s.whatsapp.net'])
+	})
+
+	it('does not try own-account aliases for another business', () => {
+		expect(
+			getOrderMexJidCandidates('22222222222222@lid', ['15550000001@s.whatsapp.net', '11111111111111@lid'])
+		).toEqual(['22222222222222@lid'])
+	})
+
+	it('retries a rejected own LID with its PN alias and returns the parsed order', async () => {
+		const executeQuery = jest.fn(async (variables: Record<string, unknown>) => {
+			if (orderJidFromVariables(variables) === '11111111111111@lid') throw mexBadRequest()
+			return orderResponse
+		})
+		const debug = jest.fn()
+
+		const result = await fetchMexOrderDetails({
+			orderId: 'order-1',
+			token: 'token-1',
+			requestedJid: '11111111111111@lid',
+			ownJids: ['15550000001@s.whatsapp.net', '11111111111111@lid'],
+			executeQuery,
+			logger: { debug }
+		})
+
+		expect(executeQuery).toHaveBeenCalledTimes(2)
+		expect(orderJidFromVariables(executeQuery.mock.calls[0]![0])).toBe('11111111111111@lid')
+		expect(orderJidFromVariables(executeQuery.mock.calls[1]![0])).toBe('15550000001@s.whatsapp.net')
+		expect(debug).toHaveBeenCalledWith(
+			{ orderId: 'order-1', attempt: 1 },
+			'order lookup rejected own-account alias; trying the next alias'
+		)
+		expect(result).toEqual(parseMexOrderDetails(orderResponse))
+	})
+
+	it('also retries a rejected own PN with its LID alias', async () => {
+		const executeQuery = jest.fn(async (variables: Record<string, unknown>) => {
+			if (orderJidFromVariables(variables) === '15550000001@s.whatsapp.net') throw mexBadRequest()
+			return orderResponse
+		})
+
+		await fetchMexOrderDetails({
+			orderId: 'order-1',
+			token: 'token-1',
+			requestedJid: '15550000001@s.whatsapp.net',
+			ownJids: ['15550000001@s.whatsapp.net', '11111111111111@lid'],
+			executeQuery,
+			logger: { debug: jest.fn() }
+		})
+
+		expect(orderJidFromVariables(executeQuery.mock.calls[0]![0])).toBe('15550000001@s.whatsapp.net')
+		expect(orderJidFromVariables(executeQuery.mock.calls[1]![0])).toBe('11111111111111@lid')
+	})
+
+	it('propagates the final structured error when neither own-account alias resolves the order', async () => {
+		const finalFailure = mexBadRequest()
+		const executeQuery = jest
+			.fn<(variables: Record<string, unknown>) => Promise<unknown>>()
+			.mockRejectedValueOnce(mexBadRequest())
+			.mockRejectedValueOnce(finalFailure)
+
+		await expect(
+			fetchMexOrderDetails({
+				orderId: 'order-1',
+				token: 'token-1',
+				requestedJid: '11111111111111@lid',
+				ownJids: ['15550000001@s.whatsapp.net', '11111111111111@lid'],
+				executeQuery,
+				logger: { debug: jest.fn() }
+			})
+		).rejects.toBe(finalFailure)
+		expect(executeQuery).toHaveBeenCalledTimes(2)
+	})
+
+	it('does not retry transport, authentication, or malformed-response failures', async () => {
+		const failure = new Boom('Business request unavailable', { statusCode: 503 })
+		const executeQuery = jest.fn(async () => Promise.reject(failure))
+
+		await expect(
+			fetchMexOrderDetails({
+				orderId: 'order-1',
+				token: 'token-1',
+				requestedJid: '11111111111111@lid',
+				ownJids: ['15550000001@s.whatsapp.net', '11111111111111@lid'],
+				executeQuery,
+				logger: { debug: jest.fn() }
+			})
+		).rejects.toBe(failure)
+		expect(executeQuery).toHaveBeenCalledTimes(1)
+	})
+
+	it('recognizes only structured MEX bad-request errors as alias mismatches', () => {
+		expect(isMexOrderAliasFallbackError(mexBadRequest())).toBe(true)
+		expect(isMexOrderAliasFallbackError(new Boom('Bad Request', { statusCode: 400 }))).toBe(false)
+		expect(isMexOrderAliasFallbackError(new Error('GraphQL server error: Bad Request'))).toBe(false)
+	})
+
+	it('rejects malformed order responses with a 502 Boom', () => {
+		expect(() => parseMexOrderDetails({ order: {} })).toThrow(Boom)
+		try {
+			parseMexOrderDetails({ order: {} })
+		} catch (error) {
+			expect((error as Boom).output.statusCode).toBe(502)
+		}
+	})
+})

--- a/src/__tests__/Socket/business-order.test.ts
+++ b/src/__tests__/Socket/business-order.test.ts
@@ -79,8 +79,9 @@ describe('business order socket', () => {
 		expect(logger.debug).toHaveBeenCalledWith(
 			{
 				queryId: '26593811266898374',
-				orderId: 'order-1',
-				jid: '15550000001@s.whatsapp.net'
+				requestedJidType: 'lid',
+				resolvedJidType: 'pn',
+				usedOwnPnAlias: true
 			},
 			'querying order details through MEX'
 		)

--- a/src/__tests__/Socket/business-order.test.ts
+++ b/src/__tests__/Socket/business-order.test.ts
@@ -1,0 +1,103 @@
+import { jest } from '@jest/globals'
+import type { SocketConfig } from '../../Types'
+import type { ILogger } from '../../Utils/logger'
+import { type BinaryNode, getBinaryNodeChild } from '../../WABinary'
+
+const orderResponse = {
+	order: {
+		price_details: { currency: 'MXN', total_amount: '300000' },
+		products: [
+			{
+				id: 'product-1',
+				name: 'Notebook',
+				currency: 'MXN',
+				price: '150000',
+				quantity: '2',
+				media: { images: [{ request_image_url: 'https://example.invalid/thumb.jpg' }] }
+			}
+		]
+	}
+}
+
+const logger: ILogger = {
+	level: 'silent',
+	child: () => logger,
+	trace: jest.fn(),
+	debug: jest.fn(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn()
+}
+
+const query = jest.fn(
+	async (_node: BinaryNode): Promise<BinaryNode> => ({
+		tag: 'iq',
+		attrs: {},
+		content: [
+			{
+				tag: 'result',
+				attrs: {},
+				content: Buffer.from(JSON.stringify({ data: { xwa_checkout_get_order_info: orderResponse } }))
+			}
+		]
+	})
+)
+
+jest.unstable_mockModule('../../Socket/messages-recv', () => ({
+	makeMessagesRecvSocket: () => ({
+		authState: {
+			creds: {
+				me: { id: '15550000001:4@s.whatsapp.net', lid: '11111111111111:7@lid' }
+			}
+		},
+		generateMessageTag: () => 'message-tag-1',
+		query,
+		waUploadToServer: jest.fn()
+	})
+}))
+
+describe('business order socket', () => {
+	it('sends the MEX query and parses its data-path response', async () => {
+		const { makeBusinessSocket } = await import('../../Socket/business')
+		const socket = makeBusinessSocket({ logger } as SocketConfig)
+
+		await expect(socket.getOrderDetails('order-1', 'token-1', '11111111111111:3@lid')).resolves.toEqual({
+			price: { currency: 'MXN', total: 300000 },
+			products: [
+				{
+					id: 'product-1',
+					name: 'Notebook',
+					currency: 'MXN',
+					price: 150000,
+					quantity: 2,
+					imageUrl: 'https://example.invalid/thumb.jpg'
+				}
+			]
+		})
+
+		expect(query).toHaveBeenCalledTimes(1)
+		const request = query.mock.calls[0]![0]
+		expect(request.attrs).toEqual({
+			id: 'message-tag-1',
+			type: 'get',
+			to: '@s.whatsapp.net',
+			xmlns: 'w:mex'
+		})
+
+		const queryNode = getBinaryNodeChild(request, 'query')!
+		expect(queryNode.attrs.query_id).toBe('26593811266898374')
+		expect(JSON.parse(queryNode.content!.toString())).toEqual({
+			variables: {
+				request: {
+					order: {
+						id: 'order-1',
+						jid: '15550000001@s.whatsapp.net',
+						token: { sensitive_string_value: 'token-1' },
+						image_dimensions: { width: 100, height: 100 },
+						direct_connection_encrypted_info: null
+					}
+				}
+			}
+		})
+	})
+})

--- a/src/__tests__/Socket/business-order.test.ts
+++ b/src/__tests__/Socket/business-order.test.ts
@@ -76,6 +76,14 @@ describe('business order socket', () => {
 		})
 
 		expect(query).toHaveBeenCalledTimes(1)
+		expect(logger.debug).toHaveBeenCalledWith(
+			{
+				queryId: '26593811266898374',
+				orderId: 'order-1',
+				jid: '15550000001@s.whatsapp.net'
+			},
+			'querying order details through MEX'
+		)
 		const request = query.mock.calls[0]![0]
 		expect(request.attrs).toEqual({
 			id: 'message-tag-1',


### PR DESCRIPTION
## Problem

Native catalog order messages can identify the local business with `sellerJid` as its LID, while the order MEX lookup for the reproduced session accepts the account's PN. The existing `getOrderDetails(orderId, token)` path cannot use the seller JID from the message and relies on the legacy order IQ, so consumers can receive the order shell but fail to resolve its line items.

A live native-catalog order reproduced this as a structured MEX `400` when the local LID was used. No real JIDs, tokens, or auth state are included in this PR.

Related to #2717, which reports timeouts in the adjacent catalog and collection read paths. Both failures come from business-data flows that have moved away from the legacy IQ endpoints; this PR applies the current WhatsApp Web MEX flow specifically to order details and does not claim to close the broader catalog/collection issue.

## Change

- Use WhatsApp Web's persisted `xwa_checkout_get_order_info` MEX query and parse its response into the existing `OrderDetails` shape.
- Accept an optional seller JID as the third `getOrderDetails` argument, preserving existing two-argument calls.
- Normalize the requested JID before the query. When an incoming order contains the authenticated account's known LID, resolve it to that account's PN and make one MEX request. PN and external-business JIDs remain unchanged.
- Propagate GraphQL, transport, authentication, and malformed-response failures without alias retries. This single-request behavior supersedes the earlier retry approach because the response has no verified alias-mismatch discriminator.
- Validate the unwrapped MEX data-path payload at runtime, including rejecting blank numeric values, and return a `502` `Boom` for malformed payloads.
- Emit structured debug context with the query ID, requested/resolved JID types, and whether the authenticated PN alias was used. No order IDs, raw JIDs, tokens, or auth state are logged.

The request sent through `w:mex` has this shape:

```json
{
  "request": {
    "order": {
      "id": "<order-id>",
      "jid": "<seller-jid>",
      "token": { "sensitive_string_value": "<token>" },
      "image_dimensions": { "width": 100, "height": 100 },
      "direct_connection_encrypted_info": null
    }
  }
}
```

## Validation

- `yarn build`
- `yarn tsc --noEmit`
- Prettier on all five changed files
- Full unit suite: 30 suites, 419 tests passed
- Focused order MEX suites: 12 tests passed
- The socket-level integration test mocks the binary MEX response and verifies the IQ namespace, persisted query ID, request variables, LID-to-PN resolution, data-path extraction, parsed response, and PII-safe structured debug log.

`yarn test:e2e` was not run because it requires the external bartender setup. The live account reproduced the original LID/structured-400 trigger; the post-change JID resolution and response handling are covered by deterministic MEX tests.

Designed and reviewed by @arturhc, with implementation assistance from Codex; validated through local tests.
