### PR TITLE
fix: serialize all transactions on a SignalKeyStore with one mutex

### DIFF
--- a/src/Utils/auth-utils.ts
+++ b/src/Utils/auth-utils.ts
@@ -123,7 +123,8 @@ export const addTransactionCapability = (
 	// Queues for concurrency control (keyed by signal data type - bounded set)
 	const keyQueues = new Map<string, PQueue>()
 
-	// Transaction mutexes with reference counting for cleanup
+	// All transactions on this store now share one mutex, keyed by this constant - `key` below is trace-log-only.
+	const TX_MUTEX_KEY = '__tx__'
 	const txMutexes = new Map<string, Mutex>()
 	const txMutexRefCounts = new Map<string, number>()
 
@@ -310,8 +311,8 @@ export const addTransactionCapability = (
 			}
 
 			// New transaction - acquire mutex and create context
-			const mutex = getTxMutex(key)
-			acquireTxMutexRef(key)
+			const mutex = getTxMutex(TX_MUTEX_KEY)
+			acquireTxMutexRef(TX_MUTEX_KEY)
 
 			try {
 				return await mutex.runExclusive(async () => {
@@ -321,7 +322,7 @@ export const addTransactionCapability = (
 						dbQueries: 0
 					}
 
-					logger.trace('entering transaction')
+					logger.trace({ key }, 'entering transaction')
 
 					try {
 						const result = await txStorage.run(ctx, work)
@@ -338,7 +339,7 @@ export const addTransactionCapability = (
 					}
 				})
 			} finally {
-				releaseTxMutexRef(key)
+				releaseTxMutexRef(TX_MUTEX_KEY)
 			}
 		}
 	}

--- a/src/Utils/auth-utils.ts
+++ b/src/Utils/auth-utils.ts
@@ -106,6 +106,9 @@ export function makeCacheableSignalKeyStore(
 	}
 }
 
+// Shared across wrapper instances, keyed by the raw store itself
+const txMutexesByStore = new WeakMap<SignalKeyStore, Mutex>()
+
 /**
  * Adds DB-like transaction capability to the SignalKeyStore
  * Uses AsyncLocalStorage for automatic context management
@@ -123,10 +126,15 @@ export const addTransactionCapability = (
 	// Queues for concurrency control (keyed by signal data type - bounded set)
 	const keyQueues = new Map<string, PQueue>()
 
-	// All transactions on this store now share one mutex, keyed by this constant - `key` below is trace-log-only.
-	const TX_MUTEX_KEY = '__tx__'
-	const txMutexes = new Map<string, Mutex>()
-	const txMutexRefCounts = new Map<string, number>()
+	// Dedupes concurrent cache-miss reads of the same type within one transaction's body
+	const readMutexes = new Map<string, Mutex>()
+
+	// One mutex per raw store, shared across wrappers, guarding transaction() itself
+	let txMutex = txMutexesByStore.get(state)
+	if (!txMutex) {
+		txMutex = new Mutex()
+		txMutexesByStore.set(state, txMutex)
+	}
 
 	// Pre-key manager for specialized operations
 	const preKeyManager = new PreKeyManager(state, logger)
@@ -143,40 +151,14 @@ export const addTransactionCapability = (
 	}
 
 	/**
-	 * Get or create a transaction mutex
+	 * Get or create a read-dedup mutex for a specific key type
 	 */
-	function getTxMutex(key: string): Mutex {
-		if (!txMutexes.has(key)) {
-			txMutexes.set(key, new Mutex())
-			txMutexRefCounts.set(key, 0)
+	function getReadMutex(key: string): Mutex {
+		if (!readMutexes.has(key)) {
+			readMutexes.set(key, new Mutex())
 		}
 
-		return txMutexes.get(key)!
-	}
-
-	/**
-	 * Acquire a reference to a transaction mutex
-	 */
-	function acquireTxMutexRef(key: string): void {
-		const count = txMutexRefCounts.get(key) ?? 0
-		txMutexRefCounts.set(key, count + 1)
-	}
-
-	/**
-	 * Release a reference to a transaction mutex and cleanup if no longer needed
-	 */
-	function releaseTxMutexRef(key: string): void {
-		const count = (txMutexRefCounts.get(key) ?? 1) - 1
-		txMutexRefCounts.set(key, count)
-
-		// Cleanup if no more references and mutex is not locked
-		if (count <= 0) {
-			const mutex = txMutexes.get(key)
-			if (mutex && !mutex.isLocked()) {
-				txMutexes.delete(key)
-				txMutexRefCounts.delete(key)
-			}
-		}
+		return readMutexes.get(key)!
 	}
 
 	/**
@@ -232,7 +214,7 @@ export const addTransactionCapability = (
 				ctx.dbQueries++
 				logger.trace({ type, count: missing.length }, 'fetching missing keys in transaction')
 
-				const fetched = await getTxMutex(type).runExclusive(() => state.get(type, missing))
+				const fetched = await getReadMutex(type).runExclusive(() => state.get(type, missing))
 
 				// Update cache
 				ctx.cache[type] = ctx.cache[type] || ({} as any)
@@ -302,6 +284,8 @@ export const addTransactionCapability = (
 		isInTransaction,
 
 		transaction: async (work, key) => {
+			void key // trace-log-unsafe (callers embed JIDs in it) - kept for type compat only
+
 			const existing = txStorage.getStore()
 
 			// Nested transaction - reuse existing context
@@ -311,36 +295,29 @@ export const addTransactionCapability = (
 			}
 
 			// New transaction - acquire mutex and create context
-			const mutex = getTxMutex(TX_MUTEX_KEY)
-			acquireTxMutexRef(TX_MUTEX_KEY)
+			return await txMutex.runExclusive(async () => {
+				const ctx: TransactionContext = {
+					cache: {},
+					mutations: {},
+					dbQueries: 0
+				}
 
-			try {
-				return await mutex.runExclusive(async () => {
-					const ctx: TransactionContext = {
-						cache: {},
-						mutations: {},
-						dbQueries: 0
-					}
+				logger.trace('entering transaction')
 
-					logger.trace({ key }, 'entering transaction')
+				try {
+					const result = await txStorage.run(ctx, work)
 
-					try {
-						const result = await txStorage.run(ctx, work)
+					// Commit mutations
+					await commitWithRetry(ctx.mutations)
 
-						// Commit mutations
-						await commitWithRetry(ctx.mutations)
+					logger.trace({ dbQueries: ctx.dbQueries }, 'transaction completed')
 
-						logger.trace({ dbQueries: ctx.dbQueries }, 'transaction completed')
-
-						return result
-					} catch (error) {
-						logger.error({ error }, 'transaction failed, rolling back')
-						throw error
-					}
-				})
-			} finally {
-				releaseTxMutexRef(TX_MUTEX_KEY)
-			}
+					return result
+				} catch (error) {
+					logger.error({ error }, 'transaction failed, rolling back')
+					throw error
+				}
+			})
 		}
 	}
 }

--- a/src/__tests__/Utils/auth-utils.test.ts
+++ b/src/__tests__/Utils/auth-utils.test.ts
@@ -1,5 +1,12 @@
 import { Boom } from '@hapi/boom'
-import type { AuthenticationCreds, Contact, SignalDataSet, SignalKeyStore } from '../../Types'
+// wrapped - single line exceeds prettier's 120-char printWidth
+import type {
+	AuthenticationCreds,
+	Contact,
+	SignalDataSet,
+	SignalKeyStore,
+	SignalKeyStoreWithTransaction
+} from '../../Types'
 import { addTransactionCapability, assertMeId, initAuthCreds } from '../../Utils/auth-utils'
 import type { ILogger } from '../../Utils/logger'
 
@@ -91,6 +98,42 @@ describe('assertMeId', () => {
 	})
 })
 
+const runInterleavingScenario = async (
+	raw: SignalKeyStore,
+	stateA: SignalKeyStoreWithTransaction,
+	stateB: SignalKeyStoreWithTransaction
+) => {
+	const aHasRead = deferred()
+	const aMayWrite = deferred()
+	let bSettled = false
+
+	const txA = stateA.transaction(async () => {
+		const existing = await stateA.get('sender-key-memory', ['group1'])
+		aHasRead.resolve()
+		await aMayWrite.promise
+		await stateA.set({ 'sender-key-memory': { group1: { ...existing.group1, deviceB: true } } })
+	}, 'relayMessage-meId')
+
+	await aHasRead.promise
+
+	const txB = stateB
+		.transaction(async () => {
+			const existing = await stateB.get('sender-key-memory', ['group1'])
+			await stateB.set({ 'sender-key-memory': { group1: { ...existing.group1, deviceC: true } } })
+		}, 'migrate-1-sessions-lidUser')
+		.then(() => {
+			bSettled = true
+		})
+
+	await flushMicrotasks()
+	expect(bSettled).toBe(false)
+
+	aMayWrite.resolve()
+	await Promise.all([txA, txB])
+
+	return raw.get('sender-key-memory', ['group1'])
+}
+
 describe('addTransactionCapability', () => {
 	it('serializes transactions that use different keys against the same store', async () => {
 		const raw = makeInMemoryStore()
@@ -98,35 +141,7 @@ describe('addTransactionCapability', () => {
 
 		const state = addTransactionCapability(raw, makeTestLogger(), { maxCommitRetries: 1, delayBetweenTriesMs: 5 })
 
-		const aHasRead = deferred()
-		const aMayWrite = deferred()
-		let bSettled = false
-
-		const txA = state.transaction(async () => {
-			const existing = await state.get('sender-key-memory', ['group1'])
-			aHasRead.resolve()
-			await aMayWrite.promise
-			await state.set({ 'sender-key-memory': { group1: { ...existing.group1, deviceB: true } } })
-		}, 'relayMessage-meId')
-
-		await aHasRead.promise
-
-		const txB = state
-			.transaction(async () => {
-				const existing = await state.get('sender-key-memory', ['group1'])
-				await state.set({ 'sender-key-memory': { group1: { ...existing.group1, deviceC: true } } })
-			}, 'migrate-1-sessions-lidUser')
-			.then(() => {
-				bSettled = true
-			})
-
-		await flushMicrotasks()
-		expect(bSettled).toBe(false)
-
-		aMayWrite.resolve()
-		await Promise.all([txA, txB])
-
-		const final = await raw.get('sender-key-memory', ['group1'])
+		const final = await runInterleavingScenario(raw, state, state)
 		expect(final.group1).toEqual({ deviceA: true, deviceB: true, deviceC: true })
 	})
 
@@ -139,35 +154,7 @@ describe('addTransactionCapability', () => {
 		const stateA = addTransactionCapability(raw, logger, opts)
 		const stateB = addTransactionCapability(raw, logger, opts)
 
-		const aHasRead = deferred()
-		const aMayWrite = deferred()
-		let bSettled = false
-
-		const txA = stateA.transaction(async () => {
-			const existing = await stateA.get('sender-key-memory', ['group1'])
-			aHasRead.resolve()
-			await aMayWrite.promise
-			await stateA.set({ 'sender-key-memory': { group1: { ...existing.group1, deviceB: true } } })
-		}, 'relayMessage-meId')
-
-		await aHasRead.promise
-
-		const txB = stateB
-			.transaction(async () => {
-				const existing = await stateB.get('sender-key-memory', ['group1'])
-				await stateB.set({ 'sender-key-memory': { group1: { ...existing.group1, deviceC: true } } })
-			}, 'migrate-1-sessions-lidUser')
-			.then(() => {
-				bSettled = true
-			})
-
-		await flushMicrotasks()
-		expect(bSettled).toBe(false)
-
-		aMayWrite.resolve()
-		await Promise.all([txA, txB])
-
-		const final = await raw.get('sender-key-memory', ['group1'])
+		const final = await runInterleavingScenario(raw, stateA, stateB)
 		expect(final.group1).toEqual({ deviceA: true, deviceB: true, deviceC: true })
 	})
 })

--- a/src/__tests__/Utils/auth-utils.test.ts
+++ b/src/__tests__/Utils/auth-utils.test.ts
@@ -56,6 +56,12 @@ const deferred = <T = void>() => {
 	return { promise, resolve }
 }
 
+const flushMicrotasks = async (times = 50) => {
+	for (let i = 0; i < times; i++) {
+		await Promise.resolve()
+	}
+}
+
 describe('assertMeId', () => {
 	it('returns me.id when authenticated', () => {
 		const creds = credsWithMe({ id: '5511999999999@s.whatsapp.net' })
@@ -92,12 +98,9 @@ describe('addTransactionCapability', () => {
 
 		const state = addTransactionCapability(raw, makeTestLogger(), { maxCommitRetries: 1, delayBetweenTriesMs: 5 })
 
-		// mirrors the real collision: an outgoing relayMessage() transaction (keyed by meId) racing
-		// the own-identity PN->LID migration socket.ts fires on every connection open (keyed by
-		// migrate-N-sessions-<lidUser>) - two different keys, same underlying sender-key-memory record.
 		const aHasRead = deferred()
 		const aMayWrite = deferred()
-		const bDone = deferred<void>()
+		let bSettled = false
 
 		const txA = state.transaction(async () => {
 			const existing = await state.get('sender-key-memory', ['group1'])
@@ -113,11 +116,53 @@ describe('addTransactionCapability', () => {
 				const existing = await state.get('sender-key-memory', ['group1'])
 				await state.set({ 'sender-key-memory': { group1: { ...existing.group1, deviceC: true } } })
 			}, 'migrate-1-sessions-lidUser')
-			.then(() => bDone.resolve())
+			.then(() => {
+				bSettled = true
+			})
 
-		// give txB a real chance to run to completion here - it only can if it's NOT
-		// blocked behind txA's still-open transaction, which is exactly the bug.
-		await Promise.race([bDone.promise, new Promise(r => setTimeout(r, 30))])
+		await flushMicrotasks()
+		expect(bSettled).toBe(false)
+
+		aMayWrite.resolve()
+		await Promise.all([txA, txB])
+
+		const final = await raw.get('sender-key-memory', ['group1'])
+		expect(final.group1).toEqual({ deviceA: true, deviceB: true, deviceC: true })
+	})
+
+	it('serializes transactions from two separate wrappers over the same store', async () => {
+		const raw = makeInMemoryStore()
+		await raw.set({ 'sender-key-memory': { group1: { deviceA: true } } })
+
+		const logger = makeTestLogger()
+		const opts = { maxCommitRetries: 1, delayBetweenTriesMs: 5 }
+		const stateA = addTransactionCapability(raw, logger, opts)
+		const stateB = addTransactionCapability(raw, logger, opts)
+
+		const aHasRead = deferred()
+		const aMayWrite = deferred()
+		let bSettled = false
+
+		const txA = stateA.transaction(async () => {
+			const existing = await stateA.get('sender-key-memory', ['group1'])
+			aHasRead.resolve()
+			await aMayWrite.promise
+			await stateA.set({ 'sender-key-memory': { group1: { ...existing.group1, deviceB: true } } })
+		}, 'relayMessage-meId')
+
+		await aHasRead.promise
+
+		const txB = stateB
+			.transaction(async () => {
+				const existing = await stateB.get('sender-key-memory', ['group1'])
+				await stateB.set({ 'sender-key-memory': { group1: { ...existing.group1, deviceC: true } } })
+			}, 'migrate-1-sessions-lidUser')
+			.then(() => {
+				bSettled = true
+			})
+
+		await flushMicrotasks()
+		expect(bSettled).toBe(false)
 
 		aMayWrite.resolve()
 		await Promise.all([txA, txB])

--- a/src/__tests__/Utils/auth-utils.test.ts
+++ b/src/__tests__/Utils/auth-utils.test.ts
@@ -1,11 +1,60 @@
 import { Boom } from '@hapi/boom'
-import type { AuthenticationCreds, Contact } from '../../Types'
-import { assertMeId, initAuthCreds } from '../../Utils/auth-utils'
+import type { AuthenticationCreds, Contact, SignalDataSet, SignalKeyStore } from '../../Types'
+import { addTransactionCapability, assertMeId, initAuthCreds } from '../../Utils/auth-utils'
+import type { ILogger } from '../../Utils/logger'
 
 const credsWithMe = (me?: Partial<Contact>): AuthenticationCreds => ({
 	...initAuthCreds(),
 	me: me as Contact | undefined
 })
+
+const makeTestLogger = (): ILogger =>
+	({
+		level: 'silent',
+		child: () => makeTestLogger(),
+		trace: () => {},
+		debug: () => {},
+		info: () => {},
+		warn: () => {},
+		error: () => {},
+		fatal: () => {}
+	}) as unknown as ILogger
+
+const makeInMemoryStore = (): SignalKeyStore => {
+	const db: { [type: string]: { [id: string]: unknown } } = {}
+	return {
+		get: async (type, ids) => {
+			const table = db[type] || {}
+			const result: { [id: string]: unknown } = {}
+			for (const id of ids) {
+				if (table[id] !== undefined) {
+					result[id] = table[id]
+				}
+			}
+
+			return result as never
+		},
+		set: async (data: SignalDataSet) => {
+			for (const type of Object.keys(data)) {
+				const entries = data[type as keyof SignalDataSet] as { [id: string]: unknown }
+				const table = (db[type] = db[type] || {})
+				for (const id of Object.keys(entries)) {
+					if (entries[id] === null) {
+						delete table[id]
+					} else {
+						table[id] = entries[id]
+					}
+				}
+			}
+		}
+	}
+}
+
+const deferred = <T = void>() => {
+	let resolve!: (value: T) => void
+	const promise = new Promise<T>(r => (resolve = r))
+	return { promise, resolve }
+}
 
 describe('assertMeId', () => {
 	it('returns me.id when authenticated', () => {
@@ -33,5 +82,47 @@ describe('assertMeId', () => {
 	it('throws Boom 401 when me.id is empty string', () => {
 		const creds = credsWithMe({ id: '' })
 		expect(() => assertMeId(creds)).toThrow(/not authenticated/)
+	})
+})
+
+describe('addTransactionCapability', () => {
+	it('serializes transactions that use different keys against the same store', async () => {
+		const raw = makeInMemoryStore()
+		await raw.set({ 'sender-key-memory': { group1: { deviceA: true } } })
+
+		const state = addTransactionCapability(raw, makeTestLogger(), { maxCommitRetries: 1, delayBetweenTriesMs: 5 })
+
+		// mirrors the real collision: an outgoing relayMessage() transaction (keyed by meId) racing
+		// the own-identity PN->LID migration socket.ts fires on every connection open (keyed by
+		// migrate-N-sessions-<lidUser>) - two different keys, same underlying sender-key-memory record.
+		const aHasRead = deferred()
+		const aMayWrite = deferred()
+		const bDone = deferred<void>()
+
+		const txA = state.transaction(async () => {
+			const existing = await state.get('sender-key-memory', ['group1'])
+			aHasRead.resolve()
+			await aMayWrite.promise
+			await state.set({ 'sender-key-memory': { group1: { ...existing.group1, deviceB: true } } })
+		}, 'relayMessage-meId')
+
+		await aHasRead.promise
+
+		const txB = state
+			.transaction(async () => {
+				const existing = await state.get('sender-key-memory', ['group1'])
+				await state.set({ 'sender-key-memory': { group1: { ...existing.group1, deviceC: true } } })
+			}, 'migrate-1-sessions-lidUser')
+			.then(() => bDone.resolve())
+
+		// give txB a real chance to run to completion here - it only can if it's NOT
+		// blocked behind txA's still-open transaction, which is exactly the bug.
+		await Promise.race([bDone.promise, new Promise(r => setTimeout(r, 30))])
+
+		aMayWrite.resolve()
+		await Promise.all([txA, txB])
+
+		const final = await raw.get('sender-key-memory', ['group1'])
+		expect(final.group1).toEqual({ deviceA: true, deviceB: true, deviceC: true })
 	})
 })


### PR DESCRIPTION
## Summary

`addTransactionCapability`'s `transaction()` partitions its mutex by the caller-supplied `key` label. Two transactions on the *same* `SignalKeyStore` with *different* keys therefore run with **no mutual exclusion at all**, even though both read and write the same underlying `session`/`device-list`/`sender-key-memory` state through independent in-memory `ctx.cache` snapshots — whichever transaction's `commitWithRetry()` lands last silently wins, discarding the other's writes.

Concretely, this happens on every connection open:
- `socket.ts`'s `CB:success` handler fires the own-identity PN→LID migration via `process.nextTick()`, unawaited — its `migrateSession()` call runs its own transaction keyed `` `migrate-${deviceJids.length}-sessions-${lidUser}` ``.
- An application sending a message the instant `connection.update: 'open'` fires (a very common pattern) triggers `relayMessage()`'s own transaction, keyed by `meId`.

These two keys are never equal, so the two transactions race.

## Security-sensitive

This change controls concurrent access to `SignalKeyStore` state - sessions, prekeys, device lists, sender keys. It does not change what gets read/written or how it's encrypted; it only changes the locking around it, from "serialized per caller-supplied key label" (unsafe, as above) to "serialized per underlying store." No new data is persisted or exposed. The caller-supplied `key` label - which real call sites build from JIDs (`meId`, `migrate-N-sessions-<lidUser>`) - is no longer written to trace logs.

## Real-world impact

Reproduced against two independent production accounts:
- An outgoing **group** message resolving to `"sending message to 0 devices"` with the message content itself **never reaching the wire** — no exception thrown, the send appears to succeed.
- A **permanent retry loop** against the account's own other linked device, where the server itself rejects every resend attempt with `smax-invalid (479): stanza rejected by server — likely stale device session or malformed addressing`.

This lines up closely with the mechanism already described (and closed without a fix, by the stale bot) in #2704 and #2548, and with the broader symptom in #2297.

## Fix

- All transactions against a given `SignalKeyStore` now share one mutex, held for the store's lifetime in a `WeakMap` keyed by the raw store itself - so two separate `addTransactionCapability()` wrappers over the same store also serialize against each other, not just two calls through the same wrapper.
- `key` is no longer used for mutex selection or logged at trace level.
- The unrelated per-type mutex inside `get()` (dedupes concurrent cache-miss reads *within* one transaction's body) is unchanged in behavior, just renamed for clarity now that it's the only remaining per-key mutex map.

## Test

`src/__tests__/Utils/auth-utils.test.ts` adds two regression tests:
- Two concurrent transactions with different keys, writing overlapping fields of the same `sender-key-memory` record - confirmed to fail (reproducing the exact lost-update pattern seen in production) without this fix, and pass with it.
- The same scenario across two separate `addTransactionCapability()` wrappers over one store.

Both assert deterministically (via a bounded microtask flush, no wall-clock timing) that the second transaction is still blocked before the first is allowed to proceed, so the test can't pass by timing luck.

## One thing I'd like feedback on

This trades some concurrency for correctness — every transaction on a store is now fully sequential, where before, differently-keyed transactions could run in parallel (unsafely, per above, but still). I don't have visibility into whether any call site was relying on that parallelism for throughput. Happy to explore a more targeted fix (e.g. only serializing operations known to touch overlapping state) if full serialization is a concern — flagging it here rather than assuming full serialization is the right tradeoff.

`npm run build`, `npm run lint`, and `npm test` all pass unchanged (409/409 tests, same baseline lint warnings as `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Personal note - I use mudslide to expose a send only whatsapp message api at [Watobot](https://watobot.xyz) using [Mudslide](https://github.com/robvanderleek/mudslide) . I have been wanting to upgrade to latest Baileys as the v6.7.x showed that delivery to some of the connected devices are either skipped or are unencryptable. It could be because mudslide closes the window post send too quickly & also does not implement `getMessage`. But my testing revealed that those were not the culprit. Very recently, I started to experience messages sent to a large group were unencryptable & Claude found it in the Baileys logs the race condition. 

I will probably wait for Baileys to become stable to upgrade mudslide to listen to latest Baileys. But if this change hit production, I would be willing to try the rc version again. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction consistency when multiple operations use the same underlying store.
  - Transactions now remain properly serialized across different keys, preventing overlapping updates from producing inconsistent results.
  - Consistent behavior is maintained when operations are initiated through separate wrappers for the same store.
  - Suspended transactions now preserve correct ordering and produce reliably merged state after completion.
  - Added regression coverage for interleaved transactions and shared-store scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->