### PR TITLE
fix(events): preserve decoded timestamp during buffered receipt merge

### DIFF
--- a/src/Utils/event-buffer.ts
+++ b/src/Utils/event-buffer.ts
@@ -503,7 +503,12 @@ function append<E extends BufferableEvent>(
 
 				if (data.messageUpdates[key]) {
 					logger.debug('absorbed prior message update in message upsert')
+					const messageTimestamp = message.messageTimestamp
 					Object.assign(message, data.messageUpdates[key].update)
+					if (messageTimestamp !== undefined) {
+						message.messageTimestamp = messageTimestamp
+					}
+
 					delete data.messageUpdates[key]
 				}
 

--- a/src/Utils/event-buffer.ts
+++ b/src/Utils/event-buffer.ts
@@ -529,7 +529,12 @@ function append<E extends BufferableEvent>(
 				const keyStr = stringifyMessageKey(key)
 				const existing = data.historySets.messages[keyStr] || data.messageUpserts[keyStr]?.message
 				if (existing) {
+					const messageTimestamp = existing.messageTimestamp
 					Object.assign(existing, update)
+					if (messageTimestamp !== undefined) {
+						existing.messageTimestamp = messageTimestamp
+					}
+
 					// if the message was received & read by us
 					// the chat counter must have been incremented
 					// so we need to decrement it

--- a/src/Utils/event-buffer.ts
+++ b/src/Utils/event-buffer.ts
@@ -285,6 +285,17 @@ const makeBufferData = (): BufferedEventData => {
 	}
 }
 
+/**
+ * Merges an incoming socket event into the shared buffered-event accumulator
+ * (`data`), deduplicating and combining fields per event type (history sets,
+ * message upserts/updates/receipts, chat/contact changes, etc.) so the
+ * eventual flush emits one consolidated update instead of many partial ones.
+ *
+ * For message updates specifically, an already-decoded `messageTimestamp` on
+ * the buffered message is preserved across the merge — a receipt-only update
+ * must not overwrite a timestamp that was already correctly decoded from an
+ * earlier upsert, regardless of which order the two events arrive in.
+ */
 function append<E extends BufferableEvent>(
 	data: BufferedEventData,
 	historyCache: Set<string>,

--- a/src/__tests__/Utils/event-buffer.test.ts
+++ b/src/__tests__/Utils/event-buffer.test.ts
@@ -53,6 +53,44 @@ describe('event-buffer', () => {
 
 			ev.destroy()
 		})
+
+		it('preserves the decoded message timestamp when a receipt follows the upsert', () => {
+			const ev = makeEventBuffer(makeTestLogger())
+			const receivedEvents: BaileysEventMap['messages.upsert'][] = []
+			const key = {
+				remoteJid: '1234567890@s.whatsapp.net',
+				id: 'message-id',
+				fromMe: false
+			}
+
+			ev.on('messages.upsert', (data: BaileysEventMap['messages.upsert']) => {
+				receivedEvents.push(data)
+			})
+
+			ev.buffer()
+			ev.emit('messages.upsert', {
+				messages: [{ key, messageTimestamp: 100 }],
+				type: 'append'
+			})
+			ev.emit('messages.update', [
+				{
+					key,
+					update: {
+						status: WAMessageStatus.DELIVERY_ACK,
+						messageTimestamp: 200
+					}
+				}
+			])
+			ev.flush()
+
+			expect(receivedEvents).toHaveLength(1)
+			expect(receivedEvents[0]!.messages[0]).toMatchObject({
+				messageTimestamp: 100,
+				status: WAMessageStatus.DELIVERY_ACK
+			})
+
+			ev.destroy()
+		})
 	})
 
 	describe('messaging-history.set pastParticipants buffering', () => {

--- a/src/__tests__/Utils/event-buffer.test.ts
+++ b/src/__tests__/Utils/event-buffer.test.ts
@@ -1,4 +1,4 @@
-import type { BaileysEventMap } from '../../Types'
+import { type BaileysEventMap, WAMessageStatus } from '../../Types'
 import { makeEventBuffer } from '../../Utils/event-buffer'
 import type { ILogger } from '../../Utils/logger'
 
@@ -15,6 +15,46 @@ const makeTestLogger = (): ILogger =>
 	}) as unknown as ILogger
 
 describe('event-buffer', () => {
+	describe('messages.update buffering', () => {
+		it('preserves the decoded message timestamp when absorbing a prior receipt update', () => {
+			const ev = makeEventBuffer(makeTestLogger())
+			const receivedEvents: BaileysEventMap['messages.upsert'][] = []
+			const key = {
+				remoteJid: '1234567890@s.whatsapp.net',
+				id: 'message-id',
+				fromMe: false
+			}
+
+			ev.on('messages.upsert', (data: BaileysEventMap['messages.upsert']) => {
+				receivedEvents.push(data)
+			})
+
+			ev.buffer()
+			ev.emit('messages.update', [
+				{
+					key,
+					update: {
+						status: WAMessageStatus.DELIVERY_ACK,
+						messageTimestamp: 200
+					}
+				}
+			])
+			ev.emit('messages.upsert', {
+				messages: [{ key, messageTimestamp: 100 }],
+				type: 'append'
+			})
+			ev.flush()
+
+			expect(receivedEvents).toHaveLength(1)
+			expect(receivedEvents[0]!.messages[0]).toMatchObject({
+				messageTimestamp: 100,
+				status: WAMessageStatus.DELIVERY_ACK
+			})
+
+			ev.destroy()
+		})
+	})
+
 	describe('messaging-history.set pastParticipants buffering', () => {
 		it('should include pastParticipants in flushed event', async () => {
 			const logger = makeTestLogger()


### PR DESCRIPTION
## Summary

- preserve a freshly decoded message timestamp when a prior buffered `messages.update` is absorbed into `messages.upsert`
- continue merging receipt status and all other update fields
- add a deterministic regression test for the offline-flush event ordering

## Root cause

During one offline buffer window, a 1:1 receipt can be processed before the corresponding message. The pending update contains the receipt timestamp in `messageTimestamp`, and the later `Object.assign` replaced the timestamp decoded from the message stanza.

The fix snapshots an existing upsert timestamp before merging the pending update and restores it afterwards. If the upsert has no timestamp, existing merge behavior is unchanged.

## Verification

- red test on the base behavior: expected decoded timestamp `100`, received receipt timestamp `200`
- focused event-buffer suite: 4/4 passed
- full test suite: 28/28 suites, 408/408 tests passed
- `yarn lint`: 0 errors; 103 existing repository warnings
- `yarn build`: passed
- `git diff --check`: passed

No live WhatsApp session was used for this test.

Closes #2726

AI assistance: used for implementation and test preparation; all changes and results were reviewed and verified by the submitter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the decoded message timestamp when a buffered receipt update is merged with a message upsert, so the original message time is no longer overwritten by the receipt's timestamp — regardless of whether the update or upsert is buffered first.

- Receipt status and all other update fields still merge as before.
- Adds regression tests covering both merge orders in the offline-flush path.
- Closes #2726.

<sup>Written for commit 70fb21fb82a29d3937b3133351a4abe14b1d9478. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how buffered message events preserve decoded timestamps while incorporating delivery acknowledgments.

* **Tests**
  * Added coverage for merging message updates and new message events.
  * Verified consistent behavior regardless of event arrival order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->