### PR TITLE
fix(deps): force transitive protobufjs to 7.6.5 via resolutions (libsignal)

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "picomatch@npm:^2.3.1": "^2.3.2",
     "picomatch@npm:^4.0.0": "^4.0.4",
     "picomatch@npm:^4.0.2": "^4.0.4",
+    "protobufjs@npm:^7.5.5": "^7.6.5",
     "socks": "^2.8.8",
     "tar": "^7.5.11",
     "tmp": "^0.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2022,6 +2022,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@protobufjs/eventemitter@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/eventemitter@npm:1.1.1"
+  checksum: 10c0/8e06193d4629c5e7c09d4f8c2ddba8fc4dfa739f0149f33a1d901568d35bb7b8b5277a4e8452baf3bdd0b302fd599cf255d193267aa93a0a4747e23cd073c4ac
+  languageName: node
+  linkType: hard
+
 "@protobufjs/fetch@npm:^1.1.0":
   version: 1.1.0
   resolution: "@protobufjs/fetch@npm:1.1.0"
@@ -2029,6 +2036,15 @@ __metadata:
     "@protobufjs/aspromise": "npm:^1.1.1"
     "@protobufjs/inquire": "npm:^1.1.0"
   checksum: 10c0/cda6a3dc2d50a182c5865b160f72077aac197046600091dbb005dd0a66db9cce3c5eaed6d470ac8ed49d7bcbeef6ee5f0bc288db5ff9a70cbd003e5909065233
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/fetch@npm:1.1.1"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.1"
+  checksum: 10c0/a497ff5433854e8577f0427983ea39b9113b49a8120f94515291d763327061d2c3013e60e24ea436d091dafae01a0f6eb1867e3b1616045d96a31d8b3c646ed4
   languageName: node
   linkType: hard
 
@@ -6238,7 +6254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:^5.0.0":
+"long@npm:^5.0.0, long@npm:^5.3.2":
   version: 5.3.2
   resolution: "long@npm:5.3.2"
   checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
@@ -7371,26 +7387,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.5.5":
-  version: 7.5.8
-  resolution: "protobufjs@npm:7.5.8"
-  dependencies:
-    "@protobufjs/aspromise": "npm:^1.1.2"
-    "@protobufjs/base64": "npm:^1.1.2"
-    "@protobufjs/codegen": "npm:^2.0.5"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
-    "@protobufjs/fetch": "npm:^1.1.0"
-    "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.1"
-    "@protobufjs/path": "npm:^1.1.2"
-    "@protobufjs/pool": "npm:^1.1.0"
-    "@protobufjs/utf8": "npm:^1.1.1"
-    "@types/node": "npm:>=13.7.0"
-    long: "npm:^5.0.0"
-  checksum: 10c0/25968259084a634e035f865febd5a31f75bdaee4fda6fba4e14c57019024e7cada859b470eb69350f430fbd0d509c805249b9fe8a6c44a57a0b484a1ef685751
-  languageName: node
-  linkType: hard
-
 "protobufjs@npm:^7.5.6":
   version: 7.5.6
   resolution: "protobufjs@npm:7.5.6"
@@ -7408,6 +7404,25 @@ __metadata:
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
   checksum: 10c0/220df6c3cf6d2346748639a9b0b688fecc994bff9fee7018a93167e8cd45ab0ee3b4270d9eaa6be33a11adb46514ef9dce7e8217fd578c36726a9e70b96327cd
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^7.6.5":
+  version: 7.6.6
+  resolution: "protobufjs@npm:7.6.6"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.2"
+    "@protobufjs/base64": "npm:^1.1.2"
+    "@protobufjs/codegen": "npm:^2.0.5"
+    "@protobufjs/eventemitter": "npm:^1.1.1"
+    "@protobufjs/fetch": "npm:^1.1.1"
+    "@protobufjs/float": "npm:^1.0.2"
+    "@protobufjs/path": "npm:^1.1.2"
+    "@protobufjs/pool": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.1"
+    "@types/node": "npm:>=13.7.0"
+    long: "npm:^5.3.2"
+  checksum: 10c0/6c0dc6d4a2801825e39417bc116297d5261c0cf28892a5e28adafc13432331c0cb75603bbe50ad6f2715f3b0a9ce2896591ad6b51fdc8eae2d05b9ac2e4a8ec1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Follow-up to #2812. That PR bumps the direct `protobufjs` dependency, but one exposed copy stays behind: `libsignal@6.0.0` requests `protobufjs` via its own `^7.5.5` range, which Yarn resolves to `7.5.8`. A direct manifest bump cannot move that transitive copy, so these advisories remain open in the installed graph:

- GHSA-wcpc-wj8m-hjx6 (HIGH, CVE-2026-48712) - DoS via unbounded Any expansion, fixed in 7.6.1
- GHSA-f38q-mgvj-vph7 (MODERATE, CVE-2026-54269) - property shadowing, fixed in 7.6.3
- GHSA-j3f2-48v5-ccww (MODERATE, CVE-2026-59877) - infinite loop in .proto option parsing, fixed in 7.6.5

This PR adds a single `resolutions` entry pinning `protobufjs@npm:^7.5.5` to `^7.6.5`, so the transitive copy pulled through libsignal now resolves to a patched release (`7.6.6`). Lockfile + one manifest line only, no code changes.

Scoped to the `^7.5.5` descriptor on purpose so it only affects the libsignal-transitive copy and does not overlap the direct-dependency bump in #2812. Can be merged before or after #2812.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the transitive `protobufjs` copy pulled by `libsignal` so it resolves to a patched release (7.6.6) instead of the vulnerable 7.5.8. A `resolutions` entry pins the `^7.5.5` range to `^7.6.5`, closing three security advisories: GHSA-wcpc-wj8m-hjx6, GHSA-f38q-mgvj-vph7, and GHSA-j3f2-48v5-ccww. Only the libsignal copy is affected; no code changes.

<sup>Written for commit 6861c80dc0b1ca142fe4d1ad5fdc191f3df1d0b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution to use a newer compatible version of `protobufjs`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->