### PR TITLE
fix: release the per-socket AsyncLocalStorage on socket end

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -1116,6 +1116,13 @@ export const makeSocket = (config: SocketConfig) => {
 		socketEndHandlers.push(handler)
 	}
 
+	// free the per-socket AsyncLocalStorage created by addTransactionCapability -
+	// end() runs every handler unconditionally and is reached from ws.on('close'),
+	// so this also fires for abnormal closes (1006)
+	registerSocketEndHandler(() => {
+		keys.disposeTransactionStorage()
+	})
+
 	/**
 	 * Fetches your account's standing when it comes to restrictions.
 	 * @returns Returns the state of the restrictions.

--- a/src/Types/Auth.ts
+++ b/src/Types/Auth.ts
@@ -98,6 +98,8 @@ export type SignalKeyStore = {
 export type SignalKeyStoreWithTransaction = SignalKeyStore & {
 	isInTransaction: () => boolean
 	transaction<T>(exec: () => Promise<T>, key: string): Promise<T>
+	/** releases the internal AsyncLocalStorage; must be called on socket end to avoid a leak */
+	disposeTransactionStorage(): void
 }
 
 export type TransactionCapabilityOptions = {

--- a/src/Utils/auth-utils.ts
+++ b/src/Utils/auth-utils.ts
@@ -340,6 +340,22 @@ export const addTransactionCapability = (
 			} finally {
 				releaseTxMutexRef(key)
 			}
+		},
+
+		disposeTransactionStorage: () => {
+			// The first txStorage.run() enables the storage, which registers it in a
+			// module-global list inside node:async_hooks holding a STRONG reference.
+			// On Node < 24 every enabled storage also stamps one symbol-keyed property
+			// onto every async resource created anywhere in the process, so the cost of
+			// never disabling grows with sockets-ever-created x live async resources
+			// (observed: 1.9GB of a 2.1GB heap after 25h at ~250 concurrent sockets).
+			// Only .disable() releases it - GC alone never collects an enabled storage,
+			// on any Node version.
+			try {
+				txStorage.disable()
+			} catch (err) {
+				logger.warn({ err }, 'failed to disable transaction storage')
+			}
 		}
 	}
 }

--- a/src/__tests__/Signal/lid-mapping.test.ts
+++ b/src/__tests__/Signal/lid-mapping.test.ts
@@ -9,7 +9,8 @@ const mockKeys: jest.Mocked<SignalKeyStoreWithTransaction> = {
 	get: jest.fn<SignalKeyStoreWithTransaction['get']>() as any,
 	set: jest.fn<SignalKeyStoreWithTransaction['set']>(),
 	transaction: jest.fn<SignalKeyStoreWithTransaction['transaction']>(async (work: () => any) => await work()) as any,
-	isInTransaction: jest.fn<SignalKeyStoreWithTransaction['isInTransaction']>()
+	isInTransaction: jest.fn<SignalKeyStoreWithTransaction['isInTransaction']>(),
+	disposeTransactionStorage: jest.fn<SignalKeyStoreWithTransaction['disposeTransactionStorage']>()
 }
 const logger = P({ level: 'silent' })
 

--- a/src/__tests__/Utils/tc-token.test.ts
+++ b/src/__tests__/Utils/tc-token.test.ts
@@ -30,7 +30,8 @@ const createMockKeys = (): jest.Mocked<SignalKeyStoreWithTransaction> => ({
 	get: jest.fn<SignalKeyStoreWithTransaction['get']>() as any,
 	set: jest.fn<SignalKeyStoreWithTransaction['set']>(),
 	transaction: jest.fn<SignalKeyStoreWithTransaction['transaction']>(async (work: () => any) => await work()) as any,
-	isInTransaction: jest.fn<SignalKeyStoreWithTransaction['isInTransaction']>()
+	isInTransaction: jest.fn<SignalKeyStoreWithTransaction['isInTransaction']>(),
+	disposeTransactionStorage: jest.fn<SignalKeyStoreWithTransaction['disposeTransactionStorage']>()
 })
 
 describe('storeTcTokensFromIqResult', () => {


### PR DESCRIPTION
addTransactionCapability() creates one AsyncLocalStorage per socket, and the first transaction() enables it via txStorage.run(). An enabled storage is held by a STRONG reference in a module-global list inside node:async_hooks, and only .disable() releases it - GC never collects an enabled storage, on any Node version (verified with WeakRef on v22 and v24).

On Node < 24 the cost is severe: every enabled storage stamps one symbol-keyed property onto every async resource created anywhere in the process, so heap grows with sockets-ever-created x live async resources. A production heap snapshot (25h uptime, ~250 concurrent sockets) showed 1,907MB of a 2,130MB heap in property dictionaries from exactly this. On Node >= 24 the symbol stamping is gone (async context frames are the default) but the storage instances still accumulate forever.

Fix: expose disposeTransactionStorage() on the key store and call it from a socket end handler. end() runs every registered handler unconditionally and is reached from ws.on('close'), so this also fires for abnormal closes (1006). Bounds live storages to concurrent sockets instead of ever-created.

Running in production for a week at ~250 concurrent sockets: no transaction/key-store regressions, heap growth eliminated.

Fixes #2806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary transaction resources when connections end, including unexpected WebSocket closures.
  * Improved transaction lifecycle handling to release resources after operations complete.

* **Tests**
  * Updated test fixtures to support the enhanced transaction cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a memory leak where per-socket AsyncLocalStorage instances were never disabled, causing strong references that grew the heap unboundedly. Now they're disposed when the socket ends, including abnormal closes, so memory is bounded to concurrent sockets.

- Adds `disposeTransactionStorage()` to the key store and calls it from a socket end handler.
- Verified in production at ~250 concurrent sockets: no regressions and heap growth eliminated.
- Fixes #2806.

<sup>Written for commit 28208858afb703f8fda56aa713a483f4fada020b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

