### PR TITLE
fix(media): propagate source stream errors in downloadEncryptedContent

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -649,6 +649,11 @@ export const downloadEncryptedContent = async (
 			}
 		}
 	})
+	// pipe() does not forward 'error' events from source to destination —
+	// without this, a dropped connection or malformed response on `fetched`
+	// crashes the process (unhandled 'error' on the source) instead of
+	// surfacing as an error on the returned stream that callers can catch.
+	fetched.on('error', err => output.destroy(err))
 	return fetched.pipe(output, { end: true })
 }
 


### PR DESCRIPTION
`fetched.pipe(output, { end: true })` in `downloadEncryptedContent` never attached an error listener on the source stream. Node's `pipe()` does not forward `'error'` events from source to destination, so a dropped connection or malformed response from the media host crashed the process (unhandled `'error'` on the source) instead of surfacing as a catchable error on the returned Transform stream that callers already handle.

Fix: forward the source stream's error into the returned Transform via `output.destroy(err)`, matching the existing pattern already used a bit further down in the same file for upload streams (`stream.on('error', ...)`).

No behavior change for the success path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a dropped media-host connection or malformed response from crashing the process. Previously the source stream's `'error'` event went unhandled because `pipe()` doesn't forward errors; now it's forwarded via `output.destroy(err)` so callers catch it on the returned Transform stream. No change to the success path.

<sup>Written for commit 27733072a2d792a4f7ce16b4461ccdba1e7ee853. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/WhiskeySockets/Baileys/pull/2815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved encrypted content downloads by safely surfacing source stream errors through the returned stream.
  - Prevented dropped connections or malformed responses from causing unhandled process crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->