### PR TITLE
fix(communities): parse group metadata responses

### DIFF
--- a/src/Socket/communities.ts
+++ b/src/Socket/communities.ts
@@ -1,3 +1,4 @@
+import { Boom } from '@hapi/boom'
 import { proto } from '../../WAProto/index.js'
 import {
 	type GroupMetadata,
@@ -432,7 +433,15 @@ export const makeCommunitiesSocket = (config: SocketConfig) => {
 }
 
 export const extractCommunityMetadata = (result: BinaryNode) => {
-	const community = getBinaryNodeChild(result, 'community')!
+	const community = getBinaryNodeChild(result, 'community') || getBinaryNodeChild(result, 'group')
+	if (!community) {
+		throw new Boom('Invalid community metadata response: missing <community> or <group> node', { data: result })
+	}
+
+	if (!community.attrs.id) {
+		throw new Boom('Invalid community metadata response: missing community id', { data: community })
+	}
+
 	const descChild = getBinaryNodeChild(community, 'description')
 	let desc: string | undefined
 	let descId: string | undefined
@@ -441,9 +450,7 @@ export const extractCommunityMetadata = (result: BinaryNode) => {
 		descId = descChild.attrs.id
 	}
 
-	const communityId = community.attrs.id?.includes('@')
-		? community.attrs.id
-		: jidEncode(community.attrs.id || '', 'g.us')
+	const communityId = community.attrs.id.includes('@') ? community.attrs.id : jidEncode(community.attrs.id, 'g.us')
 	const eph = getBinaryNodeChild(community, 'ephemeral')?.attrs.expiration
 	const memberAddMode = getBinaryNodeChildString(community, 'member_add_mode') === 'all_member_add'
 	const metadata: GroupMetadata = {

--- a/src/__tests__/Socket/communities.test.ts
+++ b/src/__tests__/Socket/communities.test.ts
@@ -1,0 +1,42 @@
+import { extractCommunityMetadata } from '../../Socket/communities'
+import type { BinaryNode } from '../../WABinary'
+
+const metadataNode = (tag: 'community' | 'group'): BinaryNode => ({
+	tag,
+	attrs: {
+		id: '120363000000000000',
+		creation: '1700000000',
+		s_t: '1700000000',
+		subject: 'Test Community'
+	},
+	content: []
+})
+
+describe('extractCommunityMetadata', () => {
+	it.each(['community', 'group'] as const)('parses metadata from a <%s> response node', tag => {
+		const result: BinaryNode = {
+			tag: 'iq',
+			attrs: { type: 'result' },
+			content: [metadataNode(tag)]
+		}
+
+		const metadata = extractCommunityMetadata(result)
+
+		expect(metadata.id).toBe('120363000000000000@g.us')
+		expect(metadata.subject).toBe('Test Community')
+	})
+
+	it('throws a classified error when neither metadata node is present', () => {
+		const result: BinaryNode = { tag: 'iq', attrs: { type: 'result' }, content: [] }
+
+		expect(() => extractCommunityMetadata(result)).toThrow(/missing <community> or <group> node/)
+	})
+
+	it('throws when the metadata node has no id', () => {
+		const community = metadataNode('community')
+		delete (community.attrs as Record<string, string>).id
+		const result: BinaryNode = { tag: 'iq', attrs: { type: 'result' }, content: [community] }
+
+		expect(() => extractCommunityMetadata(result)).toThrow(/missing community id/)
+	})
+})

--- a/src/__tests__/Socket/communities.test.ts
+++ b/src/__tests__/Socket/communities.test.ts
@@ -1,3 +1,4 @@
+import { Boom } from '@hapi/boom'
 import { extractCommunityMetadata } from '../../Socket/communities'
 import type { BinaryNode } from '../../WABinary'
 
@@ -29,7 +30,15 @@ describe('extractCommunityMetadata', () => {
 	it('throws a classified error when neither metadata node is present', () => {
 		const result: BinaryNode = { tag: 'iq', attrs: { type: 'result' }, content: [] }
 
-		expect(() => extractCommunityMetadata(result)).toThrow(/missing <community> or <group> node/)
+		let thrown: unknown
+		try {
+			extractCommunityMetadata(result)
+		} catch (err) {
+			thrown = err
+		}
+
+		expect(thrown).toBeInstanceOf(Boom)
+		expect((thrown as Boom).message).toMatch(/missing <community> or <group> node/)
 	})
 
 	it('throws when the metadata node has no id', () => {
@@ -37,6 +46,14 @@ describe('extractCommunityMetadata', () => {
 		delete (community.attrs as Record<string, string>).id
 		const result: BinaryNode = { tag: 'iq', attrs: { type: 'result' }, content: [community] }
 
-		expect(() => extractCommunityMetadata(result)).toThrow(/missing community id/)
+		let thrown: unknown
+		try {
+			extractCommunityMetadata(result)
+		} catch (err) {
+			thrown = err
+		}
+
+		expect(thrown).toBeInstanceOf(Boom)
+		expect((thrown as Boom).message).toMatch(/missing community id/)
 	})
 })


### PR DESCRIPTION
## Summary

- accept a `<group>` node when community metadata responses do not contain `<community>`
- throw classified `Boom` errors for malformed metadata responses instead of dereferencing `undefined`
- cover both response shapes and malformed responses with focused regression tests

## Why

`extractCommunityMetadata()` currently uses a non-null assertion on the `<community>` child. Interactive metadata responses can carry the same metadata in a `<group>` child, so the next `.attrs` access throws a generic `TypeError`.

This revisits the fix proposed in #2425, which was closed without merge, and adds current regression coverage plus explicit handling for malformed responses.

Closes #2753.

## Verification

- red: the `<group>` fixture failed on current `master` with `TypeError: Cannot read properties of undefined (reading 'attrs')`
- green: focused regression suite — 4 tests passed
- full unit suite — 29 suites and 411 tests passed
- `yarn lint` — 0 errors (103 existing warnings)
- `yarn build` — passed
- `git diff --check` — passed
- gitleaks on changed files — no findings

E2E was not run: this is a deterministic metadata-parser change covered with binary-node fixtures and does not add a socket flow.

Drafted with Codex, reviewed and tested by me.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes community metadata parsing so responses with a `<group>` node are accepted instead of throwing a `TypeError`, and malformed responses now throw classified `Boom` errors instead of dereferencing `undefined`. Adds regression tests covering both response shapes and missing ids, and asserts the thrown error is a `Boom` instance rather than a plain `Error`.

<sup>Written for commit 85f80c99173191125c34f2ee540ed558b433aeff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of community metadata responses.
  - Clear, classified errors are now reported when required community or group information is missing or incomplete.
  - Community identifiers are consistently normalized with the `@g.us` suffix, improving reliability when processing valid responses.

- **Tests**
  - Added coverage for valid community and group responses, identifier normalization, subjects, and invalid response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->