### PR TITLE
fix(deps): bump link-preview-js to ^5.0.0 to patch SSRF (GHSA-4gp8-rjrq-ch6q)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jimp": "^1.6.1",
     "jiti": "^2.4.2",
     "json": "^11.0.0",
-    "link-preview-js": "^3.0.0",
+    "link-preview-js": "^5.0.0",
     "lru-cache": "^11.1.0",
     "open": "^8.4.2",
     "pino-pretty": "^13.1.1",
@@ -89,7 +89,7 @@
   "peerDependencies": {
     "audio-decode": "^2.1.3",
     "jimp": "^1.6.1",
-    "link-preview-js": "^3.0.0",
+    "link-preview-js": "^5.0.0",
     "sharp": "*"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3116,7 +3116,7 @@ __metadata:
     jiti: "npm:^2.4.2"
     json: "npm:^11.0.0"
     libsignal: "npm:^6.0.0"
-    link-preview-js: "npm:^3.0.0"
+    link-preview-js: "npm:^5.0.0"
     lru-cache: "npm:^11.1.0"
     music-metadata: "npm:^11.12.3"
     open: "npm:^8.4.2"
@@ -3138,7 +3138,7 @@ __metadata:
   peerDependencies:
     audio-decode: ^2.1.3
     jimp: ^1.6.1
-    link-preview-js: ^3.0.0
+    link-preview-js: ^5.0.0
     sharp: "*"
   peerDependenciesMeta:
     audio-decode:
@@ -6135,13 +6135,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"link-preview-js@npm:^3.0.0":
-  version: 3.2.0
-  resolution: "link-preview-js@npm:3.2.0"
+"link-preview-js@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "link-preview-js@npm:5.0.0"
   dependencies:
     cheerio: "npm:1.0.0-rc.11"
-    url: "npm:0.11.0"
-  checksum: 10c0/2ee44cd65a741959153dd02ef894de67b816db72ccd29666d62142101945ffd87c10ab9233272733fc0965fa42ba6990591709552289afd8ffc539f4ffd11aff
+    undici: "npm:^8.6.0"
+  checksum: 10c0/facbc5d3c1c0c040766c05d27dc251d9d80143c0baf87c37c20be231033136143820dbb585c5465884c0837f57c0e440e5ab010e1a303945e550931c08019b77
   languageName: node
   linkType: hard
 
@@ -7458,13 +7458,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:1.3.2":
-  version: 1.3.2
-  resolution: "punycode@npm:1.3.2"
-  checksum: 10c0/281fd20eaf4704f79d80cb0dc65065bf6452ee67989b3e8941aed6360a5a9a8a01d3e2ed71d0bde3cd74fb5a5dd9db4160bed5a8c20bed4b6764c24ce4c7d2d2
-  languageName: node
-  linkType: hard
-
 "punycode@npm:^2.1.0":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
@@ -7476,13 +7469,6 @@ __metadata:
   version: 7.0.1
   resolution: "pure-rand@npm:7.0.1"
   checksum: 10c0/9cade41030f5ec95f5d55a11a71404cd6f46b69becaad892097cd7f58e2c6248cd0a933349ca7d21336ab629f1da42ffe899699b671bc4651600eaf6e57f837e
-  languageName: node
-  linkType: hard
-
-"querystring@npm:0.2.0":
-  version: 0.2.0
-  resolution: "querystring@npm:0.2.0"
-  checksum: 10c0/2036c9424beaacd3978bac9e4ba514331cc73163bea7bf3ad7e2c7355e55501938ec195312c607753f9c6e70b1bf9dfcda38db6241bd299c034e27ac639d64ed
   languageName: node
   linkType: hard
 
@@ -8398,6 +8384,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:^8.6.0":
+  version: 8.10.2
+  resolution: "undici@npm:8.10.2"
+  checksum: 10c0/66d7fc69149207cab570d6abbc9e965b6afe1ae889a7d46945b431165c973d6a56f3dd8b70a856e7ae1e550b6366a1cde6f06e68640587f0dadca38de72995ee
+  languageName: node
+  linkType: hard
+
 "unique-filename@npm:^4.0.0":
   version: 4.0.0
   resolution: "unique-filename@npm:4.0.0"
@@ -8524,16 +8517,6 @@ __metadata:
   version: 5.0.0
   resolution: "url-join@npm:5.0.0"
   checksum: 10c0/ed2b166b4b5a98adcf6828a48b6bd6df1dac4c8a464a73cf4d8e2457ed410dd8da6be0d24855b86026cd7f5c5a3657c1b7b2c7a7c5b8870af17635a41387b04c
-  languageName: node
-  linkType: hard
-
-"url@npm:0.11.0":
-  version: 0.11.0
-  resolution: "url@npm:0.11.0"
-  dependencies:
-    punycode: "npm:1.3.2"
-    querystring: "npm:0.2.0"
-  checksum: 10c0/bbe05f9f570ec5c06421c50ca63f287e61279092eed0891db69a9619323703ccd3987e6eed234c468794cf25680c599680d5c1f58d26090f1956c8e9ed8346a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Follow-up to #2812, which called out the `link-preview-js` SSRF as a separate breaking-major bump.

`link-preview-js` before 4.0.1 is affected by GHSA-4gp8-rjrq-ch6q (HIGH, CVE-2026-43897): SSRF via IPv6 and internal loopback bypass. Baileys pins `^3.0.0` in both `devDependencies` and `peerDependencies`, so both the build graph and downstream consumers can resolve the vulnerable line.

This bumps to `^5.0.0`, the latest line, which carries the full SSRF hardening chain:

- 4.0.1 - loopback address fixes
- 4.0.4 - DNS-rebinding hardening
- 5.0.0 - https resolved-IP fix

## No code changes needed

The only usage is `getLinkPreview` in `src/Utils/link-preview.ts`. The API is unchanged from v3 to v5:

- options still accepted: `followRedirects` (`follow`), `handleRedirects(baseURL, forwardedURL)`, `timeout`, `proxyUrl`, `headers`
- response fields still present: `title`, `url`, `images`

Verified against the v5 type definitions (`ILinkPreviewOptions` / `ILinkPreviewBaseOptions` / `ILinkPreviewResponse`). Lockfile also drops the abandoned `punycode` / `querystring` / `url` shims that v3 carried.

## Note on the peer range

The `peerDependencies` bump from `^3.0.0` to `^5.0.0` is intentional: leaving `^3` in the peer range would let consumers keep installing the vulnerable v3, so the SSRF would stay reachable. If you would rather keep older consumers working, `^3.0.0 || ^5.0.0` is possible, but that still permits the vulnerable line, so a hard floor is the safer default. Happy to adjust to whatever you prefer.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `link-preview-js` from `^3.0.0` to `^5.0.0` to fix a high-severity SSRF vulnerability (GHSA-4gp8-rjrq-ch6q). The old version could be exploited via IPv6 and loopback bypass; v5 includes the full hardening chain. The `getLinkPreview` API is unchanged, so no code changes are required. The peer dependency range is also bumped to `^5.0.0` to prevent consumers from installing the vulnerable v3.

<sup>Written for commit 7a5425c66b0c15ded78e9cf62c218b893662b4b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported link preview library version to align development and peer dependency requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->